### PR TITLE
add black installation command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ To install in colab, do this
 !pip install -e .
 ```
 
+To install [black](https://black.readthedocs.io/en/stable/), do this (quotes are mandatory for `zsh`)
+```
+pip install -U 'black[jupyter]'
+```
+
 Related libraries:
 
 - [murphy-lab/JSL](https://github.com/probml/JSL) 


### PR DESCRIPTION
An extension to #64. 

- [x] Added a command in `README.md` to install the latest `black[jupyter]`.