### PR TITLE
Fix broadcasting in calculating emission log probs

### DIFF
--- a/ssm_jax/hmm/models.py
+++ b/ssm_jax/hmm/models.py
@@ -99,30 +99,33 @@ class BaseHMM(ABC):
         """
         lp = self.initial_distribution.log_prob(states[0])
         lp += self.transition_distribution[states[:-1]].log_prob(states[1:]).sum()
-        lp += self.emission_distribution[states].log_prob(emissions).sum()
+        lp += self.emission_distribution[states].log_prob(emissions).sum(0)
         return lp
 
     def marginal_log_prob(self, emissions):
-        log_likelihoods = self.emission_distribution.log_prob(emissions[...,None,:])
+        # Add extra dimension to emissions for broadcasting.
+        log_likelihoods = self.emission_distribution.log_prob(emissions[:,None,...])
         return hmm_filter(self.initial_probabilities,
                             self.transition_matrix,
                             log_likelihoods)[0]
 
     def most_likely_states(self, emissions):
-        log_likelihoods = self.emission_distribution.log_prob(emissions[...,None,:])
+        # Add extra dimension to emissions for broadcasting.
+        log_likelihoods = self.emission_distribution.log_prob(emissions[:,None,...])
         return hmm_posterior_mode(self.initial_probabilities,
                                   self.transition_matrix,
                                   log_likelihoods)
 
     def filter(self, emissions):
-        log_likelihoods = self.emission_distribution.log_prob(emissions[...,None,:])
+        # Add extra dimension to emissions for broadcasting.
+        log_likelihoods = self.emission_distribution.log_prob(emissions[:,None,...])
         return hmm_filter(self.initial_probabilities,
                             self.transition_matrix,
                             log_likelihoods)
 
     def smoother(self, emissions):
-        # emissions is (T,D). Reshape to (T,1,D) so it broadcasts to (K,D)
-        log_likelihoods = self.emission_distribution.log_prob(emissions[...,None,:])
+        # Add extra dimension to emissions for broadcasting.
+        log_likelihoods = self.emission_distribution.log_prob(emissions[:,None,...])
         return hmm_smoother(self.initial_probabilities,
                             self.transition_matrix,
                             log_likelihoods)


### PR DESCRIPTION
Fix reshaping of `emissions` so that broadcasting works with `HMM.emission_distribution.log_prob()` works for both scalar and vector observations.

The behaviour is now:
- **scalar** - (T,) --[reshape]--> (T,1)  --[tfp broadcast]--> (T,K).
- **vector** - (T,D) --[reshape]--> (T,1,D) --[tfp broadcast]--> (T,K).

This fixes many methods in HMM subclasses with scalar observations (e.g. `CategoricalHMM.filter()`, `CategoricalHMM.smoother()`, etc.).

The PR also changes a line in `BaseHMM.log_prob()` to only sum over the leading axis, this helps for a failure case whereby extra dimensions in the input can cause broadcasting of the tfp log prob which is subsequently hidden by a `.sum()`.

With the present change the method will output an array with shape determined by the broadcasting (e.g. if `x` is shape `(T,)` inputing `x[:,None]` will now output an array of shape `(T,)` rather than `()` which at least makes it clear that broadcasting has occurred). Going forward it might be useful to have some shape checking steps.