### PR TITLE
compute normalized gaussian hmm sufficient stats

### DIFF
--- a/ssm_jax/hmm/learning_test.py
+++ b/ssm_jax/hmm/learning_test.py
@@ -3,10 +3,85 @@ import jax.random as jr
 import numpy as np
 import optax
 import pytest
+import chex
 import ssm_jax.hmm.learning as learn
 from ssm_jax.hmm.models import GaussianHMM
 
+# =============================================================================
+# "STANDARD" EM steps for Gaussian HMM
+#   This perfroms out-of-place HMM updates (i.e. a new HMM is returned)
+#   These results are used as reference for test cases
+# =============================================================================
+from functools import partial
+from jax import vmap, tree_map
+from ssm_jax.hmm.inference import hmm_smoother, compute_transition_probs
+from tensorflow_probability.substrates.jax.distributions import Dirichlet
 
+@chex.dataclass
+class GaussianHMMSuffStats:
+    # Wrapper for sufficient statistics of a GaussianHMM
+    marginal_loglik: chex.Scalar
+    initial_probs: chex.Array
+    trans_probs: chex.Array
+    sum_w: chex.Array
+    sum_x: chex.Array
+    sum_xxT: chex.Array
+    
+def standard_e_step(hmm: GaussianHMM, batch_emissions: chex.Array) -> GaussianHMMSuffStats:
+    def _single_e_step(emissions):
+        # Run the smoother
+        posterior = hmm_smoother(hmm.initial_probabilities,
+                                 hmm.transition_matrix,
+                                 hmm._conditional_logliks(emissions))
+
+        # Compute the initial state and transition probabilities
+        initial_probs = posterior.smoothed_probs[0]
+        trans_probs = compute_transition_probs(hmm.transition_matrix, posterior)
+
+        # Compute the expected sufficient statistics
+        sum_w = jnp.einsum("tk->k", posterior.smoothed_probs)
+        sum_x = jnp.einsum("tk, ti->ki", posterior.smoothed_probs, emissions)
+        sum_xxT = jnp.einsum("tk, ti, tj->kij", posterior.smoothed_probs, emissions, emissions)
+
+        stats = GaussianHMMSuffStats(
+            marginal_loglik=posterior.marginal_loglik,
+            initial_probs=initial_probs,
+            trans_probs=trans_probs,
+            sum_w=sum_w,
+            sum_x=sum_x,
+            sum_xxT=sum_xxT
+        )
+        return stats
+
+    # Map the E step calculations over batches
+    return vmap(_single_e_step)(batch_emissions)
+
+def standard_m_step(batch_stats: GaussianHMMSuffStats) -> GaussianHMM:
+    # Sum the statistics across all batches
+    stats = tree_map(partial(jnp.sum, axis=0), batch_stats)
+
+    # Initial distribution
+    initial_probs = Dirichlet(1.0001 + stats.initial_probs).mode()
+
+    # Transition distribution
+    transition_matrix = Dirichlet(1.0001 + stats.trans_probs).mode()
+
+    # Gaussian emission distribution
+    emission_dim = stats.sum_x.shape[-1]
+    emission_means = stats.sum_x / stats.sum_w[:, None]
+    emission_covs = (
+        stats.sum_xxT / stats.sum_w[:, None, None]
+        - jnp.einsum("ki,kj->kij", emission_means, emission_means)
+        + 1e-4 * jnp.eye(emission_dim)
+    )
+
+    # Pack the results into a new GaussianHMM
+    return GaussianHMM(initial_probs, transition_matrix, emission_means, emission_covs)
+
+# =============================================================================
+# Setup
+# =============================================================================
+                 
 def make_rnd_hmm(num_states=5, emission_dim=2):
     # Specify parameters of the HMM
     initial_probs = jnp.ones(num_states) / num_states
@@ -46,6 +121,25 @@ def test_hmm_fit_em(num_iters=2):
     assert jnp.alltrue(mu.shape == (10, 2))
     assert jnp.allclose(mu[0, 0], -0.712, atol=1e-1)
 
+def test_hmm_fit_normd_vs_standard(num_iters=4):    
+    true_hmm, _, batch_emissions = make_rnd_model_and_data()
+    batch_emissions = batch_emissions.reshape(4, -1, true_hmm.num_obs)
+
+    # Quick test: 2 iterations
+    test_hmm_em = GaussianHMM.random_initialization(jr.PRNGKey(1), 2 * true_hmm.num_states, true_hmm.num_obs)
+    test_hmm_em, logprobs_em = learn.hmm_fit_em(test_hmm_em, batch_emissions, num_iters=num_iters)
+    
+    # Compute reference values from "standard" formulation
+    ref_hmm_em = GaussianHMM.random_initialization(jr.PRNGKey(1), 2 * true_hmm.num_states, true_hmm.num_obs)
+    for _ in range(num_iters):
+        ref_batch_stats = standard_e_step(ref_hmm_em, batch_emissions)
+        ref_hmm_em = standard_m_step(ref_batch_stats)
+    ref_logprobs = ref_batch_stats.marginal_loglik.sum()
+
+    assert jnp.allclose(logprobs_em[-1], ref_logprobs, atol=1)
+    mu = np.array(test_hmm_em.emission_means)
+    assert jnp.alltrue(mu.shape == (10, 2))
+    assert jnp.allclose(mu[0, 0], ref_hmm_em.emission_means[0,0], atol=1e-3)
 
 def test_hmm_fit_sgd(num_iters=2):
     true_hmm, _, batch_emissions = make_rnd_model_and_data()


### PR DESCRIPTION
(Same as earlier PR #116 , but the changes have been moved to a different branch on the fork)

This pull request results in more numerically stable calculations of Gaussian HMM Sufficient Statistics
- Returns normalized versions of expected sufficient statistics (see math below)
- Catches DBZ errors (which manifest as NaNs) resulting from states with zero probability (`sum_w` contains a 0)

**Drawbacks**
The m-step code is more opaque, due to the weighted average of the batched and normalized and sufficient statistics that must be taken. Previously, when the sufficient statistics were unnormalized, all the parameters in the sufficient statistics could be summed with a `tree_map` call. Now, the initial state and transitition probabilities are summed across batched, but the (normalized) Gaussian sufficient statistics must be weighted appropriately.

---

In the E-step, normalized sufficient statistics are calculated, and in the M-step, the normalized sufficient statistics are combined as a weighted average to recover the posterior mean and covariance parameters. The derivation is as follows:

**Single batch emissions (derivation `e_step` changes)**
Let the emissions have shape $(T, D)$ where $T$ is the number of timesteps, and $D$ is the emission dimensions. Note the following identity (in the mean parameter case):
$$\mathbb{E}[\mathbf{x}] = \frac{\sum\limits_{t=1}^T w_t x_t}{\sum\limits_{t=1}^T w_t}= \frac{\sum\limits_{t=1}^T w_t x_t}{W}= \sum\limits_{t=1}^T \frac{w_t}{W} x_t$$
where $W=\sum\limits_{t=1}^T w_t$. The normalized sufficient statistics are $\frac{w_t}{W} x_t$. Returning this value is numerically more stable than returning the unnormalized sum $w_t x_t$ then dividing by $W$ (in the m-step) since $0 < \frac{w_t}{W} \leq 1$.

In the local function `_single_e_step`, 
- `sum_w` corresponds to $W$
- `normd_w` corresponds to the value $\frac{w_t}{W}$ (this is not returned in sufficient stats dataclass)
- `normd_x` corresponds to $\frac{w_t}{W} x_t$
- `normd_xxT` corresponds to $\frac{w_t}{W} x_t x_t^T$

**Batched emissions (derivation of `m_step` changes)**
Now, let the emissions have shape $(B, T_B, D)$ where $B$ is the number of batches and $T_B$ is the number of timesteps per batch. The total number of emissions is $$T = B * T_B = \sum_{b=1}^{B} T_B.$$ Note that we can assume the number of timesteps per batch $T_B$ is constant since we are vmapping over these batched emissions.

This leads to the following equivalent breakouts (should be curly braces but they won't display, so I'm using square brackets and limits/verts):
- $\mathbf{x} = [x_t] \big\vert_{t=1}^T = [x_{b,\tau}] \big\vert_{b=1, \tau=1}^{B,T_B}$
- $\sum\limits_{t=1}^T w_t = \sum\limits_{b=1}^B \Big( \sum\limits_{\tau=1}^{T_B} w_{b,\tau} \Big)$

The variables in the vmapped function `_single_e_step` are now more accurately re-indexed with $b$ and $\tau$ as below:
- `sum_w` corresponds to $W_b := \sum\limits_{\tau=1}^{T_B} w_{b,\tau}$
- `normd_w` corresponds to the value $\frac{w_{b, \tau}}{W_b}$ (this is not returned in sufficient stats dataclass)
- `normd_x` corresponds to $\tilde\mu_b := \frac{w_{b,\tau}}{W_b} x_{b,\tau}$
- `normd_xxT` corresponds to $\tilde\rho_b := \frac{w_{b,\tau}}{W_b} x_{b,\tau} x_{b,\tau}^T$

Given these batched and normalized sufficient statistics, we compute the mean parameter by splitting the summation: 
$$\mathbb{E}[\mathbf{x}] = \frac{\sum\limits_{t=1}^T w_t x_t}{\sum\limits_{t=1}^T w_t} = \frac{\sum\limits_{b=1}^B\Big(\sum\limits_{\tau=1}^{T_B} w_{b,\tau} x_{b,\tau}\Big)}{\sum\limits_{b=1}^B \Big( \sum\limits_{\tau=1}^{T_B} w_{b,\tau} \Big)}=\frac{\sum\limits_{b=1}^B \Big( W_b \frac{w_{b,\tau}}{W_b} x_{b,\tau}\Big)}{\sum\limits_{b=1}^B W_b} = \frac{\sum\limits_{b=1}^B \Big( W_b \tilde\mu_b\Big)}{\sum\limits_{b=1}^B W_b}.$$

Similarly, the second moment is computed as
$$\mathbb{E}[\mathbf{x} \mathbf{x}^T]=\frac{\sum\limits_{b=1}^B \Big( W_b \tilde\rho_b\Big)}{\sum\limits_{b=1}^B W_b}.$$

Note that in the code, the expression for the mean (and similarly for the second moment) are implemented as:
$$\mathbb{E}[\mathbf{x}] = \frac{\sum\limits_{b=1}^B \Big( W_b \tilde\mu_b\Big)}{\sum\limits_{b=1}^B W_b} = \sum\limits_{b=1}^B \Big( \frac{W_b}{{\sum\limits_{b=1}^B W_b}} \tilde\mu_b\Big)$$
where `normd_w` in `m_step` corresponds to  $\frac{W_b}{{\sum\limits_{b=1}^B W_b}}$.