### PR TITLE
Reimplement test_hmm_posterior_sample to compare with full joint probs

### DIFF
--- a/ssm_jax/hmm/inference_test.py
+++ b/ssm_jax/hmm/inference_test.py
@@ -220,5 +220,3 @@ def test_hmm_smoother_stability(key=0, num_timesteps=10000, num_states=100, scal
 
     assert jnp.all(jnp.isfinite(posterior.smoothed_probs))
     assert jnp.allclose(posterior.smoothed_probs.sum(1), 1.0)
-
-test_hmm_posterior_sample()


### PR DESCRIPTION
## Description
Reimplement `test_hmm_posterior_sample`, the unit test for `hmm_posterior_sample`.

## Detail
As suggested by @murphyk's [comment](https://github.com/probml/ssm-jax/pull/26#issuecomment-1142354276), I reimplemented the unit test for `hmm_posterior_sample` to do the following:

1. Take `num_samples=1000000` random samples from `hmm_posterior_sample` and compute the relative frequencies of each possible state sequence.
2. Compute theoretical complete joint probabilities using `big_log_joint`.
3. Compare the two distributions to absolute tolerance `eps=1e-3`.
4. Iterate with `num_iterations=5` different random seeds.

With a sample size of 1 million per iteration, the sampled distribution matched the theoretical one to `1e-3` (0.1%) tolerance.

## Issue 
#8 

## Checklist:

- [x] Performed a self-review of the code
