### PR TITLE
Kalman info form marginal log likelihood and smoothing

### DIFF
--- a/ssm_jax/lgssm/info_inference.py
+++ b/ssm_jax/lgssm/info_inference.py
@@ -239,7 +239,9 @@ def lgssm_info_smoother(params, emissions, inputs=None):
 
         # Compute the smoothed parameter estimates
         smoothed_prec = filtered_prec + F.T @ Q_prec @ (F - G)
-        smoothed_eta = filtered_eta + G.T @ (smoothed_eta_next - pred_eta)
+        smoothed_eta = filtered_eta +\
+                       G.T @ (smoothed_eta_next - pred_eta) +\
+                       (G.T - F.T) @ Q_prec @ (B @ u + b)
 
         return (smoothed_eta, smoothed_prec), (smoothed_eta, smoothed_prec)
 

--- a/ssm_jax/lgssm/info_inference.py
+++ b/ssm_jax/lgssm/info_inference.py
@@ -38,6 +38,25 @@ class LGSSMInfoPosterior:
 # Helper functions
 _get_params = lambda x, dim, t: x[t] if x.ndim == dim+1 else x
 
+def _mvn_info_log_prob(eta,Lambda,x):
+    """Calculate the log probability of an observation from a MVN 
+    parameterised in information form.
+
+    Args:
+        eta (D,): precision weighted mean.
+        Lambda (D,D): precision.
+        x (D,): observation.
+
+    Returns:
+        log_prob: log probability of x.
+    """
+    D = len(Lambda)
+    lp = x.T @ eta - 0.5 * x.T @ Lambda @ x
+    lp += -0.5 * eta.T @ jnp.linalg.solve(Lambda, eta)
+    sign, logdet = jnp.linalg.slogdet(Lambda)
+    lp += -0.5 * (D * jnp.log(2*jnp.pi) - sign * logdet)
+    return lp
+
 
 def _info_predict(eta, Lambda, F, Q_prec, B, u, b):
     """Predict next mean and precision under a linear Gaussian model

--- a/ssm_jax/lgssm/info_inference_test.py
+++ b/ssm_jax/lgssm/info_inference_test.py
@@ -83,6 +83,9 @@ def test_info_kalman_filter():
     assert jnp.allclose(info_filtered_covs,
                         lgssm_posterior.filtered_covariances,
                         rtol=1e-2)
+    assert jnp.allclose(lgssm_info_posterior.marginal_loglik,
+                        lgssm_posterior.marginal_loglik,
+                        rtol=1e-2)
 
 
 def test_info_kf_linreg():

--- a/ssm_jax/lgssm/info_inference_test.py
+++ b/ssm_jax/lgssm/info_inference_test.py
@@ -22,9 +22,11 @@ def info_to_moment_form(etas,Lambdas):
     covs = jnp.linalg.inv(Lambdas)
     return means, covs
 
-def test_info_kalman_filtering_and_smoothing():
-    """ Test information form Kalman filter against the moment form version."""
 
+class TestInfoFilteringAndSmoothing:
+    """Test information form filtering and smoothing by comparing it to moment
+    form.
+    """
     delta = 1.0
     F = jnp.array([
         [1., 0, delta, 0],
@@ -89,9 +91,9 @@ def test_info_kalman_filtering_and_smoothing():
     inputs = jnp.zeros((num_timesteps,input_size))
     x, y = lgssm.sample(key,num_timesteps,inputs)
 
-    lgssm_posterior = lgssm.smoother(y,inputs)
+    lgssm_moment_posterior = lgssm.smoother(y,inputs)
     lgssm_info_posterior = lgssm_info_smoother(lgssm_info, y, inputs) 
-    
+
     info_filtered_means, info_filtered_covs = info_to_moment_form(
             lgssm_info_posterior.filtered_etas,
             lgssm_info_posterior.filtered_precisions
@@ -100,25 +102,32 @@ def test_info_kalman_filtering_and_smoothing():
             lgssm_info_posterior.smoothed_etas,
             lgssm_info_posterior.smoothed_precisions
             )
+    def test_filtered_means(self):
+        assert jnp.allclose(self.info_filtered_means,
+                            self.lgssm_moment_posterior.filtered_means,
+                            rtol=1e-2)
 
-    assert jnp.allclose(info_filtered_means,
-                        lgssm_posterior.filtered_means,
-                        rtol=1e-2)
-    assert jnp.allclose(info_filtered_covs,
-                        lgssm_posterior.filtered_covariances,
-                        rtol=1e-2)
-    assert jnp.allclose(info_smoothed_means,
-                        lgssm_posterior.smoothed_means,
-                        rtol=1e-2)
-    assert jnp.allclose(info_smoothed_covs,
-                        lgssm_posterior.smoothed_covariances,
-                        rtol=1e-2)
-    assert jnp.allclose(lgssm_info_posterior.marginal_loglik,
-                        lgssm_posterior.marginal_loglik,
-                        rtol=1e-2)
+    def test_filtered_covs(self):
+        assert jnp.allclose(self.info_filtered_covs,
+                            self.lgssm_moment_posterior.filtered_covariances,
+                            rtol=1e-2)
 
+    def test_smoothed_means(self):
+        assert jnp.allclose(self.info_smoothed_means,
+                            self.lgssm_moment_posterior.smoothed_means,
+                            rtol=1e-2)
 
-def test_info_kf_linreg():
+    def test_smoothed_covs(self):
+        assert jnp.allclose(self.info_smoothed_covs,
+                            self.lgssm_moment_posterior.smoothed_covariances,
+                            rtol=1e-2)
+    
+    def test_marginal_loglik(self):
+        assert jnp.allclose(self.lgssm_info_posterior.marginal_loglik,
+                            self.lgssm_moment_posterior.marginal_loglik,
+                            rtol=1e-2)
+
+class TestInfoKFLinReg:
     """Test non-stationary emission matrix in information filter.
     
     Compare to moment form filter using the example in 
@@ -177,10 +186,12 @@ def test_info_kf_linreg():
             lgssm_info_posterior.filtered_precisions
             )
 
-    assert jnp.allclose(info_filtered_means,
-                        lgssm_moment_posterior.filtered_means,
-                        rtol=1e-2)
-    assert jnp.allclose(info_filtered_covs,
-                        lgssm_moment_posterior.filtered_covariances,
-                        rtol=1e-2)
-
+    def test_filtered_means(self):
+        assert jnp.allclose(self.info_filtered_means,
+                            self.lgssm_moment_posterior.filtered_means,
+                            rtol=1e-2)
+    def test_filtered_covs(self):
+        assert jnp.allclose(self.info_filtered_covs,
+                            self.lgssm_moment_posterior.filtered_covariances,
+                            rtol=1e-2)
+    

--- a/ssm_jax/lgssm/models.py
+++ b/ssm_jax/lgssm/models.py
@@ -43,7 +43,9 @@ class LinearGaussianSSM:
                  emission_input_weights=None,
                  emission_bias=None):
         self.emission_dim, self.state_dim = emission_matrix.shape
-        self.input_dim = dynamics_input_weights.shape[1] if dynamics_input_weights is not None else 0
+        dynamics_input_dim = dynamics_input_weights.shape[1] if dynamics_input_weights is not None else 0
+        emission_input_dim = emission_input_weights.shape[1] if emission_input_weights is not None else 0
+        self.input_dim = max(dynamics_input_dim, emission_input_dim)
 
         # Save required args
         self.dynamics_matrix = dynamics_matrix


### PR DESCRIPTION
## Marginal log likelihood

- Add the log likelihood calculation to `lgssm_info_filter`.
- Add assertion to info-moment comparison test.

## Information smoothing

- Add `lgssm_info_smoother` which does information form smoothing. 
- Convert the filtering test to now compare both filter and smoother outputs between information and moment form.

This resolves #11.

### Potential Optimisations 

There are a couple of potential optimisations that could be made to the smoothing code: 
- **Numerical stability** - convert to a more stable form to ensure symmetry, analogous to the following in the info filter:
```python
        ImKF = I - K @ F.T
        Lambda_pred = ImKF @ Q_prec @ ImKF.T + K @ Lambda @ K.T
```
- **Avoid duplicate marginalisation**:
    - At present the `_smooth_step` function recalculates the predicted parameters $\eta_{t+1|t}, \Lambda_{t+1|t}$ from the filter.
    - As in information form the predict step essentially requires a matrix inversion, it might be better to save the predicted params during the filtering and to pass to the smoother along with the filtered values. 
    - To avoid changing things too much this could be done by either:
      - Add boolean arg to `lgssm_info_filter` to determine whether a tuple of predicted params is returned alongside the `LGSSMInfoPosterior` object.
      - Extract the filtering code to `_info_filter()` which returns a tuple of filtered and predicted values and then make `lgssm_info_filter` a light wrapper which packs the necessary output into the `LGSSMInfoPosterior`.

