### PR TITLE
Add information form filtering.

### DIFF
--- a/ssm_jax/lgssm/info_inference.py
+++ b/ssm_jax/lgssm/info_inference.py
@@ -42,7 +42,35 @@ _get_params = lambda x, dim, t: x[t] if x.ndim == dim+1 else x
 def _info_predict(eta, Lambda, F, Q_prec, B, u, b):
     """Predict next mean and precision under a linear Gaussian model
 
-        p(z_{t+1}) = \int N(z_t | mu_t, Sigma_t) N(z_{t+1} | F z_t, Q)
+    Marginalising over the uncertainty in z_t the predicted latent state at
+    the next time step is given by:
+        p(z_{t+1}| z_t, u_t) 
+            = \int p(z_{t+1}, z_t | u_t) dz_t
+            = \int N(z_t | mu_t, Sigma_t) N(z_{t+1} | F z_t + B u_t + b, Q) dz_t
+            = N(z_t | m_{t+1|t}, Sigma_{t+1|t})
+    with
+        m_{t+1|t} = F m_t + B u_t + b
+        Sigma_{t+1|t} = F Sigma_t F^T + Q
+
+    The corresponding information form parameters are:
+        eta_{t+1|t} = K eta_t + Lambda_{t+1|t} (B u_t + b)
+        Lambda_{t+1|t} = L Q_prec L^T + K Lambda_t K^T
+    where
+        K = Q_prec F ( Lambda_t + F^T Q_prec F)^{-1}
+        L = I - K F^T
+
+    Args:
+        eta (D_hid,): prior precision weighted mean.
+        Lambda (D_hid,D_hid): prior precision matrix.
+        F (D_hid,D_hid): dynamics matrix.
+        Q_prec (D_hid,D_hid): dynamics precision matrix.
+        B (D_hid,D_in): dynamics input matrix.
+        u (D_in,): inputs.
+        b (D_hid,): dynamics bias.
+
+    Returns:
+        eta_pred (D_hid,): predicted precision weighted mean.
+        Lambda_pred (D_hid,D_hid): predicted precision.
     """
     K = jnp.linalg.solve(Lambda + F.T @ Q_prec @ F, F.T @ Q_prec).T
     I = jnp.eye(len(Lambda))
@@ -54,47 +82,56 @@ def _info_predict(eta, Lambda, F, Q_prec, B, u, b):
     return eta_pred, Lambda_pred
 
 
-def _info_condition_on(eta, P, H, R_prec, D, u, d, obs):
+def _info_condition_on(eta, Lambda, H, R_prec, D, u, d, obs):
     """Condition a Gaussian potential on a new linear Gaussian observation.
 
-        p(z_t|y_t) \prop  N(z_t | mu_{t|t-1}, Sigma_{t|t-1}) N(y_t | H z_t, R)
+        p(z_t|y_t, u_t) \prop  N(z_t | mu_{t|t-1}, Sigma_{t|t-1}) * 
+                          N(y_t | H z_t + D u_t + d, R)
 
-        The prior precision and precision-weighted mean are given by:
-            Lambda_{t|t-1} = Sigma_{t|t-1}^{-1}
-            eta_{t|t-1} = Lambda{t|t-1} mu_{t|t-1},
-        respectively. 
+    The prior precision and precision-weighted mean are given by:
+        Lambda_{t|t-1} = Sigma_{t|t-1}^{-1}
+        eta_{t|t-1} = Lambda{t|t-1} mu_{t|t-1},
+    respectively. 
 
-        The upated parameters are then:
-            Lambda_t = Lambda_{t|t-1} + H^T R_prec H
-            eta_t = eta_{t|t-1} + H^T R_prec y_t
+    The upated parameters are then:
+        Lambda_t = Lambda_{t|t-1} + H^T R_prec H
+        eta_t = eta_{t|t-1} + H^T R_prec (y_t - Du - d)
 
     Args:
-        eta: prior precision weighted mean.
-        P: prior precision matrix.
-        R_prec: precision matrix for observations.
-        obs: observation.
+        eta (D_hid,): prior precision weighted mean.
+        Lambda (D_hid,D_hid): prior precision matrix.
+        H (D_obs,D_hid): emission matrix.
+        R_prec (D_obs,D_obs): precision matrix for observations.
+        D (D_obs,D_in): emission input weights.
+        u (D_in,): inputs.
+        d (D_obs,): emission bias.
+        obs (D_obs,): observation.
+
+    Returns:
+        eta_cond (D_hid,): posterior precision weighted mean.
+        Lambda_cond (D_hid,D_hid): posterior precision.
     """
-    C = H.T @ R_prec
-    P_cond = P + C @ H
-    eta_cond = eta + C @ (obs - D @ u - d)
-    return eta_cond, P_cond
+    HR = H.T @ R_prec
+    Lambda_cond = Lambda + HR @ H
+    eta_cond = eta + HR @ (obs - D @ u - d)
+    return eta_cond, Lambda_cond
 
 
-def lgssm_info_filter(params, inputs, emissions, num_timesteps=None):
+def lgssm_info_filter(params, emissions, inputs):
     """Run a Kalman filter to produce the marginal likelihood and filtered state
     estimates.
 
     Args:
         params: an LGSSMParams instance (or object with the same fields)
-        inputs: array of length T containing inputs.
-        emissions: array (T,D) of data.
+        inputs (T,D_in): array of inputs.
+        emissions (T,D_obs): array of observations.
 
     Returns:
         filtered_posterior: LGSSMPosterior instance containing,
             filtered_etas
             filtered_precisions
     """
-    num_timesteps = len(emissions) if num_timesteps is None else num_timesteps
+    num_timesteps = len(emissions) 
 
     def _step(carry, t):
         pred_eta, pred_prec = carry

--- a/ssm_jax/lgssm/info_inference.py
+++ b/ssm_jax/lgssm/info_inference.py
@@ -118,16 +118,15 @@ def _info_condition_on(eta, Lambda, H, R_prec, D, u, d, obs):
 
 
 def lgssm_info_filter(params, emissions, inputs):
-    """Run a Kalman filter to produce the marginal likelihood and filtered state
-    estimates.
+    """Run a Kalman filter to produce the filtered state estimates.
 
     Args:
-        params: an LGSSMParams instance (or object with the same fields)
-        inputs (T,D_in): array of inputs.
+        params: an LGSSMInfoParams instance.
         emissions (T,D_obs): array of observations.
+        inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: LGSSMPosterior instance containing,
+        filtered_posterior: LGSSMInfoPosterior instance containing,
             filtered_etas
             filtered_precisions
     """

--- a/ssm_jax/lgssm/info_inference.py
+++ b/ssm_jax/lgssm/info_inference.py
@@ -1,0 +1,123 @@
+import jax.numpy as jnp
+import jax.random as jr
+from jax import lax
+from distrax import MultivariateNormalFullCovariance as MVN
+import chex
+
+@chex.dataclass
+class LGSSMInfoParams:
+    """Lightweight container for LGSSM parameters in information form.
+    """
+    initial_mean: chex.Array
+    initial_precision: chex.Array
+    dynamics_matrix: chex.Array
+    dynamics_precision: chex.Array
+    emission_matrix: chex.Array
+    emission_precision: chex.Array
+
+
+@chex.dataclass
+class LGSSMInfoPosterior:
+    """Simple wrapper for properties of an LGSSM posterior distribution in
+    information form.
+
+    Attributes:
+            filtered_means: (T,K) array,
+                E[x_t | y_{1:t}, u_{1:t}].
+            filtered_precisions: (T,K,K) array,
+                inv(Cov[x_t | y_{1:t}, u_{1:t}]).
+    """
+    filtered_etas: chex.Array = None
+    filtered_precisions: chex.Array = None
+
+
+# Helper functions
+_get_params = lambda x, dim, t: x[t] if x.ndim == dim+1 else x
+
+
+def _info_predict(eta, P, F_inv, Q_prec):
+    """Predict next mean and precision under a linear Gaussian model
+
+        p(z_{t+1}) = \int N(z_t | mu_t, Sigma_t) N(z_{t+1} | F z_t, Q)
+    """
+    I = jnp.eye(len(P))
+    Q = jnp.linalg.inv(Q_prec)
+    M = F_inv.T @ P @ F_inv
+    C = jnp.linalg.solve(I + M @ Q, F_inv.T)
+    P_pred = C @ P @ F_inv
+    eta_pred = C @ eta
+    return eta_pred, P_pred
+
+
+def _info_condition_on(eta, P, H, R_prec, obs):
+    """Condition a Gaussian potential on a new linear Gaussian observation.
+
+        p(z_t|y_t) \prop  N(z_t | mu_{t|t-1}, Sigma_{t|t-1}) N(y_t | H z_t, R)
+
+        The prior precision and precision-weighted mean are given by:
+            Lambda_{t|t-1} = Sigma_{t|t-1}^{-1}
+            eta_{t|t-1} = Lambda{t|t-1} mu_{t|t-1},
+        respectively. 
+
+        The upated parameters are then:
+            Lambda_t = Lambda_{t|t-1} + H^T R_prec H
+            eta_t = eta_{t|t-1} + H^T R_prec y_t
+
+    Args:
+        eta: prior precision weighted mean.
+        P: prior precision matrix.
+        R_prec: precision matrix for observations.
+        obs: observation.
+    """
+    C = H.T @ R_prec
+    P_cond = P + C @ H
+    eta_cond = eta + C @ obs
+    return eta_cond, P_cond
+
+
+def lgssm_info_filter(params, emissions, num_timesteps=None):
+    """Run a Kalman filter to produce the marginal likelihood and filtered state
+    estimates.
+
+    Args:
+        params: an LGSSMParams instance (or object with the same fields)
+        inputs: array of length T containing inputs.
+        emissions: array (T,D) of data.
+
+    Returns:
+        filtered_posterior: LGSSMPosterior instance containing,
+            filtered_etas
+            filtered_precisions
+    """
+    num_timesteps = len(emissions) if num_timesteps is None else num_timesteps
+
+    def _step(carry, t):
+        pred_eta, pred_prec = carry
+
+        # Shorthand: get parameters and inputs for time index t
+        F = _get_params(params.dynamics_matrix, 2, t)
+        Q_prec = _get_params(params.dynamics_precision, 2, t)
+        H = _get_params(params.emission_matrix, 2, t)
+        R_prec = _get_params(params.emission_precision, 2, t)
+        y = emissions[t]
+
+        # Condition on this emission
+        filtered_eta, filtered_prec = _info_condition_on(
+            pred_eta, pred_prec, H, R_prec, y)
+
+        # Predict the next state
+        F_inv = jnp.linalg.inv(F)
+        pred_mean, pred_cov = _info_predict(
+            filtered_eta, filtered_prec, F_inv, Q_prec)
+
+        return (pred_mean, pred_cov), (filtered_eta, filtered_prec)
+
+    # Run the Kalman filter
+    initial_eta = params.initial_precision @ params.initial_mean 
+    carry = (initial_eta, params.initial_precision)
+    _, (filtered_etas, filtered_precisions) = lax.scan(
+        _step, carry, jnp.arange(num_timesteps))
+    return LGSSMInfoPosterior(filtered_etas=filtered_etas,
+                              filtered_precisions=filtered_precisions)
+
+

--- a/ssm_jax/lgssm/info_inference_test.py
+++ b/ssm_jax/lgssm/info_inference_test.py
@@ -69,7 +69,7 @@ def test_info_kalman_filter():
 
     lgssm_posterior = lgssm.filter(y)
     inputs = jnp.zeros((num_timesteps,1))
-    lgssm_info_posterior = lgssm_info_filter(lgssm_info, inputs, y) 
+    lgssm_info_posterior = lgssm_info_filter(lgssm_info, y, inputs) 
     
     info_filtered_means = vmap(jnp.linalg.solve)(
             lgssm_info_posterior.filtered_precisions,
@@ -85,7 +85,7 @@ def test_info_kalman_filter():
                         rtol=1e-2)
 
 
-def test_info_linreg():
+def test_info_kf_linreg():
     """Test non-stationary emission matrix in information filter.
     
     Compare to moment form filter using the example in 
@@ -136,8 +136,8 @@ def test_info_linreg():
         emission_precision=R_prec
     )
 
-    lgssm_moment_posterior = lgssm_filter(lgssm_moment,inputs,y[:,None])
-    lgssm_info_posterior = lgssm_info_filter(lgssm_info,inputs,y[:,None])
+    lgssm_moment_posterior = lgssm_filter(lgssm_moment, y[:,None], inputs)
+    lgssm_info_posterior = lgssm_info_filter(lgssm_info, y[:,None], inputs)
 
     info_filtered_means = vmap(jnp.linalg.solve)(
             lgssm_info_posterior.filtered_precisions,

--- a/ssm_jax/lgssm/info_inference_test.py
+++ b/ssm_jax/lgssm/info_inference_test.py
@@ -1,0 +1,154 @@
+from jax import vmap
+from jax import numpy as jnp
+from jax import random as jr
+
+from ssm_jax.lgssm.models import LinearGaussianSSM
+from ssm_jax.lgssm.inference import LGSSMParams, lgssm_filter
+from ssm_jax.lgssm.info_inference import LGSSMInfoParams, lgssm_info_filter
+
+def test_info_kalman_filter():
+    """ Test information form kalman filter against the moment form version."""
+
+    delta = 1.0
+    F = jnp.array([
+        [1., 0, delta, 0],
+        [0, 1., 0, delta],
+        [0, 0, 1., 0],
+        [0, 0, 0, 1.]
+    ])
+
+    H = jnp.array([
+        [1., 0, 0, 0],
+        [0, 1., 0, 0]
+    ])
+
+    state_size, _ = F.shape
+    observation_size, _ = H.shape
+
+    Q = jnp.eye(state_size) * 0.001
+    Q_prec = jnp.linalg.inv(Q)
+    R = jnp.eye(observation_size) * 1.0
+    R_prec = jnp.linalg.inv(R)
+
+    # Prior parameter distribution
+    mu0 = jnp.array([8., 10., 1., 0.])
+    Sigma0 = jnp.eye(state_size) * 0.1
+    Lambda0 = jnp.linalg.inv(Sigma0)
+
+    # Construct LGSSM
+    lgssm = LinearGaussianSSM(
+        initial_mean=mu0,
+        initial_covariance=Sigma0,
+        dynamics_matrix=F,
+        dynamics_covariance=Q,
+        emission_matrix=H,
+        emission_covariance=R)
+
+    # Collect information form parameters
+    B = jnp.zeros((state_size,1))
+    b = jnp.zeros((state_size,1))
+    D = jnp.zeros((observation_size,1))
+    d = jnp.zeros((observation_size,1))
+
+    lgssm_info = LGSSMInfoParams(
+        initial_mean=mu0,
+        initial_precision=Lambda0,
+        dynamics_matrix=F,
+        dynamics_precision=Q_prec,
+        dynamics_input_weights=B,
+        dynamics_bias=b,
+        emission_matrix=H,
+        emission_precision=R_prec,
+        emission_input_weights=D,
+        emission_bias=d)
+
+    # Sample data from model.
+    key = jr.PRNGKey(111)
+    num_timesteps = 15
+    x, y = lgssm.sample(key,num_timesteps)
+
+    lgssm_posterior = lgssm.filter(y)
+    inputs = jnp.zeros((num_timesteps,1))
+    lgssm_info_posterior = lgssm_info_filter(lgssm_info, inputs, y) 
+    
+    info_filtered_means = vmap(jnp.linalg.solve)(
+            lgssm_info_posterior.filtered_precisions,
+            lgssm_info_posterior.filtered_etas
+            )
+    info_filtered_covs = jnp.linalg.inv(lgssm_info_posterior.filtered_precisions)
+
+    assert jnp.allclose(info_filtered_means,
+                        lgssm_posterior.filtered_means,
+                        rtol=1e-2)
+    assert jnp.allclose(info_filtered_covs,
+                        lgssm_posterior.filtered_covariances,
+                        rtol=1e-2)
+
+
+def test_info_linreg():
+    """Test non-stationary emission matrix in information filter.
+    
+    Compare to moment form filter using the example in 
+        `lgssm/demos/kf_linreg.py`
+    """
+    n_obs = 21
+    x = jnp.linspace(0, 20, n_obs)
+    X = jnp.column_stack((jnp.ones_like(x), x)) # Design matrix.
+    F = jnp.eye(2)
+    Q = jnp.zeros((2,2)) # No parameter drift.
+    Q_prec = jnp.diag(jnp.repeat(1e32, 2)) # Can't use infinite precision.
+    obs_var = 1.
+    R = jnp.ones((1,1)) * obs_var
+    R_prec = jnp.linalg.inv(R)
+    mu0 = jnp.zeros(2)
+    Sigma0 = jnp.eye(2) * 10.
+    Lambda0 = jnp.linalg.inv(Sigma0)
+
+    # Data from original matlab example
+    y = jnp.array([2.4865, -0.3033, -4.0531, -4.3359, -6.1742, -5.604, -3.5069,
+                   -2.3257, -4.6377, -0.2327, -1.9858, 1.0284, -2.264, -0.4508,
+                   1.1672, 6.6524, 4.1452, 5.2677, 6.3403, 9.6264, 14.7842])
+    inputs = jnp.zeros((len(y),1))
+
+    lgssm_moment = LGSSMParams(
+        initial_mean=mu0,
+        initial_covariance=Sigma0,
+        dynamics_matrix=F,
+        dynamics_input_weights=jnp.zeros((mu0.shape[0],1)), # no inputs
+        dynamics_bias=jnp.zeros(1),
+        dynamics_covariance=Q,
+        emission_matrix=X[:,None,:],
+        emission_input_weights=jnp.zeros(1),
+        emission_bias=jnp.zeros(1),
+        emission_covariance=R
+    )
+
+    lgssm_info = LGSSMInfoParams(
+        initial_mean=mu0,
+        initial_precision=Lambda0,
+        dynamics_matrix=F,
+        dynamics_input_weights=jnp.zeros((mu0.shape[0],1)), # no inputs
+        dynamics_bias=jnp.zeros(1),
+        dynamics_precision=Q_prec,
+        emission_matrix=X[:,None,:],
+        emission_input_weights=jnp.zeros(1),
+        emission_bias=jnp.zeros(1),
+        emission_precision=R_prec
+    )
+
+    lgssm_moment_posterior = lgssm_filter(lgssm_moment,inputs,y[:,None])
+    lgssm_info_posterior = lgssm_info_filter(lgssm_info,inputs,y[:,None])
+
+    info_filtered_means = vmap(jnp.linalg.solve)(
+            lgssm_info_posterior.filtered_precisions,
+            lgssm_info_posterior.filtered_etas
+            )
+    info_filtered_covs = jnp.linalg.inv(lgssm_info_posterior.filtered_precisions)
+
+    assert jnp.allclose(info_filtered_means,
+                        lgssm_moment_posterior.filtered_means,
+                        rtol=1e-2)
+    assert jnp.allclose(info_filtered_covs,
+                        lgssm_moment_posterior.filtered_covariances,
+                        rtol=1e-2)
+


### PR DESCRIPTION
### Filtering 
`ssm_jax/lgssm/info_inference.py` contains code for kalman filtering in information form.

The implementation more-or-less mirrors the filtering in `lgssm.inference` with `_predict()` and `_condition_on()` changed to accept and return precision (`Lambda`) and precision-weighted mean (`eta`).

### Tests
`ssm_jax/lgssm_info_inference.py` contains tests which compare the output of `lgssm.info_inference.lgssm_info_filter` to `lgssm.inference.lgssm_filter`. There are currently two tests:
  - `test_info_kalman_filter` - simple test with stationary system.
  -  `test_info_kf_linreg` - uses the example in `lgssm/demos/kf_linreg.py` to test non-stationary parameters.