### PR TITLE
Reimplement hmm_posterior_sample

### DIFF
--- a/ssm_jax/hmm/inference_test.py
+++ b/ssm_jax/hmm/inference_test.py
@@ -102,7 +102,7 @@ def test_hmm_posterior_sample(key=0, num_timesteps=5, num_states=2,
         return jnp.array_equal(unique_seqs[counts.argmax()], mode_seq)
     
     keys = jr.split(key, num_iterations)
-    assert jnp.all(vmap(iterate_test, (0,))(keys))
+    assert jnp.all(vmap(iterate_test)(keys))
 
 
 def test_two_filter_smoother(key=0, num_timesteps=5, num_states=2):


### PR DESCRIPTION
## Description
Fix bugs in `hmm_posterior_sample` and verify correctness using unit test created as `test_hmm_posterior_sample`.

## Detail
Since `hmm_posterior_sample` returns a random output, there seemed to be no straightforward way to implement its unit test. 

Initially, I considered computing the probabilities of each of the possible state sequences, running `hmm_posterior_sample` many times and comparing the sampled frequencies across the possible sequences with the theoretical probabilities.

This seemed needlessly complicated, and the frequencies tended not to uniformly converge to the theoretical values when performing a reasonable number of random samples.

In the end, I settled on the approach of computing the mode sequence of the generated random samples and comparing it to the posterior mode computed by Viterbi algorithm (using `hmm_posterior_mode`).

## Issue 
#8 

## Checklist:

- [x] Performed a self-review of the code
