### PR TITLE
Update lgssm filtering output and port lgssm demos from JSL.

### DIFF
--- a/ssm_jax/lgssm/demos/kf_parallel.py
+++ b/ssm_jax/lgssm/demos/kf_parallel.py
@@ -1,0 +1,104 @@
+# This example demonstrates the use of the functional inference interface in 
+#  ssm_jax where `jax.vmap` is used to map smoothing over multiple samples.
+#
+#  Note the use of `lgssm_smoother()` rather than `LinearGaussianSSM.smoother()`
+
+from jax import numpy as jnp
+from jax import random as jr
+from jax import vmap
+from matplotlib import pyplot as plt
+
+from ssm_jax.misc.plot_utils import plot_lgssm_posterior
+from ssm_jax.lgssm.models import LinearGaussianSSM
+from ssm_jax.lgssm.inference import lgssm_smoother
+
+def kf_parallel():
+    delta = 1.0
+    F = jnp.array([
+        [1, 0, delta, 0],
+        [0, 1, 0, delta],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1]
+    ])
+
+    H = jnp.array([
+        [1., 0, 0, 0],
+        [0, 1., 0, 0]
+    ])
+
+    state_size, _ = F.shape
+    observation_size, _ = H.shape
+
+    Q = jnp.eye(state_size) * 0.001
+    R = jnp.eye(observation_size) * 1.0
+
+    # Prior parameter distribution
+    mu0 = jnp.array([8, 10, 1, 0]).astype(float)
+    Sigma0 = jnp.eye(state_size) * 0.1
+
+    lgssm = LinearGaussianSSM(
+        initial_mean=mu0,
+        initial_covariance=Sigma0,
+        dynamics_matrix=F,
+        dynamics_covariance=Q,
+        emission_matrix=H,
+        emission_covariance=R)
+
+    num_timesteps = 15
+    num_samples = 4
+    key = jr.PRNGKey(310)
+    keys = jr.split(key,num_samples)
+    inputs = jnp.zeros((num_samples, num_timesteps,0))
+
+    xs, ys = vmap(lambda key: lgssm.sample(key, num_timesteps))(keys)
+
+    lgssm_posteriors = vmap(lgssm_smoother,(None,0,0))(lgssm,inputs,ys)
+
+    return xs, ys, lgssm_posteriors
+
+def plot_kf_parallel(xs, ys, lgssm_posteriors):
+    num_samples = len(xs)
+    
+    # Plot Data 
+    fig,ax = plt.subplots()
+    for n in range(num_samples):
+        ax.plot(*xs[n,:,:2].T, ls="--", color=f"C{n}")
+        ax.plot(*ys[n,...].T,'.', color=f"C{n}", label=f"Trajectory {n+1}")
+    ax.set_title("Data")
+    ax.legend()
+
+    # Plot Filtering 
+    fig,ax = plt.subplots()
+    for n in range(num_samples):
+        ax.plot(*ys[n,...].T,'.')
+        filt_means = lgssm_posteriors.filtered_means[n,...]
+        filt_covs = lgssm_posteriors.filtered_covariances[n,...]
+        plot_lgssm_posterior(filt_means,
+                             filt_covs,
+                             ax,color=f"C{n}",
+                             ellipse_kwargs={'edgecolor':f"C{n}",
+                                             'linewidth':0.5},
+                             label=f"Trajectory {n+1}")
+    ax.legend(fontsize=10);
+    ax.set_title("Filtered Posterior")
+
+    # Plot Smoothing
+    fig,ax = plt.subplots()
+    for n in range(num_samples):
+        ax.plot(*ys[n,...].T,'.')
+        filt_means = lgssm_posteriors.smoothed_means[n,...]
+        filt_covs = lgssm_posteriors.smoothed_covariances[n,...]
+        plot_lgssm_posterior(filt_means,
+                             filt_covs,
+                             ax,color=f"C{n}",
+                             ellipse_kwargs={'edgecolor':f"C{n}",
+                                             'linewidth':0.5},
+                             label=f"Trajectory {n+1}")
+    ax.legend(fontsize=10);
+    ax.set_title("Smoothed Posterior")
+    plt.show()
+
+
+if __name__ == "__main__":
+    xs, ys, lgssm_posteriors = kf_parallel()
+    plot_kf_parallel(xs, ys, lgssm_posteriors)

--- a/ssm_jax/lgssm/demos/kf_spiral.py
+++ b/ssm_jax/lgssm/demos/kf_spiral.py
@@ -1,0 +1,78 @@
+# This example demonstrates the use of the lgssm filtering and smoothing when 
+#  the linear dynamical system induced by the matrix F has imaginary eigenvalues.
+
+from jax import numpy as jnp
+from jax import random as jr
+from matplotlib import pyplot as plt
+
+from ssm_jax.misc.plot_utils import plot_lgssm_posterior
+from ssm_jax.lgssm.models import LinearGaussianSSM
+
+def kf_spiral():
+    delta = 1.0
+    F = jnp.array([
+        [0.1, 1.1, delta, 0],
+        [-1, 1, 0, delta],
+        [0, 0, 0.1, 0],
+        [0, 0, 0, 0.1]
+    ])
+
+    H = jnp.array([
+        [1, 0, 0, 0],
+        [0, 1, 0, 0]
+    ])
+
+    state_size, _ = F.shape
+    observation_size, _ = H.shape
+
+    Q = jnp.eye(state_size) * 0.001
+    R = jnp.eye(observation_size) * 2.0
+
+    # Prior parameter distribution
+    mu0 = jnp.array([1., 1., 1., 0])
+    Sigma0 = jnp.eye(state_size) * 0.1
+
+    lgssm = LinearGaussianSSM(
+        initial_mean=mu0,
+        initial_covariance=Sigma0,
+        dynamics_matrix=F,
+        dynamics_covariance=Q,
+        emission_matrix=H,
+        emission_covariance=R)
+
+    num_timesteps = 15
+    key = jr.PRNGKey(111)
+    inputs = jnp.zeros((num_timesteps,0))
+
+    x, y = lgssm.sample(key,num_timesteps)
+
+    lgssm_posterior = lgssm.smoother(y)
+
+    return x, y, lgssm_posterior
+
+def plot_kf_spiral(x, y, lgssm_posterior):
+    ### Plotting ###
+    fig, ax = plt.subplots()
+    ax.plot(*x[:,:2].T,
+             ls="--", color="darkgrey",
+             marker="o", markersize=5, label="true state")
+    plot_lgssm_posterior(lgssm_posterior.filtered_means,
+                         lgssm_posterior.filtered_covariances,
+                         ax=ax, color="tab:red", label="filtered",
+                         ellipse_kwargs={"linewidth":0.5})
+
+    fig, ax = plt.subplots()
+    ax.plot(*x[:,:2].T,
+             ls="--", color="darkgrey",
+             marker="o", markersize=5, label="true state")
+    plot_lgssm_posterior(lgssm_posterior.smoothed_means,
+                         lgssm_posterior.smoothed_covariances,
+                         ax=ax,
+                         color="tab:red", label="smoothed",
+                         ellipse_kwargs={"linewidth":0.5})
+    plt.show()
+
+
+if __name__ == "__main__":
+    x, y, lgssm_posterior = kf_spiral()
+    plot_kf_spiral(x, y, lgssm_posterior)

--- a/ssm_jax/lgssm/demos/kf_tracking.py
+++ b/ssm_jax/lgssm/demos/kf_tracking.py
@@ -1,56 +1,26 @@
+# This demo provides a basic example of Kalman filtering and
+#  smoothing with ssm_jax.
+ 
 import numpy as np
 from jax import numpy as jnp
 from jax import random as jr
 from matplotlib import pyplot as plt
 
-from ssm_jax.misc.plot_utils import plot_ellipse
+from ssm_jax.misc.plot_utils import plot_lgssm_posterior
 from ssm_jax.lgssm.models import LinearGaussianSSM
-from ssm_jax.lgssm.inference import lgssm_filter, lgssm_smoother
 
-def plot_tracking_values(observed, filtered, cov_hist, signal_label, ax):
-    """
-    observed: array(nsteps, 2)
-        Array of observed values
-    filtered: array(nsteps, state_size)
-        Array of latent (hidden) values. We consider only the first
-        two dimensions of the latent values
-    cov_hist: array(nsteps, state_size, state_size)
-        History of the retrieved (filtered) covariance matrices
-    ax: matplotlib AxesSubplot
-    """
-    timesteps, _ = observed.shape
-    ax.plot(observed[:, 0], observed[:, 1], marker="o", linewidth=0,
-            markerfacecolor="none", markeredgewidth=2, markersize=8, label="observed", c="tab:green")
-    ax.plot(*filtered[:, :2].T, label=signal_label, c="tab:red", marker="x", linewidth=2)
-    for t in range(0, timesteps, 1):
-        covn = cov_hist[t][:2, :2]
-        plot_ellipse(covn, filtered[t, :2], ax, n_std=2.0, plot_center=False)
-    ax.axis("equal")
-    ax.legend()
-
-def plot_state_space(z, ax=None, **plt_kwargs):
-    if ax is None:
-        fig, ax = plt.subplots()
-    
-    x,y = z[:,:2].T
-    if 'marker' not in plt_kwargs:
-        plt_kwargs['marker'] = "o"
-    ax.plot(x,y,**plt_kwargs)
-    ax.axis('equal');
-
-
-def main():
+def kf_tracking():
     delta = 1.0
     F = jnp.array([
-        [1, 0, delta, 0],
-        [0, 1, 0, delta],
-        [0, 0, 1, 0],
-        [0, 0, 0, 1]
+        [1., 0, delta, 0],
+        [0, 1., 0, delta],
+        [0, 0, 1., 0],
+        [0, 0, 0, 1.]
     ])
 
     H = jnp.array([
-        [1, 0, 0, 0],
-        [0, 1, 0, 0]
+        [1., 0, 0, 0],
+        [0, 1., 0, 0]
     ])
 
     state_size, _ = F.shape
@@ -60,7 +30,7 @@ def main():
     R = jnp.eye(observation_size) * 1.0
 
     # Prior parameter distribution
-    mu0 = jnp.array([8, 10, 1, 0]).astype(float)
+    mu0 = jnp.array([8., 10., 1., 0.])
     Sigma0 = jnp.eye(state_size) * 0.1
 
     lgssm = LinearGaussianSSM(
@@ -71,23 +41,67 @@ def main():
         emission_matrix=H,
         emission_covariance=R)
 
+    # Sample data from model.
     key = jr.PRNGKey(111)
     num_timesteps = 15
-    inputs = jnp.zeros((num_timesteps,0))
-
     x, y = lgssm.sample(key,num_timesteps)
 
-    ll_filt, filtered_means, filtered_covs = lgssm_filter(lgssm, inputs, y)
-    lgssm_posterior = lgssm_smoother(lgssm, inputs, y)
+    # Calculate filtered and smoothed posterior values.
+    lgssm_posterior = lgssm.smoother(y)
 
-    fig, (ax1, ax2) = plt.subplots(1,2, figsize=(10,5))
-    plot_tracking_values(y,filtered_means,filtered_covs, "filtered", ax1)
-    plot_tracking_values(
-            y,
-            lgssm_posterior.smoothed_means,
-            lgssm_posterior.smoothed_covariances,
-            "smoothed", ax2)
+    return x, y, lgssm_posterior
+
+
+def plot_kf_tracking(x,y,lgssm_posterior):
+
+    observation_marker_kwargs={
+        "marker":"o",
+        "markerfacecolor":"none",
+        "markeredgewidth":2,
+        "markersize":8
+    }
+
+    # Plot Data
+    fig, ax = plt.subplots()
+    ax.plot(*x[:,:2].T, marker="s", color="C0", label="true state");
+    ax.plot(*y.T, ls="",
+             **observation_marker_kwargs,
+             color="tab:green",
+             label="emissions")
+    ax.legend()
+
+    # Plot Filtering 
+    fig, ax = plt.subplots()
+    ax.plot(*y.T, ls="",
+             **observation_marker_kwargs,
+             color="tab:green",
+             label="observed")
+    ax.plot(*x[:,:2].T,
+             ls="--", color="darkgrey", label="true state")
+    plot_lgssm_posterior(lgssm_posterior.filtered_means,
+                         lgssm_posterior.filtered_covariances,
+                         ax,
+                         color="tab:red", label="filtered means",
+                         ellipse_kwargs={'edgecolor':'k',
+                                         'linewidth':0.5});
+
+    # Plot Smoothing 
+    fig, ax = plt.subplots()
+    ax.plot(*y.T, ls="",
+             **observation_marker_kwargs,
+             color="tab:green",
+             label="observed")
+    ax.plot(*x[:,:2].T,
+             ls="--", color="darkgrey", label="true state")
+    plot_lgssm_posterior(lgssm_posterior.smoothed_means,
+                         lgssm_posterior.smoothed_covariances,
+                         ax,
+                         color="tab:red", label="smoothed means",
+                         ellipse_kwargs={'edgecolor':'k',
+                                         'linewidth':0.5});
     plt.show()
 
+
 if __name__ == "__main__":
-    main()
+    x, y, lgssm_posterior = kf_tracking()
+    plot_kf_tracking(x, y, lgssm_posterior)

--- a/ssm_jax/lgssm/models.py
+++ b/ssm_jax/lgssm/models.py
@@ -115,8 +115,8 @@ class LinearGaussianSSM:
     def marginal_log_prob(self, emissions, inputs=None):
         num_timesteps = len(emissions)
         inputs = jnp.zeros((num_timesteps, 0)) if inputs is None else inputs
-        ll, _, _ = lgssm_filter(self, inputs, emissions)
-        return ll
+        filtered_posterior = lgssm_filter(self, inputs, emissions)
+        return filtered_posterior.marginal_loglik
 
     def filter(self, emissions, inputs=None):
         num_timesteps = len(emissions)

--- a/ssm_jax/misc/plot_utils.py
+++ b/ssm_jax/misc/plot_utils.py
@@ -3,12 +3,21 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse, transforms
 
 # https://matplotlib.org/devdocs/gallery/statistics/confidence_ellipse.html
-def plot_ellipse(Sigma, mu, ax, n_std=3.0, facecolor='none', edgecolor='k', plot_center='true', **kwargs):
+def plot_ellipse(Sigma, mu, ax, n_std=3.0,
+                 facecolor='none', edgecolor='k', 
+                 **kwargs):
+    """ Plot an ellipse to with centre `mu` and axes defined by `Sigma`. """
     cov = Sigma
     pearson = cov[0, 1] / np.sqrt(cov[0, 0] * cov[1, 1])
 
     ell_radius_x = np.sqrt(1 + pearson)
     ell_radius_y = np.sqrt(1 - pearson)
+
+    # if facecolor not in kwargs:
+    #     kwargs['facecolor'] = 'none'
+    # if edgecolor not in kwargs:
+    #     kwargs['edgecolor'] = 'k'
+
     ellipse = Ellipse((0, 0), width=ell_radius_x * 2, height=ell_radius_y * 2,
                       facecolor=facecolor, edgecolor=edgecolor, **kwargs)
 
@@ -25,6 +34,51 @@ def plot_ellipse(Sigma, mu, ax, n_std=3.0, facecolor='none', edgecolor='k', plot
 
     ellipse.set_transform(transf + ax.transData)
 
-    if plot_center:
-        ax.plot(mean_x, mean_y, '.')
     return ax.add_patch(ellipse)
+
+def plot_uncertainty_ellipses(means, Sigmas, ax, n_std=3.0, **kwargs):
+    """ Loop over means and Sigmas to add ellipses representing uncertainty. """
+    for Sigma, mu in zip(Sigmas, means):
+        plot_ellipse(Sigma, mu, ax, n_std, **kwargs)
+
+
+def plot_lgssm_posterior(post_means, post_covs, ax=None,
+                         ellipse_kwargs={}, **kwargs):
+    """ Plot posterior means and covariances for the first two dimensions of
+     the latent state of a LGSSM.
+
+    Args:
+        post_means: array(T, D).
+        post_covs: array(T, D, D).
+        ax: matplotlib axis.
+        ellipse_kwargs: keyword arguments passed to matplotlib.patches.Ellipse().
+        **kwargs: passed to ax.plot().
+    """
+    if ax is None:
+        fig, ax = plt.subplots()
+
+    # This is to stop some weird behaviour where running the function multiple
+    # #  times with an empty argument wouldn't reset the dictionary.
+    # if ellipse_kwargs is None:
+    #     ellipse_kwargs = dict()
+
+    # if 'edgecolor' not in ellipse_kwargs:
+    #     if 'color' in kwargs:
+    #         ellipse_kwargs['edgecolor'] = kwargs['color']
+
+    # Select the first two dimensions of the latent space.
+    post_means = post_means[:,:2]
+    post_covs = post_covs[:,:2,:2]
+
+    # Plot the mean trajectory 
+    ax.plot(post_means[:,0], post_means[:,1],**kwargs)
+    # Plot covariance at each time point.
+    plot_uncertainty_ellipses(post_means, post_covs, ax, **ellipse_kwargs)
+
+    ax.axis('equal')
+
+    if 'label' in kwargs:
+        ax.legend()
+
+    return ax
+


### PR DESCRIPTION
### LGSSM Filtering Output 
The function `lgssm.inference.lgssm_filter` is updated to return as `LGSSMPosterior` object to match the behaviour of `lgssm.inference.lgssm_smoother`. 

The `LGSSMPosterior` dataclass is updated so that it can be instantiated without values from the smoothing posterior. 

Instances of the use of the filtering function have been updated to work with the new output.

There are also some changes to the docstrings in `lgssm/inference.py` to be more informative and to standardise formatting a bit.

---

### LGSSM Inference Test
The test in `lgssm/inference_test.py` is updated to use a more rigorous dynamical system and to remove unnecessary additional calls to `lgssm_filter` which is called in `LinearGaussianSSM.smoother()`.

---

### LGSSM Demos
The `kf_tracking.py` demo is updated, and the `kf_spiral.py` and `kf_parallel.py` demos are ported from JSL as mentioned in issue #6.

A preliminary step towards making a simple test for these demos is made by separating inference and plotting into different functions.

Further, a number of plotting tools are added to `ssm_jax/misc/plot_utils.py`.