### PR TITLE
Reimplement hmm_fixed_lag_smoother

### DIFF
--- a/ssm_jax/hmm/demos/fixed_lag_smoother.ipynb
+++ b/ssm_jax/hmm/demos/fixed_lag_smoother.ipynb
@@ -1,0 +1,526 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "fixed_lag_smoother.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Fixed Lag Smoother"
+      ],
+      "metadata": {
+        "id": "YNVwtTv8P0bZ"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# 0. Imports"
+      ],
+      "metadata": {
+        "id": "Fob7r0qaR1Nk"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!git clone https://github.com/probml/ssm-jax.git\n",
+        "%cd ssm-jax\n",
+        "!pip install -e ."
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "N4P2DsduVbW5",
+        "outputId": "54e48c02-124c-40aa-d748-bc4a37a5e01f"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'ssm-jax'...\n",
+            "remote: Enumerating objects: 590, done.\u001b[K\n",
+            "remote: Counting objects: 100% (95/95), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (58/58), done.\u001b[K\n",
+            "remote: Total 590 (delta 47), reused 41 (delta 37), pack-reused 495\u001b[K\n",
+            "Receiving objects: 100% (590/590), 1.64 MiB | 20.20 MiB/s, done.\n",
+            "Resolving deltas: 100% (333/333), done.\n",
+            "/content/ssm-jax/ssm-jax\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Obtaining file:///content/ssm-jax/ssm-jax\n",
+            "Requirement already satisfied: jax in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.3.8)\n",
+            "Requirement already satisfied: jaxlib in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.3.7+cuda11.cudnn805)\n",
+            "Requirement already satisfied: optax in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.1.2)\n",
+            "Requirement already satisfied: chex in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.1.3)\n",
+            "Requirement already satisfied: distrax in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.1.2)\n",
+            "Requirement already satisfied: tensorflow_probability in /usr/local/lib/python3.7/dist-packages (from ssm-jax==0.1) (0.16.0)\n",
+            "Requirement already satisfied: absl-py>=0.9.0 in /usr/local/lib/python3.7/dist-packages (from chex->ssm-jax==0.1) (1.1.0)\n",
+            "Requirement already satisfied: dm-tree>=0.1.5 in /usr/local/lib/python3.7/dist-packages (from chex->ssm-jax==0.1) (0.1.7)\n",
+            "Requirement already satisfied: toolz>=0.9.0 in /usr/local/lib/python3.7/dist-packages (from chex->ssm-jax==0.1) (0.11.2)\n",
+            "Requirement already satisfied: numpy>=1.18.0 in /usr/local/lib/python3.7/dist-packages (from chex->ssm-jax==0.1) (1.21.6)\n",
+            "Requirement already satisfied: scipy>=1.2.1 in /usr/local/lib/python3.7/dist-packages (from jax->ssm-jax==0.1) (1.4.1)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from jax->ssm-jax==0.1) (4.2.0)\n",
+            "Requirement already satisfied: opt-einsum in /usr/local/lib/python3.7/dist-packages (from jax->ssm-jax==0.1) (3.3.0)\n",
+            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from jaxlib->ssm-jax==0.1) (2.0)\n",
+            "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from tensorflow_probability->ssm-jax==0.1) (4.4.2)\n",
+            "Requirement already satisfied: six>=1.10.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow_probability->ssm-jax==0.1) (1.15.0)\n",
+            "Requirement already satisfied: gast>=0.3.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow_probability->ssm-jax==0.1) (0.5.3)\n",
+            "Requirement already satisfied: cloudpickle>=1.3 in /usr/local/lib/python3.7/dist-packages (from tensorflow_probability->ssm-jax==0.1) (1.3.0)\n",
+            "Installing collected packages: ssm-jax\n",
+            "  Attempting uninstall: ssm-jax\n",
+            "    Found existing installation: ssm-jax 0.1\n",
+            "    Can't uninstall 'ssm-jax'. No files were found to uninstall.\n",
+            "  Running setup.py develop for ssm-jax\n",
+            "Successfully installed ssm-jax-0.1\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import ssm_jax.hmm.inference as core\n",
+        "import ssm_jax.hmm.inference_test as test\n",
+        "\n",
+        "import jax.numpy as jnp\n",
+        "import jax.random as jr\n",
+        "import jax.lax as lax\n",
+        "from jax import vmap"
+      ],
+      "metadata": {
+        "id": "sNgYCLHe7-fC"
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# 1. Fixed Lag Smoother - Two Implementations"
+      ],
+      "metadata": {
+        "id": "jbmIOFafYk7b"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "QDJ7YcaZGSTI"
+      },
+      "outputs": [],
+      "source": [
+        "# Naive (un-vectorized) version that smooths backward inside the window\n",
+        "def hmm_fixed_lag_smoother_iterative(initial_distribution,\n",
+        "                                     transition_matrix,\n",
+        "                                     log_likelihoods,\n",
+        "                                     window_size):\n",
+        "    \n",
+        "    num_timesteps, num_states = log_likelihoods.shape\n",
+        "\n",
+        "    def _step(carry, t):\n",
+        "        # Unpack the inputs\n",
+        "        log_normalizers, filtered_probs, predicted_probs = carry\n",
+        "        t_offset = t + offset\n",
+        "\n",
+        "        # Get parameters for time t\n",
+        "        A_fwd = core._get_params(transition_matrix, 2, t_offset-1)\n",
+        "        A_bwd = core._get_params(transition_matrix, 2, t_offset)\n",
+        "        ll = log_likelihoods[t_offset]\n",
+        "        \n",
+        "        # Shift window forward by 1\n",
+        "        log_normalizers = log_normalizers[1:]\n",
+        "        predicted_probs = predicted_probs[1:]\n",
+        "        filtered_probs = filtered_probs[1:]\n",
+        "        \n",
+        "        # Perform forward operation\n",
+        "        predicted_probs_next = core._predict(filtered_probs[-1], A_fwd)\n",
+        "        filtered_probs_next, log_norm = core._condition_on(predicted_probs_next, ll)\n",
+        "        log_normalizers = jnp.concatenate((log_normalizers,\n",
+        "                                           jnp.array([log_norm])))\n",
+        "        filtered_probs = jnp.concatenate((filtered_probs,\n",
+        "                                          jnp.array([filtered_probs_next])))\n",
+        "        predicted_probs = jnp.concatenate((predicted_probs,\n",
+        "                                           jnp.array([predicted_probs_next])))\n",
+        "\n",
+        "        # Smooth backwards inside the window\n",
+        "        window_lb = t_offset - window_size + 1\n",
+        "        transition_backward = lax.dynamic_slice(transition_matrix,\n",
+        "                                                (window_lb,0,0),\n",
+        "                                                (window_size,num_states,num_states))\n",
+        "        transition_backward = transition_matrix\n",
+        "        lls_backward = lax.dynamic_slice(log_likelihoods, \n",
+        "                                         (window_lb, 0), \n",
+        "                                         (window_size, num_states))\n",
+        "        _, betas = core.hmm_backward_filter(transition_backward, lls_backward)\n",
+        "        betas = jnp.pad(betas, ((window_size-betas.shape[0],0), (0,0)))\n",
+        "\n",
+        "        # Compute posterior values\n",
+        "        def compute_posterior(filtered_probs, beta):\n",
+        "            smoothed_probs = filtered_probs * beta\n",
+        "            return jnp.where(smoothed_probs.sum(), \n",
+        "                             smoothed_probs/smoothed_probs.sum(), smoothed_probs)\n",
+        "        smoothed_probs = vmap(compute_posterior, (0, 0))(filtered_probs, betas)\n",
+        "\n",
+        "        post = core.HMMPosterior(marginal_loglik = log_normalizers.sum(),\n",
+        "                                 filtered_probs = filtered_probs,\n",
+        "                                 predicted_probs = predicted_probs,\n",
+        "                                 smoothed_probs = smoothed_probs)\n",
+        "\n",
+        "        return (log_normalizers, filtered_probs, predicted_probs), post\n",
+        "    \n",
+        "    # Filter on first observation\n",
+        "    ll = log_likelihoods[0]\n",
+        "    filtered_probs, log_norm = core._condition_on(initial_distribution, ll)\n",
+        "    \n",
+        "    # Reshape for lax.scan\n",
+        "    filtered_probs = jnp.pad(jnp.expand_dims(filtered_probs, axis=0),\n",
+        "                             ((window_size-1,0), (0,0)))\n",
+        "    predicted_probs = jnp.pad(jnp.expand_dims(initial_distribution, axis=0),\n",
+        "                              ((window_size-1,0), (0,0)))\n",
+        "    log_normalizers = jnp.pad(jnp.array([log_norm]), (window_size-1,0))\n",
+        "\n",
+        "    # Pad transition and log likelihoods for backwards smoothing using lax.scan\n",
+        "    if transition_matrix.ndim == 3:\n",
+        "        transition_matrix = jnp.pad(transition_matrix, \n",
+        "                                    ((window_size-2,0), (0,0), (0,0)), \n",
+        "                                    constant_values=1)\n",
+        "    else:\n",
+        "        transition_matrix = jnp.repeat(jnp.expand_dims(transition_matrix, axis=0),\n",
+        "                                       window_size-1+num_timesteps,\n",
+        "                                       axis=0)\n",
+        "    log_likelihoods = jnp.pad(log_likelihoods, ((window_size-2,0), (0,0)))\n",
+        "    offset = window_size-2\n",
+        "\n",
+        "    carry = (log_normalizers, filtered_probs, predicted_probs)\n",
+        "    _, posts = lax.scan(\n",
+        "        _step, carry, jnp.arange(1, num_timesteps)\n",
+        "    )\n",
+        "\n",
+        "    # Include initial values\n",
+        "    marginal_loglik = jnp.concatenate((jnp.array([log_normalizers.sum()]), \n",
+        "                                      posts.marginal_loglik))\n",
+        "    predicted_probs = jnp.concatenate((jnp.expand_dims(predicted_probs, axis=0),\n",
+        "                                       posts.predicted_probs))\n",
+        "    smoothed_probs = jnp.concatenate((jnp.expand_dims(filtered_probs, axis=0),\n",
+        "                                      posts.smoothed_probs))\n",
+        "    filtered_probs = jnp.concatenate((jnp.expand_dims(filtered_probs, axis=0), \n",
+        "                                      posts.filtered_probs))\n",
+        "\n",
+        "    posts = core.HMMPosterior(marginal_loglik = marginal_loglik,\n",
+        "                              filtered_probs = filtered_probs,\n",
+        "                              predicted_probs = predicted_probs,\n",
+        "                              smoothed_probs = smoothed_probs)\n",
+        "\n",
+        "    return posts"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Vectorized version\n",
+        "def hmm_fixed_lag_smoother_vectorized(initial_distribution,\n",
+        "                                      transition_matrix,\n",
+        "                                      log_likelihoods,\n",
+        "                                      window_size):\n",
+        "    \n",
+        "    num_timesteps, num_states = log_likelihoods.shape\n",
+        "\n",
+        "    def _step(carry, t):\n",
+        "        # Unpack the inputs\n",
+        "        log_normalizers, filtered_probs, predicted_probs, bmatrices = carry\n",
+        "\n",
+        "        # Get parameters for time t\n",
+        "        A_fwd = core._get_params(transition_matrix, 2, t-1)\n",
+        "        A_bwd = core._get_params(transition_matrix, 2, t)\n",
+        "        ll = log_likelihoods[t]\n",
+        "        \n",
+        "        # Shift window forward by 1\n",
+        "        log_normalizers = log_normalizers[1:]\n",
+        "        predicted_probs = predicted_probs[1:]\n",
+        "        filtered_probs = filtered_probs[1:]\n",
+        "        bmatrices = bmatrices[1:]\n",
+        "        \n",
+        "        # Perform forward operation\n",
+        "        predicted_probs_next = core._predict(filtered_probs[-1], A_fwd)\n",
+        "        filtered_probs_next, log_norm = core._condition_on(predicted_probs_next, ll)\n",
+        "        log_normalizers = jnp.concatenate((log_normalizers,\n",
+        "                                           jnp.array([log_norm])))\n",
+        "        filtered_probs = jnp.concatenate((filtered_probs,\n",
+        "                                          jnp.array([filtered_probs_next])))\n",
+        "        predicted_probs = jnp.concatenate((predicted_probs,\n",
+        "                                           jnp.array([predicted_probs_next])))\n",
+        "\n",
+        "        # Smooth inside the window in parallel\n",
+        "        def update_bmatrix(bmatrix):\n",
+        "            return (bmatrix @ A_bwd) * jnp.exp(ll)\n",
+        "        bmatrices = vmap(update_bmatrix)(bmatrices)\n",
+        "        bmatrices = jnp.concatenate((bmatrices, jnp.eye(num_states)[None, :]))\n",
+        "\n",
+        "        # Compute beta values by row-summing bmatrices\n",
+        "        def compute_beta(bmatrix):\n",
+        "            beta = bmatrix.sum(axis=1)\n",
+        "            return jnp.where(beta.sum(), beta/beta.sum(), beta)\n",
+        "        betas = vmap(compute_beta)(bmatrices)\n",
+        "\n",
+        "        # Compute posterior values\n",
+        "        def compute_posterior(filtered_probs, beta):\n",
+        "            smoothed_probs = filtered_probs * beta\n",
+        "            return jnp.where(smoothed_probs.sum(), \n",
+        "                             smoothed_probs/smoothed_probs.sum(), smoothed_probs)\n",
+        "        smoothed_probs = vmap(compute_posterior, (0, 0))(filtered_probs, betas)\n",
+        "\n",
+        "        post = core.HMMPosterior(marginal_loglik = log_normalizers.sum(),\n",
+        "                                 filtered_probs = filtered_probs,\n",
+        "                                 predicted_probs = predicted_probs,\n",
+        "                                 smoothed_probs = smoothed_probs)\n",
+        "\n",
+        "        return (log_normalizers, filtered_probs, predicted_probs, bmatrices), post\n",
+        "    \n",
+        "    # Filter on first observation\n",
+        "    ll = log_likelihoods[0]\n",
+        "    filtered_probs, log_norm = core._condition_on(initial_distribution, ll)\n",
+        "    \n",
+        "    # Reshape for lax.scan\n",
+        "    filtered_probs = jnp.pad(jnp.expand_dims(filtered_probs, axis=0),\n",
+        "                             ((window_size-1,0), (0,0)))\n",
+        "    predicted_probs = jnp.pad(jnp.expand_dims(initial_distribution, axis=0),\n",
+        "                              ((window_size-1,0), (0,0)))\n",
+        "    log_normalizers = jnp.pad(jnp.array([log_norm]), (window_size-1,0))\n",
+        "    bmatrices = jnp.pad(jnp.expand_dims(jnp.eye(num_states), axis=0),\n",
+        "                        ((window_size-1,0), (0,0), (0,0)))\n",
+        "\n",
+        "    carry = (log_normalizers, filtered_probs, predicted_probs, bmatrices)\n",
+        "    _, posts = lax.scan(\n",
+        "        _step, carry, jnp.arange(1, num_timesteps)\n",
+        "    )\n",
+        "\n",
+        "    # Include initial values\n",
+        "    marginal_loglik = jnp.concatenate((jnp.array([log_normalizers.sum()]), \n",
+        "                                      posts.marginal_loglik))\n",
+        "    predicted_probs = jnp.concatenate((jnp.expand_dims(predicted_probs, axis=0),\n",
+        "                                       posts.predicted_probs))\n",
+        "    smoothed_probs = jnp.concatenate((jnp.expand_dims(filtered_probs, axis=0),\n",
+        "                                      posts.smoothed_probs))\n",
+        "    filtered_probs = jnp.concatenate((jnp.expand_dims(filtered_probs, axis=0), \n",
+        "                                      posts.filtered_probs))\n",
+        "\n",
+        "    posts = core.HMMPosterior(marginal_loglik = marginal_loglik,\n",
+        "                              filtered_probs = filtered_probs,\n",
+        "                              predicted_probs = predicted_probs,\n",
+        "                              smoothed_probs = smoothed_probs)\n",
+        "\n",
+        "    return posts"
+      ],
+      "metadata": {
+        "id": "6YFXqHP00UmQ"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# 2. Correctness of Implementation"
+      ],
+      "metadata": {
+        "id": "tEg7cAk0aNAH"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We test the two versions by comparing their full-lag smoothed posteriors against those of the naive ```core.hmm_smoother```.\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "WXfW503oaXXW"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def test_hmm_fixed_lag_smoother(key=0, num_timesteps=5, num_states=2):\n",
+        "    if isinstance(key, int):\n",
+        "        key = jr.PRNGKey(key)\n",
+        "    \n",
+        "    args = test.random_hmm_args(key, num_timesteps, num_states)\n",
+        "\n",
+        "    # Run the HMM smoother\n",
+        "    posterior = core.hmm_smoother(*args)\n",
+        "\n",
+        "    # Run the HMM fixed-lag smoothers (vectorized, iterative) with full window size\n",
+        "    posterior_fl_vec = hmm_fixed_lag_smoother_vectorized(*args, window_size=num_timesteps)\n",
+        "    posterior_fl_it = hmm_fixed_lag_smoother_iterative(*args, window_size=num_timesteps)\n",
+        "\n",
+        "    def compare_posteriors(post1, post2):\n",
+        "        assert jnp.allclose(post1.marginal_loglik, post2.marginal_loglik[-1])\n",
+        "        assert jnp.allclose(post1.filtered_probs, post2.filtered_probs[-1])\n",
+        "        assert jnp.allclose(post1.predicted_probs, post2.predicted_probs[-1])\n",
+        "        assert jnp.allclose(post1.smoothed_probs, post2.smoothed_probs[-1])\n",
+        "\n",
+        "    # Compare posterior values of fixed-lag smoothers to those of smoother\n",
+        "    compare_posteriors(posterior, posterior_fl_vec)\n",
+        "    compare_posteriors(posterior, posterior_fl_it)\n",
+        "\n",
+        "# Verify correctness\n",
+        "test_hmm_fixed_lag_smoother()"
+      ],
+      "metadata": {
+        "id": "WKIYdNxyDysx"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# 3. Timed Experiments"
+      ],
+      "metadata": {
+        "id": "S2ZVMRwEkQML"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import time\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "def compare_runtime(key=0, num_timesteps=10000, num_states=3, window_ub=9000, window_step=500):\n",
+        "    if isinstance(key, int):\n",
+        "        key = jr.PRNGKey(key)\n",
+        "    args = test.random_hmm_args(key, num_timesteps, num_states)\n",
+        "    window_grid = np.insert(np.arange(window_step, window_ub+1, window_step), 0, 2)\n",
+        "    \n",
+        "    it_times, vec_times = [], []\n",
+        "    for window_size in window_grid:\n",
+        "        print(f'Window of size: {window_size}')\n",
+        "        start = time.time()\n",
+        "        _ = hmm_fixed_lag_smoother_iterative(*args, window_size)\n",
+        "        it_time = time.time()-start\n",
+        "        it_times.append(it_time)\n",
+        "        print(f'Iterative version took {it_time} seconds.')\n",
+        "        start = time.time()\n",
+        "        _ = hmm_fixed_lag_smoother_vectorized(*args, window_size)\n",
+        "        vec_time = time.time()-start\n",
+        "        vec_times.append(vec_time)\n",
+        "        print(f'Vectorized version took {vec_time} seconds.')\n",
+        "\n",
+        "    # Plot the result\n",
+        "    plt.figure()\n",
+        "    plt.plot(window_grid, it_times, label='iterative')\n",
+        "    plt.plot(window_grid, vec_times, label='vectorized')\n",
+        "    plt.xlabel('window length')\n",
+        "    plt.ylabel('best time in s')\n",
+        "    plt.legend();\n",
+        "    plt.show()\n",
+        "\n",
+        "compare_runtime()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "RGcVmIuLFRy4",
+        "outputId": "afc4f5e3-100b-4fae-8a81-fd1eff6288d2"
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Window of size: 2\n",
+            "Iterative version took 0.3614373207092285 seconds.\n",
+            "Vectorized version took 0.2810072898864746 seconds.\n",
+            "Window of size: 500\n",
+            "Iterative version took 0.8622324466705322 seconds.\n",
+            "Vectorized version took 0.6720662117004395 seconds.\n",
+            "Window of size: 1000\n",
+            "Iterative version took 1.181218147277832 seconds.\n",
+            "Vectorized version took 1.0287139415740967 seconds.\n",
+            "Window of size: 1500\n",
+            "Iterative version took 1.529416799545288 seconds.\n",
+            "Vectorized version took 1.4300556182861328 seconds.\n",
+            "Window of size: 2000\n",
+            "Iterative version took 2.7996904850006104 seconds.\n",
+            "Vectorized version took 1.997316837310791 seconds.\n",
+            "Window of size: 2500\n",
+            "Iterative version took 2.498990535736084 seconds.\n",
+            "Vectorized version took 2.1012110710144043 seconds.\n",
+            "Window of size: 3000\n",
+            "Iterative version took 2.6218788623809814 seconds.\n",
+            "Vectorized version took 2.3956081867218018 seconds.\n",
+            "Window of size: 3500\n",
+            "Iterative version took 4.48356032371521 seconds.\n",
+            "Vectorized version took 2.782362461090088 seconds.\n",
+            "Window of size: 4000\n",
+            "Iterative version took 3.3518478870391846 seconds.\n",
+            "Vectorized version took 3.09979510307312 seconds.\n",
+            "Window of size: 4500\n",
+            "Iterative version took 3.846179723739624 seconds.\n",
+            "Vectorized version took 4.448943376541138 seconds.\n",
+            "Window of size: 5000\n",
+            "Iterative version took 4.076323509216309 seconds.\n",
+            "Vectorized version took 3.8642940521240234 seconds.\n",
+            "Window of size: 5500\n",
+            "Iterative version took 4.724858522415161 seconds.\n",
+            "Vectorized version took 4.481334447860718 seconds.\n",
+            "Window of size: 6000\n",
+            "Iterative version took 5.072105407714844 seconds.\n",
+            "Vectorized version took 4.542433023452759 seconds.\n",
+            "Window of size: 6500\n",
+            "Iterative version took 5.471795320510864 seconds.\n",
+            "Vectorized version took 5.1107494831085205 seconds.\n",
+            "Window of size: 7000\n",
+            "Iterative version took 5.938655138015747 seconds.\n",
+            "Vectorized version took 5.372331619262695 seconds.\n",
+            "Window of size: 7500\n",
+            "Iterative version took 6.486835479736328 seconds.\n",
+            "Vectorized version took 5.87862491607666 seconds.\n",
+            "Window of size: 8000\n",
+            "Iterative version took 7.955630540847778 seconds.\n",
+            "Vectorized version took 5.998695373535156 seconds.\n",
+            "Window of size: 8500\n",
+            "Iterative version took 8.570979595184326 seconds.\n",
+            "Vectorized version took 6.829608917236328 seconds.\n",
+            "Window of size: 9000\n",
+            "Iterative version took 7.781638145446777 seconds.\n",
+            "Vectorized version took 6.99358606338501 seconds.\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAEGCAYAAABvtY4XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3gU1frA8e9JJySEkNBDSAg1QAi9F1EBwYIK0lRQEER/1ntVLBfFwr2Wa0MBUVGw0kVBlA6hk9B7Qk8oaZSQkH5+f8wCgRvCJtnJJpv38zz7ZHdmds67w+ZlcubMe5TWGiGEEI7Hyd4BCCGEMIckeCGEcFCS4IUQwkFJghdCCAclCV4IIRyUi70DyMvf318HBQXZOwwhhCgzoqKiErXWVfNbV6oSfFBQEJGRkfYOQwghygyl1PGbrZMuGiGEcFCS4IUQwkFJghdCCAdVqvrg85OVlUVsbCzp6en2DsXheHh4EBAQgKurq71DEUKYoNQn+NjYWLy9vQkKCkIpZe9wHIbWmqSkJGJjYwkODrZ3OEIIE5T6Lpr09HT8/PwkuduYUgo/Pz/5y0gIB1bqEzwgyd0kclyFcGxlIsELIURpdDjhEgu2x1Jay65LgrdCp06dADh27Bg///yzTfc9ceLEfNsSQpRu62MS6f/Fel6YtZMvV8XYO5x8SYK3woYNG4CiJfjs7OwC19+Y4K+0JYQoveZEnmT49C3UqlyBfs1r8tHSQ8zeetLeYf0PSfBW8PLyAmDcuHFEREQQHh7OJ598Qk5ODi+99BJt27YlLCyMr776CoDVq1fTtWtX7r33XkJDQwHo378/rVu3pmnTpkybNu3q/i5fvkx4eDjDhg27rq3BgwezePHiqzGMGDGCuXPn3rRNIYT5tNZ8vOwQL83dRYd6fswZ25FPB4fTrWFVXl2wmxX7z9o7xOuo0tR31KZNG31jLZr9+/fTpEkTACb8sZd9py7atM3QWpV4856mBW7j5eXFpUuXWL16NR999BGLFi0CYNq0acTHx/PGG2+QkZFB586dmTNnDsePH6dfv37s2bPn6hDE5ORkqlSpwuXLl2nbti1r1qzBz8/v6r5vbGvBggX89ttvzJgxg8zMTEJCQjh06BA//PBDvm0Wdahj3uMrhLi5zOxcxs3bxfztcQxsHcDEB5rj6mycI6dmZDPk600cOpvCz090oFWgb4nFpZSK0lq3yW+dnMEXw9KlS5k5cybh4eG0b9+epKQkoqOjAWjXrt11Sffzzz+nRYsWdOjQgZMnT17d7mbuuusuVq1aRUZGBkuWLKFbt25UqFChwDaFEOa4kJbFo9M3M397HP+4syEfDAi7mtwBKrq7MH1EW6pX8uDx77cSE3+pgL2VnFJ/o1NetzrTLmlaayZNmkTv3r2vW7569WoqVqx43evly5ezceNGPD096dGjxy3Hn3t4eNCjRw/+/vtvZs2axeDBgwtsUwhhjpPJaTz2/VZOJKXx6aBw+resne92/l7uzHy8HQ9O2cDw6VuY/1QnqlfyKOForydn8IXg7e1NSkrK1de9e/dmypQpZGVlAXDo0CFSU1P/530XLlzA19cXT09PDhw4wKZNm66uc3V1vfr+Gw0aNIjvvvuOiIgI+vTpU6g2hRDFt/Pkee6fvJ6ElAxmjmx30+R+RV2/inw3oh3n0zIZPn0LF9Pz/90uKZLgCyEsLAxnZ2datGjBJ598wqhRowgNDaVVq1Y0a9aMMWPG5Dtqpk+fPmRnZ9OkSRPGjRtHhw4drq4bPXo0YWFhVy+y5tWrVy/WrFnDHXfcgZubG4DVbQohimfp3jMMmraRCm7OzBvbiQ71/Kx6X/MAH6Y+0pqY+EuMnhlJRnaOyZHeXJm6yCpsT46vEP9r+rqjvLN4H2EBlfl2eBv8vdwLvY/ftsfx/Kwd9Gtek0lDWuLkZM6d4wVdZC1TffBCCGGmnFzNO4v28f2GY/RuWp1PB7WkgptzkfbVv2VtElIyeO/P/VT1dufNe0JLvDyIJHghhADSMrN57tcdLNt3lpFdgnmtbxOci3nW/US3epy9mM43645SvZIHY3uE2Cha65ia4JVSLwCjAA3sBh7TWkv5QiFEqZKQksGoGVvZHXeBt+4JZURn25XQfq1vE+JTMnj/rwNU9XZnQOsAm+37Vky7yKqUqg08C7TRWjcDnIHBZrUnhBBFEROfwv2T13Po7CW+eqSNTZM7gJOT4qOBLehS359X5u1i1cF4m+6/wLZN3r8LUEEp5QJ4AqdMbk8IIay24XAiD0zeQHpWLrPGdODO0OqmtOPm4sTUR1rTpKY3T/24jR0nz5vSzo1MS/Ba6zjgI+AEcBq4oLVeeuN2SqnRSqlIpVRkQkKCWeEIIcR1NhxOZPj0LVSv5MGCpzoRFlDZ1Pa83F34bkQ7qnq78/j3WzmaaP79K2Z20fgC9wHBQC2golLq4Ru301pP01q30Vq3qVq1qlnh2NVvv/3Gvn37Cv2+qVOnMnPmzGK3HxQURGJiYrH3I4Sj0Frz/l8HqeHjwdyxnahTxbNE2q3q7c6Mx9uhgEenbyY+xdxLkmZ20dwBHNVaJ2its4D5QLksdl6UBJ+dnc2TTz7Jo48+alJUQpRf62IS2XnyPGO718enQslOOh/sX5HpI9qSdCmTEdO3kmLi3a5mjqI5AXRQSnkCl4HbgciC31L6jBs3jjp16vD0008D8NZbb+Hl5YXWmtmzZ5ORkcH999/PhAkTAJg5cyYfffQRSinCwsIYO3Ysv//+O2vWrOHdd99l3rx5pKSk8OSTT5KWlkZISAjTp0/H19eXHj16EB4ezrp16xgyZAgpKSl4eXkxdOhQ+vbtezWm3bt3c+TIETw9PXnyySc5ceIEAJ9++imdO3cmKSmJIUOGEBcXR8eOHUvtbDNC2MsXK2OoUcmDB1sXXHrALC3qVGbysFaMmhHJkz9GMX1EW9xdijbeviCmJXit9Wal1FxgG5ANbAemFWunS8bBmd02iC6PGs3hrv/cdPWgQYN4/vnnryb42bNn88orr7B+/Xq2bNmC1pp7772XtWvX4ufnx7vvvsuGDRvw9/e/WiL43nvv5e6772bAgAGAUfJg0qRJdO/enfHjxzNhwgQ+/fRTADIzM7lyN+9bb70FQK1atdixYwcAX375JWvWrKFu3boMHTqUF154gS5dunDixAl69+7N/v37mTBhAl26dGH8+PEsXryYb7/91rbHTIgybMvRZDYfTebNe0JNSarW6tGoGh8MCOPF2Tv555xdfDYo3OZ3u5o6Dl5r/SbwppltmK1ly5bEx8dz6tQpEhIS8PX1Zffu3SxdupSWLVsCcOnSJaKjo9m5cycDBw7E398fgCpVqvzP/i5cuMD58+fp3r07AMOHD2fgwIFX1w8aNOimsaxfv56vv/6adevWAbB8+fLrun4uXrzIpUuXWLt2LfPnzwegX79++PqWXG1qIUq7L1bF4FfRjcFtA+0dCg+0CiA+JYO1hxJIz87B0822Kbls3clawJm2mQYOHMjcuXM5c+YMgwYN4vjx47z66quMGTPmuu0mTZpU7LbylhnO6/Tp04wcOZLff//96qxPubm5bNq0CQ8P+5YkFaKs2BV7nrWHEnilT+MilyCwtTHd6jGqSzAuzra/JCrVJK0waNAgfv31V+bOncvAgQPp3bs306dPvzoTU1xcHPHx8fTs2ZM5c+aQlJQEGLM4wfVlhn18fPD19SUiIgKAH3744erZ/M1kZWUxcOBA3n//fRo2bHh1ea9eva77T+VKN063bt2uzh27ZMkSzp07Z4vDIESZ98XKGCp5uPBwB/ufvV+hlDIluYMkeKs0bdqUlJQUateuTc2aNenVqxdDhw6lY8eONG/enAEDBpCSkkLTpk15/fXX6d69Oy1atODFF18EjPlVP/zwQ1q2bMnhw4eZMWMGL730EmFhYezYsYPx48cX2P6GDRuIjIzkzTffJDw8nPDwcE6dOsXnn39OZGQkYWFhhIaGMnXqVADefPNN1q5dS9OmTZk/fz6BgaXnyyyEvRw4c5Gl+87yWOdgvD1KduSMvUi54HJOjq8oL579ZTsr9p9l/bieVPZ0s3c4NiNzsgohyrWjiaks2nWKhzvWdajkfiuS4IUQDm/K6hhcnZ0Y1aWevUMpUWUiwZembiRHIsdVlAex59KYvy2OIe0Cqepd+JmZyrJSn+A9PDxISkqSZGRjWmuSkpJkiKVweF+tOYJSMKZ7+Tp7hzIwDj4gIIDY2Fik0qTteXh4EBBQcpMPCFHS4i+mMyvyJANaB1DTp4K9wylxpT7Bu7q6Ehxs2wL8Qojy4euII2Tn5PJk95KdKq+0KPVdNEIIURTJqZn8uOkE94XXpq5f/neIOzpJ8EIIh/Td+qOkZ+fwVAlPdF2aSIIXQjici+lZfL/hGH2a1qBBdW97h2M3kuCFEA7nh43HSUnP5unb6ts7FLuSBC+EcChpmdl8E3GE2xpVpVltH3uHY1eS4IUQDuXnzSc4l5bF//VsYO9Q7E4SvBDCYaRn5TBt7RE6hfjRum4ZmugmN9eU3Zb6cfBCCGGtOVGxxKdk8OmgcHuHUrDUJDi5GU5ughObITMVxq6zeTOS4IUQDiErJ5epqw/TKrAyHUP87B3ONVpD0mFLMt9kJPbEQ8Y6J1eoFQ4hPYyzeCfbdqpIghdCOITftscRd/4y7/ZvhlK2nby6ULIz4PTOa8n8xCZISzTWeVSGOu2hxRAI7AC1WoKreSUUJMELIcq8nFzN5NWHaVqrEj0aVS3ZxtOS4eQWOLHRSOhx2yAnw1jnGwwNekFge6jTAfwb2vwsvSCS4IUQZd6fu09zNDGVKcNalezZ++r3YfVE47mTC9QMh3ZPGGfpddqDd/WSiyUfkuCFEGVabq7mi5Ux1K/mRe+mNUqu4e0/Gcm96f3QdhTUagVuniXXvhUkwQshyrTl+89y8GwKnwxqgZNTCZ29H42AP56Dej3gga/BuXRO4i3j4IUQZZbWmi9XxRBYxZN7wmqVTKOJ0TDrYfALgYEzSm1yB0nwQogyLCI6kZ2xFxjbIwQX5xJIZ6lJ8NNAo7996CyoUNn8NotBumiEEGXWFytjqOnjwQOtapvfWHYGzBoGF0/BiEXgG2R+m8UkZ/BCiDJp85EkthxLZnS3eri7OJvbmNbw+zPGUMj7p0Cddua2ZyOS4IUQZdIXq2Lw93JjcNtA8xtb8wHsmgU934BmD5rfno1IghdClDl/7j5NRHQio7rWo4KbyWfvu+YYwyFbDIWu/zS3LRuTPnghRJmRnZPLR0sPMXXNYVoE+PBIh7rmNnhiEyx8Cup2gXs+A3uWQCgCSfBCiDIhISWDZ37ZxqYjyQxrH8j4e0LN7XtPPgK/DgWfOjDoB3BxM68tk0iCF0KUepHHknnqp21cTM/ivwNb8GDrAHMbvHwOfnoIdC4MmwOeVcxtzySS4IUQpZbWmm/XHeU/Sw4Q4FuBGY+3o0nNSuY2mp0Jsx6Bc8dg+O/GDU1llCR4IUSpdCkjm5fn7uTP3WfoFVqdjx5qQSUPk+8a1RoWvwDHIuD+aVC3k7ntmUwSvBCi1Dl0NoUnf4zieFIar97VmNHd6pVMlch1n8D2H6H7K9BikPntmUwSvBCiVFm4I45x83ZT0d2Fn0a1p0O9Epqdae9vsGICNBsAPV4tmTZNJgleCFEqZGbn8t7ifczYeJy2Qb58ObQV1Sp5lEzjsZGwYIxRw/2+L8vccMibMTXBK6UqA98AzQANPK613mhmm0KIsufU+cs89dM2dpw8zxNdg3m5T2NcS6J4GMC54/DLYPCqDoN/BtcS+k+lBJh9Bv8Z8JfWeoBSyg0oXdXwhRB2ty46kWd/3U5mdi6Th7Wib/OaJdd4+gX4eZAxcmbEYqjoX3JtlwDTErxSygfoBowA0FpnAplmtSeEKFtyczWTV8fw32WHaFDNiykPtyakqlfJBZCRAnNGQFI0PDwPqjYqubZLiJln8MFAAvCdUqoFEAU8p7VONbFNIUQZcD4tkxdn72TlgXj6h9di4gPN8XQzKR1lpkHiIYjfDwn7If6A8fzCCWP9vZOMmZkckJkJ3gVoBTyjtd6slPoMGAf8K+9GSqnRwGiAwMASqAonhLCrLUeTeXH2Ds5eTOed/s14uH2gbYZAZmdYEvmBPIl8n3HDEtrYxtkN/BpAnbbQ+lHjompwt+K3XUqZmeBjgVit9WbL67kYCf46WutpwDSANm3aaBPjEULYUWpGNh/+fZAZG48R4FuB2WM60jLQt2g7y86EQ0vg7F7jbDx+v1E7RucY651coEoI1GwBLQZD1cZQLRSq1APn8jN40LRPqrU+o5Q6qZRqpLU+CNwO7DOrPSFE6bUhJpFX5u8i9txlhncM4qXejajoXsT0k3AI5o2EM7tAORlJu2pjaNofqjWBqk3Ar36ZLA5ma2b/V/YM8JNlBM0R4DGT2xNClCIp6VlM/PMAv2w5QbB/RWaP6UjboCIW7tIaor6Hv14F1wrGhNcN+zjUsEZbMzXBa613AG3MbEMIUTqtPhjPq/N3c/ZiOqO71ePFOxvi4VrE8r6pSfDHs3BgEdS7De6fCt41bBuwA7plgldKVQQua61zlVINgcbAEq11lunRCSHKnAtpWbyzeB9zo2KpX82LeWM7Fb2vHeDwKljwJFxOhl7vQYenwEkmo7OGNWfwa4GuSilfYCmwFRgEDDMzMCFE2bNs31leX7CbpNRMnr4thGdvb1D0STmyM2DlO7BhEvg3NOqy1wyzbcAOzpoEr7TWaUqpkcBkrfUHSqkdZgcmhCg7klMzmfDHXhbuOEXjGt5MH9GWZrV9ir7DvBdS24yEXu+Cm9wIX1hWJXilVEeMM/aRlmUmz3IrhCgr/tx9mvEL93DhchYv3NGQsT1CcHMpYheK1hD1Hfz1mpHQB/8CjfvaNuByxJoE/xzwKrBAa71XKVUPWGVuWEKI0i4hJYPxC/ewZM8Zmtf24cdR7WlcoxizLaUmwe/PwMHFciHVRm6Z4LXWazH64a+8PgI8a2ZQQojSS2vNwh2neOuPvaRl5PByn0aM7loPl+JUf8x7IbX3RGg/Vi6k2kD5uaVLCFFsJ5LSeHvRXpbvj6dlYGU+HBBG/WreRd9hdgaseBs2fgH+jeRCqo1JghdC3NLF9Cy+XBnDd+uP4eykeKNfEx7rHIyzUzFqyCQctFxI3Q1tR8Gd78iFVBuTBC+EuKnsnFx+2XKCT5ZHcy4tkwGtAvhn70ZUL85MSznZsO17+PsNI6EP+RUa3WWzmMU11tzoVBV4AgjKu73W+nHzwhJC2JPWmtWHEnhv8X5i4i/RoV4V3ugXWryhj2f2wM5fYPccuHQWQnpC/ylyIdVE1pzBLwQigOVAjrnhCCHs7cCZi7y3eD8R0YkE+1dk2iOtuTO0etFK+l6KNxL6zl+MrhgnV2jYG1oMgUZ95UKqyaxJ8J5a61dMj0QIYVcJKRl8vOwQs7aewNvDlfF3h/Jwh7qFH9OelQ4H/4Sdv0LMcqOEb61WcNeH0OxBqOhnzgcQ/8OaBL9IKdVXa/2n6dEIIUpcelYO09cfZfKqw6Rn5TC8UxDP3d6Ayp6FKLerNZzcbJyp71kAGRfAuxZ0fhbCBkO1xuZ9AHFT1t7o9JpSKgPIAhSgtdbFuKNBCGFvWmv+2HWa95ccIO78Ze4Mrc6rdzWmXmHmRT13DHbOMhL7uaPg6glN7jUm2QjuBk5y07s9WXOjUzEGuQohSqOo4+d4d/E+tp84T2jNSnw4MIxOIf7WvTn9AuxbaHTBHF8PKAjuCt1fNpK7ewlOnC0KdNMEr5RqrLU+oJRqld96rfU288ISQpjhZHIa7/91gEW7TlPN250PBoTxYKsA68ez75lvlBPIvGTMmtTzXxA2CCrXMTdwUSQFncG/iDEZ9n/zWaeBnqZEJISwudhzaUxZfZg5kbE4OcGztzdgTLd61k+bl5sDKybA+s+gTgfo/R7Ubg22mCxbmOam/7pa69GWn7eVXDhCCFs6npTK5FWHmbctFqVgYJs6PNOzPjV9Kli/k7Rk447TwyuN0r19/iPznZYRcierEA7ocMIlvlwVw8Idp3B2UjzcoS5jutcrXGIHOLsXfh0KF0/BvZOg1aPmBCxMIQleCAdy6GwKX6yM4Y9dp3B3ceKxTkGM7laPakUpLbBnPix8Gjx8YMSfUKet7QMWppIEL4QD2HvqAl+sjGHJnjNUdHNmTLcQRnUNxt/LvfA7y80xKjyu/xTqtIeHZko5gTLKmlo0CmM2p3pa67eVUoFADa31FtOjE0IUaFfseT5fEcPy/WfxdnfhmZ71ebxzML4Vi9hHnpYM80bB4RXQ+jG46wPpby/DrDmDnwzkYoyaeRtIAeYB8veaEHYSdfwck1ZGs/pgAj4VXHnxzoYM7xSETwXXou/0Sn/7hTi45zNoPcJm8Qr7sCbBt9dat1JKbQfQWp9TSsl/6ULYweYjSXy+Mpr1MUlUqejGy30a8UiHunh7FCOxA+z9DX57Cty94bE/oU472wQs7MqaBJ+llHLGGPt+pXxwrqlRCSGucy41k2d/3U5EdCL+Xu683rcJwzoE4ulWzMtouTmw8l1Y9zEEtDP62yvVtE3Qwu6s+XZ8DiwAqiml3gMGAG+YGpUQ4qpT5y/z6PQtnEhO4193hzKsfSAerjao8XL5nNHfHrMcWg2Hvh+CSxEuyopSy5paND8ppaKA2zEKjfXXWu83PTIhBDHxKTzy7RYupWcz8/F2dKhno1K7Z/dZ+ttj4e5PoI3M3+OIrP377izGpB8uQAWlVCupRSOEubafOMdj32/FxcmJX8d0oGmtYsymlNe+hbBgrFEUbMQiCOxgm/2KUseaYZLvACOAw1j64ZFaNEKYas2hBJ78IYqq3u78MLIddf0qFn4nOdmQlgSpCZZHIsRugS3ToHYbGPSj9Lc7OGvO4B8CQrTWmWYHI8SNtNZFmyquDFu4I45/ztlJ/WrezHi8LdW8LXehag0ZF41EfTVpWxL3pfhrz68sv5ycfwOtHoW+H0l/ezlgTYLfA1QG4k2ORYjrvLNoHxsPJ7Hg6U64u9hx4ojL58DZDdyKcBZdSN+vP8qERftoG1SFrx9tc21c++ldMGsYnD+R/xs9fKBiVahYDao2gqAultf+lp+Wh1dVqOBr+ucQpYM1Cf7fwHal1B4g48pCrfW9pkUlyr3UjGx+3XKC1Mwcpqw+zPN3NLRPINmZ8HVPyM6AwT9DrXBTmtFa88myQ3y+MoY7Q6szaUjLayNlopfBnBFGEr/zHfCqdn3i9vSXu01FvqxJ8DOA94HdyPh3UUL+3H2a1MwcQmtWYvKqw9zTohYhhZlKzla2zYDkI1ChCkzvA/0nQ7MHbNpETq7mXwv38PPmEzzUJoCJ9zfHxdky0XXkd7D4H1A9FIbOkT5zUSjWTJeeprX+XGu9Smu95srD9MhEuTYnKpZg/4p8/3hbPFydeH3BbrTWt36jLWWmwpoPoG5neHoz1AyDuY/Byvcg1zbnOhnZOfzfz9v4efMJxvYI4f0Hw4zknpsLy9+CRc9DSE94bIkkd1Fo1iT4CKXUv5VSHZVSra48TI9MlFvHElPZcjSZAa0DqObtwat9m7DpSDJzo2JLNpDNX0FqPNw+3ugWGf4HhD8Maz+A2Y9AxqVi7T4lPYvHvtvKkj1neKNfE17p09i4oJydAfNHwbpPjIJfQ341SggIUUjWdNG0tPzMO1hWhkkK08yNisVJwYOtAgAY1KYO86Jiee/P/fRsXA2/opTALazL54xyuQ16Xxsn7uIO931hdJcsfQOm94Yhv0DlwELvPvFSBiO+28L+0yl8/FALHrB8VtKS4ddhcGID3PEWdH5epsUTRXbLM3it9W35PCS5C1Pk5GrmRsXSrWFVavgYwwOdnBT/fqA5qRnZvPdnCd1EvWESpF+A2/91/XKloOPTMGwOnD8J026D4xsLteuTyWkMmLKBmPhLfP1o62vJPfkofHsnxEXCg99ClxckuYtiuWmCV0o9bPn5Yn6PkgtRlCfrYhI5czGdga3rXLe8QXVvxnQLYf62ONbHJJobRMpZ2DQFmj0INZrnv039O+CJFcbIlhn3wLaZVu36wJmLPDhlA8mpmfw0qj09G1c3VsRGwjd3GDcmPboQmg+w0YcR5VlBZ/BXBv165/Oww3AGUR7MjjxJZU9X7git9j/r/q9nfYL8PHl9wW7Ss3LMCyLiI6Mf/LbXC97Ov4GR5IO6wO/PwJJxxt2jNxF5LJmHpm5EKZjzZCda161irNj/B3x/t1E6YOQyqNvJhh9GlGc3TfBa668sT5drrSfkfQArrG1AKeWslNqulFpU3GCFYzuflsmyvWfpH1473xubPFydee/+5hxLSmPyqhhzgjh33Bia2OoR8Au59fYVfGHYXOjwFGyeAj8PNPrv88jOyeX3nacY9s1m/L3cmTe2E41qWC6abpwMsx6B6k1h5HLjPw0hbMSai6yTgBtHzeS37GaeA/YDlQoRlyiHFu44RWZOLgPbBNx0m871/XmgZW2mrDHGxjeobuPRJav/A8oJur1s/XucXaDPv6FaKCx6Ab65g8yHfmb9OV+W7DnNsn1nOZeWRViAD9+NaGtcJM7Ngb9fg81TofHd8MDX4OZp288iyr2bJnilVEegE1D1hj73SoBV940rpQKAfsB7gPTbiwLNiTpJ01qVblk18fV+TVh5MJ7XFuxm1uiOODnZ6EJk/AHY9atxNu5Tu9BvT28+lJ0pvoSufRo9uQffZT3DNtfW9Gxcjbua1eC2xtWMu1Mz04w67AcXQ4enodc74GTHUgzCYRV0Bu+G0dfugtHvfsVFjEk/rPEp8PIN77+OUmo0MBogMLDww82EY9h36iJ74i7y1j2ht9zWz8ud1/o24eW5u5gdeZLB7Wz0vVn1LrhWhC7Wn4tcyshm1YF4/tpzhlUH40nLVDT2mMi3FT5mhtOH5NzxDi6del0bDXMpHn4eBKe2GxNatx9jm9iFyMdNE7zlbtU1SqnvtdbHC7tjpdTdQLzWOkop1aOAdqYB0wDatGlTwrcqitJiTtRJ3JyduC/cujPnga0DmBcVy8Q/99tG+k4AABwBSURBVHN7k+pU9S7m2Pi4KONiZ49XoWLBk2pcSMti+f6zLNlzhrXRCWRm5+Lv5Ub/lrW5q1kNOtTzwzX7PvjtSVyWvQ6J+6Hfx0b//k8DjCQ/+Cdo3K94MQtxC9bM6FTo5G7RGbhXKdUX8AAqKaV+1Fo/XMT9CQeVkZ3Db9vjuDO0Or4VrSuapZTivfub0/ezCN5dvI/PBre89ZsKsuId8PQzxrjnI+lSBkv3GUl9Q0wi2bmamj4eDG0XyF3NatAmqArOebuKnL1g4ExY8x9Y874xg1LyEXB2hccWQ+3WxYtXCCsUc8bem9Navwq8CmA5g/+nJHeRnxX74zmXllXgxdX81K/mxdgeIXy2IpoHWwXQrWHVogVwdC0cWQW93vufkgDxKemM/20vS/edIVdDYBVPRnYJpk+zGrQIqFxw/7+TE9z2GlRrYsygVLmOcYOUb1DR4hSikKyZ0amz1nr9rZYJUVRzIk9So5IHXRsUPkE/dVsIf+w8xRu/7eHv57tRwa2QFyu1hhVvQ6Xa0HbUdav+3nuGV+fvJjUjmzHdQ7g7rCahNSsVfgKSpvdDYEdwryQjZUSJsqbY2CQrl92U1nq11vruwrxHlA9nLqSz5lACD7aufX0Xh5XcXYyx8SeS05i0MrrwARxcArFbofvL4GqURriUkc1Lc3Yy5ocoavp4sOiZLrzSpzFNa/kUfXYp7xqS3EWJM3WYpBC3Mn97LLkaBtxQmqAwOob4MaB1ANPWHuG+8NrXbiK6ldxcWPkOVAkxqkQCW48l8+LsHcSdu8zTt4Xw3O0NcXOx5jxIiNKnoG/ujcMkrzwKM0xSiJvSWjMnMpZ2QVUI9i/edHiv921CpQquvLZgN7m5Vg7G2jMX4vdBz9fJ1E588NcBBn21EYVi9piOvNS7sSR3UaYVapikUsoJ8NJaXyypAIXjijp+jqOJqTzVw4qSALfgW9GN1/s24R9zdvLL1hMMa1+34DdkZ8Kq96BGc6L97+D5yevZe+oig9rU4V/3hOLlbtr4AyFKjDWnJ/9WSlVSSlXEmIB7n1LqJZPjEuXA7MiTeLo507e5bWYqeqBVbTqF+PGfJQeIv5he8Mbbf4Bzx1haYzT9vtjA6QvpfPVIa94fECbJXTgMaxJ8qOWMvT+wBAgGHjE1KuHwUjOyWbzrNHeH1aSijRLqlbHxGdm5vL1o3803zEwjZ/X7HHRryuhNVeha35+/n+9G76Y1bBKHEKWFNQneVSnlipHgf9daZ2HM6CREkV2ZVHtgm6JfXM1PsH9FnrmtPot2nWbVwfh8t9m38L84p57lncsDmXh/GN8Mb1P8O2GFKIWsSfBfAccw6sOvVUrVxbjQKkSRXZlUu01dX5vve0z3EOpX8+KNBXtIy7xWn/3C5Sxe+SmCmnumEuXWhnefG83Q9oFFH/ooRClnzZR9n2uta2ut+2rDceC2EohNOKi8k2qbkVzdXJyYeH9z4s5f5rPlxtj4DTGJ9Pl0LXUOfIuvukSLR/9LUDFH7ghR2llzJ2t1YCJQS2t9l1IqFOgIfGt2cMIx3TipthnaBVdhcNs6fLPuKEmpmcyNiqWVXxZj3f+GRvfjEhBuWttClBbWdNF8D/wN1LK8PgQ8b1ZAwrHlN6m2Wcbd1RhfT1fmRsXyaMe6zA7dgHOOFVPxCeEgrBm+4K+1nq2UehVAa52tlDJxQkzhyCKiEzhzMZ3xVtR9L67Knm78MLI9qRnZtKmcCpO+g/ChMi2eKDesSfCpSik/LCNnlFIdgAumRiUc1pyoWCp7unJ7k/+dVNsMTWpaZopc+C/jZ49xJdKuEKWBNQn+ReB3IEQptR6oipQqEEVwZVLtoe0D851U2zSJ0bDjZ2j/JPiY1+8vRGljzYQf25RS3YFGgAIOWsbCC1EoVybVfsjGY99vaeW74OoJXf9Rsu0KYWfWjKLxAJ4CumB000QopaZqrW9xL7gQ15sdaUyqHVqrUsk1emoH7PsNur0MFf1Lrl0hSgFrRtHMBJpi1ID/wvL8BzODEo5n76kL7D11seTO3jNSYONk+HUoVPCFTv9XMu0KUYpY0wffTGudd8jDKqVUAYU+hPhfcyJjLZNq17r1xsVxIRY2T4WoGZBxEQI7we3jwcPH3HaFKIWsSfDblFIdtNabAJRS7YFIc8MSjiQjO4eFO+K4s2l1KntaN6l2ocVtg41fwt4FxuvQ+6Dj/0GATG4tyq+CZnTajdHn7gpsUEqdsLyuCxwomfCEI7g6qXZrG49gyc2FQ0uMxH58Pbh5Q4ex0H4MVA60bVtClEEFncHLHKrCJoozqXa+MtNgx0+waQokHwafOtDrPWj1KHiU4AVcIUq5gmZ0Ol6SgQjHdGVS7bE9Qoo0qfZ1Us7Alq8h8lu4fA5qtYIB06HJfeAsk3QIcSP5rRCmmrfNmFR7YDEm1ebMHtg0GXbPgZwsaNzP6F8P7ABS6leIm5IE72A2HUliwh/76Ne8BoPbBeLvZb+JLLQ2Cou1C6pStNK8RyMg4r9wZJVxo1Kr4UYfu1/x53AVojyQBO9AsnNy+ddve4g7f5mPlh7i8xUx3B1Wk0c7BRFep3KJxxNZ1Em1z+6F5W9B9FLwqmEMc2z9GHhWMSVOIRyVJHgHMivyJNHxl5j6cCvqV/Pmh43HmBsVy/ztcbSoU5nhHevSL6xmidWBmRN5koqFmVT7QhysmmhcQHWvBHdMMEbEuFYwN1AhHJQkeAeRkp7FJ8sO0S6oCr2b1kApxYT7mvHP3o2Yvy2OGRuP8eLsnUz8cz9D2gUytH0gNX3MS5ypGdkssnZS7fQLsO5To59d50LHp426MXLGLkSxSIJ3EFPXHCbxUibfDm9y3TR43h6uDO8UxKMd67IuJpEZG47zxaoYJq8+TJ+mNXi0Y13aBVexydR56Vk5xMRf4sCZFNYeSiAtM6fg0gTZGRA5HdZ8AJeToflD0PMN8K1b7FiEEJLgHcKp85f5JuIo94XXosVN+tqVUnRtUJWuDapyMjmNHzcd59etJ1m8+zSNa3gzvFMQ/cNrU8Ht1t032Tm5HEtK49DZFA6cSeHQmRQOnk3heFIqudrYxs3FibvDatI6v0m1c3Nh73xY8TacPw7B3eHOt6GWTKMnhC0prbW9Y7iqTZs2OjJSqiAU1guzdrB492lW/qM7Ab6eVr/vcqZRQuD7Dcc4cCYFnwquDGpbh4fb1yXQzxOtNacupHPojCWRn03h4JkUYhIukZmdC4CTgiC/ijSq4U3D6t40ruFNwxre1K3iiYtzPrXsjq6FZePh1Hao3gzunAAht8twRyGKSCkVpbVuk986OYMv43bFnmfB9jjG9ggpVHIHqODmzOB2gQxqW4etx84xY+Mxvl13lK8jjtC4RiVik9NIyci+un1NHw8aVvemawN/Glb3plENb+pX88LD1YqLtnlHxlQKgP5TIewhcCrBiT+EKGckwZdhWmveXbwfv4puhR+KmIdSinbBVWgXXIUzF9L5afNxtp84T5u6vjSq4X317Nyngmvhd37jyJg734Z2o2VkjBAlQBJ8GbZ031m2HE3mnf7N8PYoQvLNRw0fD/7Rq1Hxd5SWDBsmycgYIexIEnwZlZmdy3+WHKB+NS+GtC3hKfAKcmo7bP0Gds+F7HQZGSOEHUmCL6N+2nyco4mpTB/RJv+LmSUpK92ow771a4iLAteK0GIItHsCqje1b2xClGOS4MugC2lZfLYims71/bitUTX7BZJ81BjHvv1HYxy7f0O46wNoMVhmUBKiFJAEXwZ9sSqaC5ezeL1vqE1uUCqU3ByIWW6U7Y1ZDsrJqO7YdhQEd5PhjkKUIpLgy5gTSWnM2HCcAa0CCK1VgpNbpCbB9pnGGfv5E0YRsO6vQOvhUMnkeVaFEEUiCb6Mef/vAzg7Kf7Z2wYjXW5Fa4iNNC6a7l0AORkQ1NUY6tj4bnC2zcgdIYQ5JMGXIVHHz7F412meu70B1St5mNNIbo5xhn50rZHYz+wy5jpt9Si0HQnVmpjTrhDC5kxL8EqpOsBMoDrGZN3TtNafmdWeozNuatpHNW93xnSvV9ydQcppSIqBpMPGz+Qjxs9zxyAn09iuWij0+9i449Tdu9ifQQhRssw8g88G/qG13qaU8gailFLLtNb7TGzTYS3efZrtJ87z/oPN8XSz4p9Na0hLypPALT+TjhjPs9KubevsDlXqGaNgGt0FfvWN4Y21WslFUyHKMNMSvNb6NHDa8jxFKbUfqA1Igi+kjOwc3v/rAI1reDPgVnObxiyH1f+BxENGnfUrnFygcl1jurvgrkZC96tvvK4UAE52HksvhLC5EumDV0oFAS2BzfmsGw2MBggMDCyJcMqcGRuOcTL5Mj+MbIez003OqLWGdR/DineMpN18IFQJuZbEKwfKRVEhyhnTE7xSyguYBzyvtb5443qt9TRgGhjlgs2Op6xJTs1k0soYejQyarnnK+MSLHwK9i2EZgPg3kngVrjKkkIIx2NqgldKuWIk95+01vPNbMtRfb4imtSMbF7re5PRK0mHYdbDkHAAer0LHf9P+s2FEIC5o2gU8C2wX2v9sVntOLIjCZf4cdNxBrcLpGH1fEaxRC+HeY8bd5M+PB9Cbiv5IIUQpZaZV9Y6A48APZVSOyyPvia253D+veQA7i5OvHBHw+tXaA0R/4WfBoBPIIxeLcldCPE/zBxFsw6QvoIi2nQkiWX7zvJS70ZU9Xa/tkL624UQVpI7WUuh3FzjpqZaPh6M7BJ8bYX0twshCkESfCn024449sRd5JNBLa7Ndxq9DOaNlP52IYTVJMGXMpczc/jw74OEBfhwX4va1/rbV74L1ZvB4B/BN8jeYQohygBJ8KXMt+uOcPpCOp8OCscpKxV+Gwv7f5f+diFEoUmCL0Wijp9jyurD9AqtTnuf8/DNMEg8CL3eMyatlv52IUQhSIIvBbYcTWbSymgiohPx93Ljnaan4esHQDnDIwugXg97hyiEKIMkwduJ1pqNR5L4fEU0m44k4+/lxmt3NWRE7gLc/pgINZrBoJ/At669QxVClFGS4EuY1pqI6EQmrYxm67FzVPN2Z/zdoQyrEYf7ilFweof0twshbEISfAnRWrP6YAKfrYhmx8nz1PTx4O37mjIoJAf3VeNh+e9QqTbcP82YYEP624UQxSQJ3mRaa5btO8uklTHsjrtA7coVmHh/cx5s6o37ho/hq6lGrfbbXjduXJKzdiGEjUiCN0luruavvWeYtDKG/acvUtfPkw8GhHF/i+q47vgBJk80ZlwKHwo9/wWVato7ZCGEg5EEb2M5uZrFu0/zxcpoDp29RL2qFfn4oRbc26IWLkdXwrSBkLAf6naG3hOhVri9QxZCOChJ8DaSlZPLHztP8cWqGI4kpNKgmhefD2lJv+Y1cU46BL88BDHLjLtQH/oBmtwj/exCCFNJgi+mi+lZ/LrlBN+vP8apC+k0ruHN5GGt6NO0Bk6Xk2HJSxA5Hdwqwp3vQPsx4OJ+6x0LIUQxSYIvothzaXy3/hiztp7kUkY2HepV4Z3+zbitUTWccrNg05ew5gPITIHWj8Ftr0FFf3uHLYQoRyTBF9Ku2PN8HXGUP3efBuDusJo80bUezWr7GIXBDiyCZeMh+QjUv8Mo61vtJtPtCSGEiSTBWyE3V7PiQDxfRxxhy9FkvN1dGNklmBGdgqhVuYKx0YnNsPIdOBYBVRvDsHnQ4A77Bi6EKNckwRcgPSuHedti+TbiKEcSU6lduQJv9GvCoLZ18PZwNTY6uQVW/xsOrwRPf+j7kdEl4yyHVghhX5KF8pF4KYOZG4/z46bjJKdmEhbgw+dDWtK3WQ1cnC3T2MZGwqqJcHgFePrBnW9D21HGxVQhhCgFJMHnEROfwjcRR5m/PY6snFxub1ydJ7oG0y64CurKkMbYKOOMPWaZkdjvmGAkdncv+wYvhBA3kASPMSLmrd/3snx/PO4uTgxsHcDILsHUq5onacdFwer/QPRSqFAF7ngL2j4hiV0IUWqV+wS/cEccbyzYgwZeuKMhD3cIxM8rzzj1U9uNxH7oL6jgC7ePh3ajwd3bbjELIYQ1ym2Cv5iexb9+28PCHadoXdeXTweFU6dKnkJfp3ZYEvsS8Khs1ItpP0YSuxCizCiXCX7L0WRemLWDMxfTefHOhjzVI+TaxdPTO2H1+3BwsSWxvwHtxoBHJfsGLYQQhVSuEnxWTi6fLY9m8uoY6lTxZM6THWkV6GusPLPbOGM/sAg8fIzyve3HGM+FEKIMKjcJ/mhiKs//up2dsRcY2DqAN+9tipe7C5w/adygtGsWuPtAj9egw5OS2IUQZZ7DJ3itNbO2nuTtRftwdXZiyrBW3NW8JqRfgGUfw6YpRlXHLi9A5+ehQmV7hyyEEDbh0An+XGom4+bv4u+9Z+kU4sd/H2pBTS8X2DwN1vwH0pKhxWCjn90nwN7hCiGETTlsgo+ITuAfs3dyLi2T1/s2YWTnIJwOLYZlb0LyYQjuZpTvlQk3hBAOyuESfHpWDh/+fZBv1x2lfjUvvnusLU1zo2HGU3Bio1EIbOgcaHCnTLghhHBoDpXgD51N4dlftnPgTAqPdqzLax098VjzPOydDxWrwd2fQstHpBCYEKJccIhMp7VmxoZjTFxygEoeLswc2oBup2fAV9NAOUP3V6DTM3KTkhCiXCnzCf5iehbP/LydNYcS6NWoMh8HR+L15yhjlEzLYcZ49kq17B2mEEKUuDKf4Cu6uZCbm8uMDqfodvw11OpjEHK7Ub63RjN7hyeEEHZT5hO8c8YFZvIGasdWqNYUHp5nTJUnhBDlXJlP8Hj4oHyDoNVwCB8KTs72jkgIIUqFsp/glYIHv7F3FEIIUeo42TsAIYQQ5jA1wSul+iilDiqlYpRS48xsSwghxPVMS/BKKWfgS+AuIBQYopQKNas9IYQQ1zPzDL4dEKO1PqK1zgR+Be4zsT0hhBB5mJngawMn87yOtSwTQghRAux+kVUpNVopFamUikxISLB3OEII4TDMTPBxQJ08rwMsy66jtZ6mtW6jtW5TtWpVE8MRQojyxcwEvxVooJQKVkq5AYOB301sTwghRB5Ka23ezpXqC3wKOAPTtdbv3WL7BOB4EZvzBxKL+F5HI8fienI8rifH4xpHOBZ1tdb5dn+YmuBLklIqUmvdxt5xlAZyLK4nx+N6cjyucfRjYfeLrEIIIcwhCV4IIRyUIyX4afYOoBSRY3E9OR7Xk+NxjUMfC4fpgxdCCHE9RzqDF0IIkYckeCGEcFBlPsGXl5LESqk6SqlVSql9Sqm9SqnnLMurKKWWKaWiLT99LcuVUupzy3HZpZRqlWdfwy3bRyulhtvrMxWXUspZKbVdKbXI8jpYKbXZ8plnWW6wQynlbnkdY1kflGcfr1qWH1RK9bbPJyk+pVRlpdRcpdQBpdR+pVTH8vrdUEq9YPkd2aOU+kUp5VFuvxta6zL7wLiB6jBQD3ADdgKh9o7LpM9aE2hlee4NHMIow/wBMM6yfBzwvuV5X2AJoIAOwGbL8irAEctPX8tzX3t/viIekxeBn4FFltezgcGW51OBsZbnTwFTLc8HA7Msz0Mt3xl3INjyXXK29+cq4rGYAYyyPHcDKpfH7wZGQcOjQIU834kR5fW7UdbP4MtNSWKt9Wmt9TbL8xRgP8aX+T6MX24sP/tbnt8HzNSGTUBlpVRNoDewTGudrLU+BywD+pTgR7EJpVQA0A/4xvJaAT2BuZZNbjwWV47RXOB2y/b3Ab9qrTO01keBGIzvVJmilPIBugHfAmitM7XW5ymn3w2MqUgrKKVcAE/gNOX0u1HWE3y5LEls+TOyJbAZqK61Pm1ZdQaobnl+s2PjKMfsU+BlINfy2g84r7XOtrzO+7mufmbL+guW7R3lWAQDCcB3li6rb5RSFSmH3w2tdRzwEXACI7FfAKIop9+Nsp7gyx2llBcwD3hea30x7zpt/G3p8ONelVJ3A/Fa6yh7x1JKuACtgCla65ZAKkaXzFXl6Lvhi3H2HQzUAipSNv8KsYmynuCtKknsKJRSrhjJ/Set9XzL4rOWP6+x/Iy3LL/ZsXGEY9YZuFcpdQyjW64n8BlGV4OLZZu8n+vqZ7as9wGScIxjAcbZZazWerPl9VyMhF8evxt3AEe11gla6yxgPsb3pVx+N8p6gi83JYkt/YLfAvu11h/nWfU7cGW0w3BgYZ7lj1pGTHQALlj+XP8b6KWU8rWc7fSyLCsztNavaq0DtNZBGP/mK7XWw4BVwADLZjceiyvHaIBle21ZPtgykiIYaABsKaGPYTNa6zPASaVUI8ui24F9lMPvBkbXTAellKfld+bKsSiX3w27X+Ut7gNjRMAhjKvcr9s7HhM/ZxeMP7F3ATssj74Y/YUrgGhgOVDFsr3CmPT8MLAbaJNnX49jXDSKAR6z92cr5nHpwbVRNPUwfgljgDmAu2W5h+V1jGV9vTzvf91yjA4Cd9n78xTjOIQDkZbvx28Yo2DK5XcDmAAcAPYAP2CMhCmX3w0pVSCEEA6qrHfRCCGEuAlJ8EII4aAkwQshhIOSBC+EEA5KErwQQjgoSfCiTFJK/amUqlyI7YOUUntsHMMlW+7Pss9wpVTfPK/fUkr909btiPJBErwok7TWfbVRUMvRhGPc3yBEsUmCF6WOUuolpdSzluefKKVWWp73VEr9ZHl+TCnlbzkz36+U+tpSA3ypUqqCZZvWSqmdSqmdwNN59u+hlPpOKbXbUpzrNsvyxUqpMMvz7Uqp8ZbnbyulnrAi5q2W+uoTLMsKiq2tZdsdSqkPLbXL3YC3gUGW5YMsuw9VSq1WSh25clyEsIYkeFEaRQBdLc/bAF6WOjxdgbX5bN8A+FJr3RQ4DzxoWf4d8IzWusUN2z+NUX+rOTAEmKGU8rjSrqX8bjZGDRMKaBcApVQvSwztMM7AWyululkR2xitdTiQgxFQJjAeoyZ5uNZ6lmXbxhilfNsBb1qOhRC3JAlelEZRGEmyEpABbMRI9F0xkvCNjmqtd+R5b5Clf76y1vpKYv4hz/ZdgB8BtNYHgONAQ8u+u2Ek9sUY/7F4AsFa64MFxNvL8tgObMNIyA1uEZu31nqjZfnPBR0MYLE26pInYhQMq36L7YUAjDKjQpQqWusspdRRjJl4NmDUV7kNqI8x0cmNMvI8zwEqFLHprRj/kRzBmOzCH3gCIzEXRAH/1lp/dd1Co26/LWK7cR/yeyusImfworSKAP6J0TUSATwJbNdWFk+yXIA9r5TqYlk07IZ9DwNQSjUEAoGDli6Sk8BAjL8a8sZQkL+Bxy21+lFK1VZKVbtFbClKqfaWRYPzrE7BmJJRiGKTBC9KqwiMeWg3aq3PAunk3z1TkMeAL5VSOzDOsq+YDDgppXYDs4ARWusrZ8kRGJOJXLY8D7hVu1rrpRjdLBst+5zLrZP0SOBrS2wVMWYSAqOsbegNF1mFKBKpJimEHSilvLTWlyzPxwE1tdbP2Tks4WCkL08I++inlHoV43fwOMb1BiFsSs7ghRDCQUkfvBBCOChJ8EII4aAkwQshhIOSBC+EEA5KErwQQjio/wfXCs/fXS07pwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/ssm_jax/hmm/inference.py
+++ b/ssm_jax/hmm/inference.py
@@ -9,7 +9,7 @@ import chex
 class HMMPosterior:
     """Simple wrapper for properties of an HMM posterior distribution.
 
-    marginal_loglik: log sum_{hidden(1:t)} prob(hidden(1:t), obs(1:t) | params)
+    marginal_loglik: log sum_{hidden(1:t)} p(hidden(1:t), obs(1:t) | params)
     filtered_probs(t,k) = p(hidden(t)=k | obs(1:t))
     predicted_probs(t,k) = p(hidden(t+1)=k | obs(1:t)) // one-step-ahead
     smoothed_probs(t,k) = p(hidden(t)=k | obs(1:T))
@@ -54,8 +54,8 @@ def hmm_filter(initial_distribution,
     """Forwards filtering.  
 
     Args:
-        initial_distribution(k): prob(hid(1)=k)
-        transition_matrix(j,k): prob(hid(t)=k | hid(t-1)=j)
+        initial_distribution(k): p(hid(1)=k)
+        transition_matrix(j,k): p(hid(t)=k | hid(t-1)=j)
         log_likelihoods(t,k): p(obs(t) | hid(t)=k)
 
     Returns: HMMPosterior object (smoothed_probs=None)
@@ -94,8 +94,8 @@ def hmm_posterior_sample(rng,
     """Sample a latent sequence from the posterior.  
 
     Args:
-        initial_distribution(k): prob(hid(1)=k)
-        transition_matrix(j,k): prob(hid(t)=k | hid(t-1)=j)
+        initial_distribution(k): p(hid(1)=k)
+        transition_matrix(j,k): p(hid(t)=k | hid(t-1)=j)
         log_likelihoods(t,k): p(obs(t) | hid(t)=k)
 
     Returns:
@@ -146,8 +146,8 @@ def hmm_backward_filter(transition_matrix,
     """_summary_
 
     Args:
-        hmm_params (_type_): _description_
-        log_likelihoods (_type_): _description_
+        transition_matrix(j,k): p(hid(t)=k | hid(t-1)=j)
+        log_likelihoods(t,k): p(obs(t) | hid(t)=k)
 
     Returns:
         log_marginal_lik
@@ -278,7 +278,7 @@ def hmm_fixed_lag_smoother(initial_distribution,
         initial_distribution(k): prob(hid(1)=k)
         transition_matrix(j,k): prob(hid(t)=k | hid(t-1)=j)
         log_likelihoods(t,k): p(obs(t) | hid(t)=k)
-        window_size (int): size of smoothed window
+        window_size(int): size of smoothed window
 
     Returns:
         HMMPosterior object

--- a/ssm_jax/hmm/inference_test.py
+++ b/ssm_jax/hmm/inference_test.py
@@ -149,6 +149,26 @@ def test_hmm_smoother(key=0, num_timesteps=5, num_states=2):
         assert jnp.allclose(posterior.smoothed_probs[t], smoothed_probs_t)
 
 
+def test_hmm_fixed_lag_smoother(key=0, num_timesteps=5, num_states=2):
+    if isinstance(key, int):
+        key = jr.PRNGKey(key)
+    
+    args = random_hmm_args(key, num_timesteps, num_states)
+
+    # Run the HMM smoother
+    posterior = core.hmm_smoother(*args)
+
+    # Run the HMM fixed-lag smoother with full window size
+    posterior_fl = core.hmm_fixed_lag_smoother(*args, window_size=num_timesteps)
+
+    # Compare posterior values of fixed-lag smoother to those of smoother
+    assert jnp.allclose(posterior.marginal_loglik, posterior_fl.marginal_loglik[-1])
+    assert jnp.allclose(posterior.filtered_probs, posterior_fl.filtered_probs[-1])
+    assert jnp.allclose(posterior.predicted_probs, posterior_fl.predicted_probs[-1])
+    assert jnp.allclose(posterior.smoothed_probs, posterior_fl.smoothed_probs[-1])
+
+
+
 def test_compute_transition_probs(key=0, num_timesteps=5, num_states=2):
     if isinstance(key, int):
         key = jr.PRNGKey(key)
@@ -220,3 +240,4 @@ def test_hmm_smoother_stability(key=0, num_timesteps=10000, num_states=100, scal
 
     assert jnp.all(jnp.isfinite(posterior.smoothed_probs))
     assert jnp.allclose(posterior.smoothed_probs.sum(1), 1.0)
+    


### PR DESCRIPTION
## Description

- Reimplement [`fixed_lag_smoother`](https://github.com/probml/JSL/blob/main/jsl/hmm/hmm_lib.py#L378) as `hmm_fixed_lag_smoother` in [inference.py](https://github.com/probml/ssm-jax/blob/main/ssm_jax/hmm/inference.py).
- Add unit test as `test_hmm_fixed_lag_smoother` in [inference_test](https://github.com/probml/ssm-jax/blob/main/ssm_jax/hmm/inference_test.py)
- Add Jupyter demo that compares performance of iterative vs vectorized versions as `fixed_lag_smoother.ipynb` and add to [smm_jax/hmm/demos](https://github.com/probml/ssm-jax/blob/main/ssm_jax/hmm/demos)

## Detail

- For consistency with the rest of the API, `hmm_fixed_lag_smoother` naively assumes that we have the complete observations for all timesteps in the form of `log_likelihoods` available (i.e., off-line, rather than on-line smoother), although a modification to allow on-line smoothing would be easily achieved.
- `hmm_fixed_lag_smoother` outputs an `HMMPosterior` object, with its parameters filled with the corresponding posterior distributions at each timestep. For example, `post.smoothed_probs[t]` gives a (`window_size`, `num_states`) matrix of window of smoothed probabilities at timestep `t`.
- The unit test, `test_hmm_fixed_lag_smoother`, compares the `marginal_loglik`, `filtered_probs`, `predicted_probs`, and `smoothed_probs` of the full-lag (i.e., `window_size == num_timesteps`) `hmm_fixed_lag_smoother` to those of the naive smoother `core.hmm_smoother`.
- To create a Jupyter notebook that compares the performances of iterative vs. vectorized versions (iterative: smooths backwards iteratively within the window at each time step, vs. vectorized: carries `bmatrix` that allows a vectorized computation (row-sum) of smoothed probabilities in the window at once), I implemented the iterative version `hmm_fixed_lag_smoother_iterative`, which, instead of carrying the intermediate `bmatrices`, uses the `core.backward_filter` to perform backward filtering at each timestep. However, as can be seen below, the `lax.scan` in both `core.hmm_backward_filter` and `hmm_fixed_lag_smoother_iterative` seems to optimize the iterations such that the performance approximates that of the vectorized version, so the comparison seems almost irrelevant. I can try a more explicit iterative version of backwards filtering instead of using the optimized `core.hmm_backward_filter`, but open to other suggestions!

![perf_comp_iter_vs_vec_fls](https://raw.githubusercontent.com/petergchang/hmm-jax/main/fixed_lag_performance_comparison.png)

## Issue 
#9
