### PR TITLE
Adding priors to HMM models

### DIFF
--- a/ssm_jax/distributions.py
+++ b/ssm_jax/distributions.py
@@ -1,0 +1,173 @@
+import jax.numpy as jnp
+from jax import vmap
+from tensorflow_probability.substrates import jax as tfp
+tfd = tfp.distributions
+tfb = tfp.bijectors
+
+
+class InverseWishart(tfd.TransformedDistribution):
+
+    def __init__(self, df, scale):
+        """Implementation of an inverse Wishart distribution as a transformation of
+        a Wishart distribution. This distribution is defined by a scalar degrees of
+        freedom `df` and a scale matrix, `scale`.
+
+        #### Mathematical Details
+        The probability density function (pdf) is,
+        ```none
+        pdf(X; df, scale) = det(X)**(-0.5 (df+k+1)) exp(-0.5 tr[inv(X) scale]) / Z
+        Z = 2**(0.5 df k) Gamma_k(0.5 df) |det(scale)|**(-0.5 df)
+        ```
+
+        where
+        * `df >= k` denotes the degrees of freedom,
+        * `scale` is a symmetric, positive definite, `k x k` matrix,
+        * `Z` is the normalizing constant, and,
+        * `Gamma_k` is the [multivariate Gamma function](
+            https://en.wikipedia.org/wiki/Multivariate_gamma_function).
+
+        Args:
+            df (_type_): _description_
+            scale (_type_): _description_
+        """
+        self._df = df
+        self._scale = scale
+        # Compute the Cholesky of the inverse scale to parameterize a
+        # Wishart distribution
+        inv_scale_tril = jnp.linalg.cholesky(jnp.linalg.inv(scale))
+
+        super().__init__(
+            tfd.WishartTriL(df, scale_tril=inv_scale_tril),
+            tfb.Chain([tfb.CholeskyOuterProduct(),
+                       tfb.CholeskyToInvCholesky(),
+                       tfb.Invert(tfb.CholeskyOuterProduct())]))
+
+    @classmethod
+    def _parameter_properties(self, dtype, num_classes=None):
+        return dict(
+            # Annotations may optionally specify properties, such as `event_ndims`,
+            # `default_constraining_bijector_fn`, `specifies_shape`, etc.; see
+            # the `ParameterProperties` documentation for details.
+            df=tfp.util.ParameterProperties(event_ndims=0),
+            scale=tfp.util.ParameterProperties(event_ndims=2))
+
+    @property
+    def df(self):
+        return self._df
+
+    @property
+    def scale(self):
+        return self._scale
+
+    def _mean(self):
+        dim = self.scale.shape[-1]
+        df = jnp.array(self.df)[..., None, None] # at least 2d on the right
+        assert self.df > dim + 1, "Mean only exists if df > dim + 1"
+        return self.scale / (df - dim - 1)
+
+    def _mode(self):
+        dim = self.scale.shape[-1]
+        df = jnp.array(self.df)[..., None, None] # at least 2d on the right
+        return self.scale / (df + dim + 1)
+
+    def _variance(self):
+        """Compute the marginal variance of each entry of the matrix.
+        """
+        def _single_variance(df, scale):
+            assert scale.ndim == 2
+            assert df.shape == scale.shape
+            dim = scale.shape[-1]
+            diag = jnp.diag(scale)
+            rows = jnp.arange(dim)[:, None].repeat(3, axis=1)
+            cols = jnp.arange(dim)[None, :].repeat(3, axis=0)
+            numer = (df - dim + 1) * scale**2 + (df - dim - 1) * diag[rows] * diag[cols]
+            denom  = (df - dim) * (df - dim - 1)**2 * (df - dim - 3)
+            return numer / denom
+
+        dfs, scales = jnp.broadcast_arrays(jnp.array(self.df)[..., None, None], self.scale)
+        if scales.ndim == 2:
+            return _single_variance(dfs, scales)
+        else:
+            return vmap(_single_variance)(dfs, scales)
+
+
+# class NormalInverseWishart(tfd.JointDistributionNamed):
+#     def __init__(self, loc, mean_concentration, df, scale, **kwargs):
+#         """
+#         A normal inverse Wishart (NIW) distribution with
+#         TODO: Finish this description
+#         Args:
+#             loc:            \mu_0 in math above
+#             mean_concentration: \kappa_0
+#             df:             \nu
+#             scale:          \Psi
+#         """
+#         # Store hyperparameters.
+#         # Note: these should really be private.
+#         self._loc = loc
+#         self._mean_concentration = mean_concentration
+#         self._df = df
+#         self._scale = scale
+
+#         super(NormalInverseWishart, self).__init__(dict(
+#             Sigma=lambda: InverseWishart(df, scale),
+#             mu=lambda Sigma: tfd.MultivariateNormalFullCovariance(
+#                 loc, Sigma / mean_concentration)
+#         ))
+
+class NormalInverseWishart(tfd.JointDistributionSequential):
+    def __init__(self, loc, mean_concentration, df, scale):
+        """
+        A normal inverse Wishart (NIW) distribution with
+        TODO: Finish this description
+        Args:
+            loc:            \mu_0 in math above
+            mean_concentration: \kappa_0
+            df:             \nu
+            scale:          \Psi
+        """
+        # Store hyperparameters.
+        # Note: these should really be private.
+        self._loc = loc
+        self._mean_concentration = mean_concentration
+        self._df = df
+        self._scale = scale
+
+        super(NormalInverseWishart, self).__init__([
+            InverseWishart(df, scale),
+            lambda Sigma: tfd.MultivariateNormalFullCovariance(
+                loc, Sigma / mean_concentration)]
+        )
+
+    @property
+    def loc(self):
+        return self._loc
+
+    @property
+    def mean_concentration(self):
+        return self._mean_concentration
+
+    @property
+    def df(self):
+        return self._df
+
+    @property
+    def scale(self):
+        return self._scale
+
+    def _mode(self):
+        r"""Solve for the mode. Recall,
+        .. math::
+            p(\mu, \Sigma) \propto
+                \mathrm{N}(\mu | \mu_0, \Sigma / \kappa_0) \times
+                \mathrm{IW}(\Sigma | \nu_0, \Psi_0)
+        The optimal mean is :math:`\mu^* = \mu_0`. Substituting this in,
+        .. math::
+            p(\mu^*, \Sigma) \propto IW(\Sigma | \nu_0 + 1, \Psi_0)
+        and the mode of this inverse Wishart distribution is at
+        .. math::
+            \Sigma^* = \Psi_0 / (\nu_0 + d + 2)
+        """
+        dim = self._loc.shape[-1]
+        covariance = jnp.einsum("...,...ij->...ij", 1 / (self._df + dim + 2), self._scale)
+        return covariance, self._loc

--- a/ssm_jax/distributions.py
+++ b/ssm_jax/distributions.py
@@ -91,30 +91,6 @@ class InverseWishart(tfd.TransformedDistribution):
             return vmap(_single_variance)(dfs, scales)
 
 
-# class NormalInverseWishart(tfd.JointDistributionNamed):
-#     def __init__(self, loc, mean_concentration, df, scale, **kwargs):
-#         """
-#         A normal inverse Wishart (NIW) distribution with
-#         TODO: Finish this description
-#         Args:
-#             loc:            \mu_0 in math above
-#             mean_concentration: \kappa_0
-#             df:             \nu
-#             scale:          \Psi
-#         """
-#         # Store hyperparameters.
-#         # Note: these should really be private.
-#         self._loc = loc
-#         self._mean_concentration = mean_concentration
-#         self._df = df
-#         self._scale = scale
-
-#         super(NormalInverseWishart, self).__init__(dict(
-#             Sigma=lambda: InverseWishart(df, scale),
-#             mu=lambda Sigma: tfd.MultivariateNormalFullCovariance(
-#                 loc, Sigma / mean_concentration)
-#         ))
-
 class NormalInverseWishart(tfd.JointDistributionSequential):
     def __init__(self, loc, mean_concentration, df, scale):
         """

--- a/ssm_jax/distributions_test.py
+++ b/ssm_jax/distributions_test.py
@@ -1,0 +1,72 @@
+import pytest
+
+import jax.numpy as jnp
+import jax.random as jr
+from ssm_jax.distributions import InverseWishart, NormalInverseWishart
+
+def test_inverse_wishart_mode(df=7.0, dim=3, scale_factor=3.0):
+    scale = scale_factor * jnp.eye(dim)
+    iw = InverseWishart(df, scale)
+    assert jnp.allclose(iw.mode(), scale / (df + dim + 1))
+
+
+def test_inverse_wishart_log_prob(df=7.0, dim=3, scale_factor=3.0, n_samples=10):
+    scale = scale_factor * jnp.eye(dim)
+    iw = InverseWishart(df, scale)
+    samples = iw.sample(seed=jr.PRNGKey(0), sample_shape=(n_samples,))
+    assert samples.shape == (n_samples, dim, dim)
+    lps = iw.log_prob(samples)
+    assert lps.shape == (n_samples,)
+    assert jnp.all(jnp.isfinite(lps))
+
+
+def test_inverse_wishart_sample(df=7.0, dim=3, scale_factor=3.0, n_samples=10000, num_std=6):
+    """Test that the sample mean is within a (large) interval around the true mean.
+    To determine the interval to 6 times the standard deviation of the Monte
+    Carlo estimator.
+
+    Note: This also tests the variance implementation indirectly. If there's a bug in
+    variance it will affect the MC error.
+    """
+    scale = scale_factor * jnp.eye(dim)
+    iw = InverseWishart(df, scale)
+    samples = iw.sample(seed=jr.PRNGKey(0), sample_shape=(n_samples,))
+    assert samples.shape == (n_samples, dim, dim)
+
+    mc_std = jnp.sqrt(iw.variance() / n_samples)
+    assert jnp.allclose(samples.mean(axis=0), iw.mean(), atol=num_std * mc_std)
+
+
+def test_normal_inverse_wishart_mode(loc=0., mean_conc=1.0, df=7.0, dim=3, scale_factor=3.0):
+    loc = loc * jnp.ones(dim)
+    scale = scale_factor * jnp.eye(dim)
+    niw = NormalInverseWishart(loc, mean_conc, df, scale)
+    Sigma, mu = niw.mode()
+    assert jnp.allclose(mu, loc)
+    assert jnp.allclose(Sigma, scale / (df + dim + 2))
+
+
+def test_normal_inverse_wishart_mode_batch(loc=0., mean_conc=1.0, df=7.0, dim=3, scale_factor=3.0, batch_size=10):
+    loc = loc * jnp.ones(dim)
+    scale = scale_factor * jnp.eye(dim)
+    niw = NormalInverseWishart(loc[None, ...].repeat(batch_size, axis=0),
+                               mean_conc,
+                               df,
+                               scale[None, ...].repeat(batch_size, axis=0))
+    Sigma, mu = niw.mode()
+    assert Sigma.shape == (batch_size, dim, dim)
+    assert mu.shape == (batch_size, dim)
+    assert jnp.allclose(mu, loc)
+    assert jnp.allclose(Sigma, scale / (df + dim + 2))
+
+
+def test_normal_inverse_wishart_log_prob(loc=0., mean_conc=1.0, df=7.0, dim=3, scale_factor=3.0, n_samples=10):
+    loc = loc * jnp.ones(dim)
+    scale = scale_factor * jnp.eye(dim)
+    niw = NormalInverseWishart(loc, mean_conc, df, scale)
+    Sigma_samples, mu_samples = niw.sample(seed=jr.PRNGKey(0), sample_shape=(n_samples,))
+    assert mu_samples.shape == (n_samples, dim)
+    assert Sigma_samples.shape == (n_samples, dim, dim)
+    lps = niw.log_prob((Sigma_samples, mu_samples))
+    assert lps.shape == (n_samples,)
+    assert jnp.all(jnp.isfinite(lps))

--- a/ssm_jax/hmm/models/base.py
+++ b/ssm_jax/hmm/models/base.py
@@ -18,27 +18,11 @@ from ssm_jax.hmm.inference import hmm_two_filter_smoother
 from ssm_jax.abstractions import SSM, Parameter
 from ssm_jax.optimize import run_sgd
 
+
 class BaseHMM(SSM):
 
-    def __init__(self, initial_probabilities, transition_matrix):
-        """
-        Abstract base class for Hidden Markov Models.
-        Child class specifies the emission distribution.
-
-        Args:
-            initial_probabilities[k]: prob(hidden(1)=k)
-            transition_matrix[j,k]: prob(hidden(t) = k | hidden(t-1)j)
-        """
-        # Check shapes
-        num_states = transition_matrix.shape[-1]
-        assert initial_probabilities.shape == (num_states,)
-        assert transition_matrix.shape == (num_states, num_states)
-
-        # Store the parameters
-        self._initial_probs = Parameter(initial_probabilities, bijector=tfb.Invert(tfb.SoftmaxCentered()))
-        self._transition_matrix = Parameter(transition_matrix, bijector=tfb.Invert(tfb.SoftmaxCentered()))
-
     # Properties to get various attributes of the model.
+    # TODO: These need to be updated when we have covariates.
     @property
     def num_states(self):
         return self.initial_distribution().probs_parameter().shape[0]
@@ -47,80 +31,75 @@ class BaseHMM(SSM):
     def num_obs(self):
         return self.emission_distribution(0).event_shape[0]
 
-    @property
-    def initial_probs(self):
-        return self._initial_probs
+    # Three helper functions to compute the initial probabilities,
+    # transition matrix (or matrices), and conditional log likelihoods.
+    # These are the args to the HMM inference functions, and they can
+    # be computed using the generic SSM initial_distribution(),
+    # transition_distribution(), and emission_distribution() functions.
+    def _compute_initial_probs(self):
+        return self.initial_distribution().probs_parameter()
 
-    @property
-    def transition_matrix(self):
-        return self._transition_matrix
+    def _compute_transition_matrices(self, **covariates):
+        if len(covariates) > 0:
+            f = lambda **covariate: \
+                vmap(lambda state: \
+                    self.transition_distribution(state, **covariate).probs_parameter())(
+                        jnp.arange(self.num_states))
+            return vmap(f)(**covariates)
+        else:
+            g = vmap(lambda state: self.transition_distribution(state).probs_parameter())
+            return g(jnp.arange(self.num_states))
 
-    def initial_distribution(self):
-        return tfd.Categorical(probs=self._initial_probs.value)
-
-    def transition_distribution(self, state):
-        return tfd.Categorical(probs=self._transition_matrix.value[state])
-
-    @abstractmethod
-    def emission_distribution(self, state):
-        """Return a distribution over emissions given current state.
-
-        Args:
-            state (PyTree): current latent state.
-
-        Returns:
-            dist (tfd.Distribution): conditional distribution of current emission.
-        """
-        raise NotImplementedError
-
-    def _conditional_logliks(self, emissions):
+    def _compute_conditional_logliks(self, emissions):
         # Compute the log probability for each time step by
         # performing a nested vmap over emission time steps and states.
-        f = lambda emission: vmap(lambda state: self.emission_distribution(state).log_prob(emission))(jnp.arange(
-            self.num_states))
+        f = lambda emission: \
+            vmap(lambda state: self.emission_distribution(state).log_prob(emission))(
+                jnp.arange(self.num_states))
         return vmap(f)(emissions)
 
     # Basic inference code
     def marginal_log_prob(self, emissions):
         """Compute log marginal likelihood of observations."""
-        post = hmm_filter(self.initial_probs.value,
-                          self.transition_matrix.value,
-                          self._conditional_logliks(emissions))
+        post = hmm_filter(self._compute_initial_probs(),
+                          self._compute_transition_matrices(),
+                          self._compute_conditional_logliks(emissions))
         ll = post.marginal_loglik
         return ll
 
     def most_likely_states(self, emissions):
         """Compute Viterbi path."""
-        return hmm_posterior_mode(self.initial_probs.value,
-                                  self.transition_matrix.value,
-                                  self._conditional_logliks(emissions))
+        return hmm_posterior_mode(self._compute_initial_probs(),
+                                  self._compute_transition_matrices(),
+                                  self._compute_conditional_logliks(emissions))
 
     def filter(self, emissions):
         """Compute filtering distribution."""
-        return hmm_filter(self.initial_probs.value,
-                          self.transition_matrix.value,
-                          self._conditional_logliks(emissions))
+        return hmm_filter(self._compute_initial_probs(),
+                          self._compute_transition_matrices(),
+                          self._compute_conditional_logliks(emissions))
 
     def smoother(self, emissions):
         """Compute smoothing distribution."""
-        return hmm_smoother(self.initial_probs.value,
-                            self.transition_matrix.value,
-                            self._conditional_logliks(emissions))
+        return hmm_smoother(self._compute_initial_probs(),
+                            self._compute_transition_matrices(),
+                            self._compute_conditional_logliks(emissions))
 
     # Expectation-maximization (EM) code
     def e_step(self, batch_emissions):
         """The E-step computes expected sufficient statistics under the
         posterior. In the generic case, we simply return the posterior itself.
         """
-
         def _single_e_step(emissions):
-            # TODO: do we need to use dynamic slice?
-            posterior = hmm_two_filter_smoother(self.initial_probs.value,
-                                                self.transition_matrix.value,
-                                                self._conditional_logliks(emissions))
+            transition_matrices = self._compute_transition_matrices()
+            posterior = hmm_two_filter_smoother(self._compute_initial_probs(),
+                                                transition_matrices,
+                                                self._compute_conditional_logliks(emissions))
 
             # Compute the transition probabilities
-            posterior.trans_probs = compute_transition_probs(self.transition_matrix.value, posterior)
+            posterior.trans_probs = compute_transition_probs(
+                transition_matrices, posterior,
+                reduce_sum=(transition_matrices.ndim == 2))
 
             return posterior
 
@@ -137,20 +116,26 @@ class BaseHMM(SSM):
         """
         def neg_expected_log_joint(params, minibatch):
             minibatch_emissions, minibatch_posteriors = minibatch
+            scale = len(batch_emissions) / len(minibatch_emissions)
             self.unconstrained_params = params
 
             def _single_expected_log_joint(emissions, posterior):
-                log_likelihoods = self._conditional_logliks(emissions)
+                initial_probs = self._compute_initial_probs()
+                trans_matrices = self._compute_transition_matrices()
+                log_likelihoods = self._compute_conditional_logliks(emissions)
                 expected_states = posterior.smoothed_probs
                 trans_probs = posterior.trans_probs
 
-                lp = jnp.sum(expected_states[0] * jnp.log(self.initial_probs.value))
-                lp += jnp.sum(trans_probs * jnp.log(self.transition_matrix.value))
+                lp = jnp.sum(expected_states[0] * jnp.log(initial_probs))
+                lp += jnp.sum(trans_probs * jnp.log(trans_matrices))
                 lp += jnp.sum(expected_states * log_likelihoods)
                 return lp
 
-            lps = vmap(_single_expected_log_joint)(minibatch_emissions, minibatch_posteriors)
-            return -jnp.sum(lps / batch_emissions.size)
+            log_prior = self.log_prior()
+            minibatch_lps = vmap(_single_expected_log_joint)(
+                minibatch_emissions, minibatch_posteriors)
+            expected_log_joint = log_prior + minibatch_lps.sum() * scale
+            return -expected_log_joint / batch_emissions.size
 
         # Minimize the negative expected log joint with SGD
         params, losses = run_sgd(neg_expected_log_joint,
@@ -174,14 +159,15 @@ class BaseHMM(SSM):
         def em_step(params):
             self.unconstrained_params = params
             batch_posteriors = self.e_step(batch_emissions)
+            lp = self.log_prior() + batch_posteriors.marginal_loglik.sum()
             self.m_step(batch_emissions, batch_posteriors, **kwargs)
-            return self.unconstrained_params, batch_posteriors
+            return self.unconstrained_params, lp
 
         log_probs = []
         params = self.unconstrained_params
         for _ in trange(num_iters):
-            params, batch_posteriors = em_step(params)
-            log_probs.append(batch_posteriors.marginal_loglik.sum())
+            params, lp = em_step(params)
+            log_probs.append(lp)
 
         self.unconstrained_params = params
         return jnp.array(log_probs)
@@ -217,8 +203,10 @@ class BaseHMM(SSM):
         def _loss_fn(params, minibatch_emissions):
             """Default objective function."""
             self.unconstrained_params = params
-            f = lambda emissions: -self.marginal_log_prob(emissions) / len(emissions)
-            return vmap(f)(minibatch_emissions).mean()
+            scale = len(batch_emissions) / len(minibatch_emissions)
+            minibatch_lls = vmap(self.marginal_log_prob)(minibatch_emissions)
+            lp = self.log_prior() + minibatch_lls.sum() * scale
+            return -lp / batch_emissions.size
 
         params, losses = run_sgd(_loss_fn,
                                  self.unconstrained_params,
@@ -230,3 +218,111 @@ class BaseHMM(SSM):
                                  key=key)
         self.unconstrained_params = params
         return losses
+
+
+class StandardHMM(BaseHMM):
+
+    def __init__(self,
+                 initial_probabilities,
+                 transition_matrix,
+                 initial_probs_concentration=1.1,
+                 transition_matrix_concentration=1.1):
+        """
+        Abstract base class for Hidden Markov Models.
+        Child class specifies the emission distribution.
+
+        Args:
+            initial_probabilities[k]: prob(hidden(1)=k)
+            transition_matrix[j,k]: prob(hidden(t) = k | hidden(t-1)j)
+        """
+        # Check shapes
+        num_states = transition_matrix.shape[-1]
+        assert initial_probabilities.shape == (num_states,)
+        assert transition_matrix.shape == (num_states, num_states)
+
+        # Store the parameters
+        self._initial_probs = Parameter(initial_probabilities, bijector=tfb.Invert(tfb.SoftmaxCentered()))
+        self._transition_matrix = Parameter(transition_matrix, bijector=tfb.Invert(tfb.SoftmaxCentered()))
+
+        # And the hyperparameters of the prior
+        self._initial_probs_concentration = Parameter(initial_probs_concentration * jnp.ones(num_states),
+                                                      is_frozen=True,
+                                                      bijector=tfb.Invert(tfb.Softplus()))
+        self._transition_matrix_concentration = Parameter(transition_matrix_concentration * jnp.ones(num_states),
+                                                          is_frozen=True,
+                                                          bijector=tfb.Invert(tfb.Softplus()))
+
+    @property
+    def initial_probs(self):
+        return self._initial_probs
+
+    @property
+    def transition_matrix(self):
+        return self._transition_matrix
+
+    def initial_distribution(self):
+        return tfd.Categorical(probs=self._initial_probs.value)
+
+    def transition_distribution(self, state):
+        return tfd.Categorical(probs=self._transition_matrix.value[state])
+
+    @abstractmethod
+    def emission_distribution(self, state):
+        """Return a distribution over emissions given current state.
+
+        Args:
+            state (PyTree): current latent state.
+
+        Returns:
+            dist (tfd.Distribution): conditional distribution of current emission.
+        """
+        raise NotImplementedError
+
+    def _m_step_initial_probs(self, batch_emissions, batch_posteriors):
+        post = tfd.Dirichlet(self._initial_probs_concentration.value +
+                             batch_posteriors.initial_probs.sum(axis=0))
+        self._initial_probs.value = post.mode()
+
+    def _m_step_transition_matrix(self, batch_emissions, batch_posteriors):
+        post = tfd.Dirichlet(self._transition_matrix_concentration.value +
+                             batch_posteriors.trans_probs.sum(axis=0))
+        self._transition_matrix.value = post.mode()
+
+    def _m_step_emissions(self, batch_emissions, batch_posteriors,
+                          optimizer=optax.adam(1e-2),
+                          num_mstep_iters=50):
+
+        def neg_expected_log_joint(params, minibatch):
+            minibatch_emissions, minibatch_posteriors = minibatch
+            scale = len(batch_emissions) / len(minibatch_emissions)
+            self.unconstrained_params = params
+
+            def _single_expected_log_like(emissions, posterior):
+                log_likelihoods = self._conditional_logliks(emissions)
+                expected_states = posterior.smoothed_probs
+                lp += jnp.sum(expected_states * log_likelihoods)
+                return lp
+
+            log_prior = self.log_prior()
+            minibatch_ells = vmap(_single_expected_log_like)(
+                minibatch_emissions, minibatch_posteriors)
+            expected_log_joint = log_prior + minibatch_ells.sum() * scale
+            return -expected_log_joint / batch_emissions.size
+
+        # Minimize the negative expected log joint with SGD
+        params, losses = run_sgd(neg_expected_log_joint,
+                                 self.unconstrained_params,
+                                 (batch_emissions, batch_posteriors),
+                                 optimizer=optimizer,
+                                 num_epochs=num_mstep_iters)
+        self.unconstrained_params = params
+
+    def m_step(self, batch_emissions, batch_posteriors,
+               optimizer=optax.adam(1e-2),
+               num_mstep_iters=50):
+
+        self._m_step_initial_probs(batch_emissions, batch_posteriors)
+        self._m_step_transition_matrix(batch_emissions, batch_posteriors)
+        self._m_step_emissions(batch_emissions, batch_posteriors,
+                               optimizer=optimizer,
+                               num_mstep_iters=num_mstep_iters)

--- a/ssm_jax/hmm/models/bernoulli_hmm.py
+++ b/ssm_jax/hmm/models/bernoulli_hmm.py
@@ -11,21 +11,36 @@ from jax.tree_util import register_pytree_node_class
 from ssm_jax.abstractions import Parameter
 from ssm_jax.hmm.inference import compute_transition_probs
 from ssm_jax.hmm.inference import hmm_smoother
-from ssm_jax.hmm.models.base import BaseHMM
+from ssm_jax.hmm.models.base import StandardHMM
 
 
 @register_pytree_node_class
-class BernoulliHMM(BaseHMM):
+class BernoulliHMM(StandardHMM):
 
-    def __init__(self, initial_probabilities, transition_matrix, emission_probs):
+    def __init__(self,
+                 initial_probabilities,
+                 transition_matrix,
+                 emission_probs,
+                 initial_probs_concentration=1.1,
+                 transition_matrix_concentration=1.1,
+                 emission_prior_concentration1=1.1,
+                 emission_prior_concentration0=1.1):
         """_summary_
         Args:
             initial_probabilities (_type_): _description_
             transition_matrix (_type_): _description_
             emission_probs (_type_): _description_
         """
-        super().__init__(initial_probabilities, transition_matrix)
+        super().__init__(initial_probabilities, transition_matrix,
+                         initial_probs_concentration=initial_probs_concentration,
+                         transition_matrix_concentration=transition_matrix_concentration)
 
+        self._emission_prior_concentration0 = Parameter(emission_prior_concentration0,
+                                                        is_frozen=True,
+                                                        bijector=tfb.Invert(tfb.Softplus()))
+        self._emission_prior_concentration1 = Parameter(emission_prior_concentration1,
+                                                        is_frozen=True,
+                                                        bijector=tfb.Invert(tfb.Softplus()))
         self._emission_probs = Parameter(emission_probs, bijector=tfb.Invert(tfb.Sigmoid()))
 
     @classmethod
@@ -44,6 +59,13 @@ class BernoulliHMM(BaseHMM):
         return tfd.Independent(tfd.Bernoulli(probs=self._emission_probs.value[state]),
                                reinterpreted_batch_ndims=1)
 
+    def log_prior(self):
+        lp = tfd.Dirichlet(self._initial_probs_concentration.value).log_prob(self.initial_probs.value)
+        lp += tfd.Dirichlet(self._transition_matrix_concentration.value).log_prob(self.transition_matrix.value).sum()
+        lp += tfd.Beta(self._emission_prior_concentration1.value,
+                         self._emission_prior_concentration0.value).log_prob(self._emission_probs.value).sum()
+        return lp
+
     def e_step(self, batch_emissions):
         """The E-step computes expected sufficient statistics under the
         posterior. In the Gaussian case, this these are the first two
@@ -61,9 +83,9 @@ class BernoulliHMM(BaseHMM):
 
         def _single_e_step(emissions):
             # Run the smoother
-            posterior = hmm_smoother(self.initial_probs.value,
-                                     self.transition_matrix.value,
-                                     self._conditional_logliks(emissions))
+            posterior = hmm_smoother(self._compute_initial_probs(),
+                                     self._compute_transition_matrices(),
+                                     self._compute_conditional_logliks(emissions))
 
             # Compute the initial state and transition probabilities
             initial_probs = posterior.smoothed_probs[0]
@@ -85,10 +107,11 @@ class BernoulliHMM(BaseHMM):
         # Map the E step calculations over batches
         return vmap(_single_e_step)(batch_emissions)
 
-    def m_step(self, batch_emissions, batch_posteriors, **kwargs):
+    def _m_step_emissions(self, batch_emissions, batch_posteriors, **kwargs):
         # Sum the statistics across all batches
         stats = tree_map(partial(jnp.sum, axis=0), batch_posteriors)
+
         # Then maximize the expected log probability as a fn of model parameters
-        self._initial_probs.value = tfd.Dirichlet(1.0001 + stats.initial_probs).mode()
-        self._transition_matrix.value = tfd.Dirichlet(1.0001 + stats.trans_probs).mode()
-        self._emission_probs.value = tfd.Beta(1.1 + stats.sum_x, 1.1 + stats.sum_1mx).mode()
+        self._emission_probs.value = tfd.Beta(
+            self._emission_prior_concentration1.value + stats.sum_x,
+            self._emission_prior_concentration0.value + stats.sum_1mx).mode()

--- a/ssm_jax/hmm/models/categorical_hmm.py
+++ b/ssm_jax/hmm/models/categorical_hmm.py
@@ -12,13 +12,19 @@ from jax.tree_util import register_pytree_node_class
 from ssm_jax.abstractions import Parameter
 from ssm_jax.hmm.inference import compute_transition_probs
 from ssm_jax.hmm.inference import hmm_smoother
-from ssm_jax.hmm.models.base import BaseHMM
+from ssm_jax.hmm.models.base import StandardHMM
 
 
 @register_pytree_node_class
-class CategoricalHMM(BaseHMM):
+class CategoricalHMM(StandardHMM):
 
-    def __init__(self, initial_probabilities, transition_matrix, emission_probs):
+    def __init__(self,
+                 initial_probabilities,
+                 transition_matrix,
+                 emission_probs,
+                 initial_probs_concentration=1.1,
+                 transition_matrix_concentration=1.1,
+                 emission_probs_concentration=1.1):
         """_summary_
 
         Args:
@@ -26,12 +32,20 @@ class CategoricalHMM(BaseHMM):
             transition_matrix (_type_): _description_
             emission_probs (_type_): _description_
         """
-        super().__init__(initial_probabilities, transition_matrix)
+        super().__init__(initial_probabilities, transition_matrix,
+                         initial_probs_concentration=initial_probs_concentration,
+                         transition_matrix_concentration=transition_matrix_concentration)
 
         # Check shapes
         assert emission_probs.ndim == 3, \
             "emission_probs must be (num_states x num_emissions x num_classes)"
+        num_classes = emission_probs.shape[2]
+
+        # Save parameters and hyperparameters
         self._emission_probs = Parameter(emission_probs, bijector=tfb.Invert(tfb.SoftmaxCentered()))
+        self._emission_probs_concentration = Parameter(emission_probs_concentration  * jnp.ones(num_classes),
+                                                       is_frozen=True,
+                                                       bijector=tfb.Invert(tfb.Softplus()))
 
     @classmethod
     def random_initialization(cls, key, num_states, num_emissions, num_classes):
@@ -58,6 +72,12 @@ class CategoricalHMM(BaseHMM):
             tfd.Categorical(probs=self.emission_probs.value[state]),
             reinterpreted_batch_ndims=1)
 
+    def log_prior(self):
+        lp = tfd.Dirichlet(self._initial_probs_concentration.value).log_prob(self.initial_probs.value)
+        lp += tfd.Dirichlet(self._transition_matrix_concentration.value).log_prob(self.transition_matrix.value).sum()
+        lp += tfd.Dirichlet(self._emission_probs_concentration.value).log_prob(self.emission_probs.value).sum()
+        return lp
+
     def e_step(self, batch_emissions):
         """The E-step computes expected sufficient statistics under the
         posterior. In the Gaussian case, this these are the first two
@@ -74,9 +94,9 @@ class CategoricalHMM(BaseHMM):
 
         def _single_e_step(emissions):
             # Run the smoother
-            posterior = hmm_smoother(self.initial_probs.value,
-                                     self.transition_matrix.value,
-                                     self._conditional_logliks(emissions))
+            posterior = hmm_smoother(self._compute_initial_probs(),
+                                     self._compute_transition_matrices(),
+                                     self._compute_conditional_logliks(emissions))
 
             # Compute the initial state and transition probabilities
             initial_probs = posterior.smoothed_probs[0]
@@ -97,10 +117,10 @@ class CategoricalHMM(BaseHMM):
         # Map the E step calculations over batches
         return vmap(_single_e_step)(batch_emissions)
 
-    def m_step(self, batch_emissions, batch_posteriors, **kwargs):
+    def _m_step_emissions(self, batch_emissions, batch_posteriors, **kwargs):
         # Sum the statistics across all batches
         stats = tree_map(partial(jnp.sum, axis=0), batch_posteriors)
+
         # Then maximize the expected log probability as a fn of model parameters
-        self._initial_probs.value = tfd.Dirichlet(1.0001 + stats.initial_probs).mode()
-        self._transition_matrix.value = tfd.Dirichlet(1.0001 + stats.trans_probs).mode()
-        self._emission_probs.value = tfd.Dirichlet(1.1 + stats.sum_x).mode()
+        self._emission_probs.value = tfd.Dirichlet(self._emission_probs_concentration.value +
+                                                   stats.sum_x).mode()

--- a/ssm_jax/hmm/models/multinomial_hmm.py
+++ b/ssm_jax/hmm/models/multinomial_hmm.py
@@ -17,7 +17,7 @@ class MultinomialHMM(StandardHMM):
                  num_trials=1,
                  initial_probs_concentration=1.1,
                  transition_matrix_concentration=1.1,
-                 emission_probs_concentration=1.1):
+                 emission_prior_concentration=1.1):
         """_summary_
 
         Args:
@@ -35,7 +35,7 @@ class MultinomialHMM(StandardHMM):
         num_classes = emission_probs.shape[2]
         self._num_trials = num_trials
         self._emission_probs = Parameter(emission_probs, bijector=tfb.Invert(tfb.SoftmaxCentered()))
-        self._emission_probs_concentration = Parameter(emission_probs_concentration  * jnp.ones(num_classes),
+        self._emission_prior_concentration = Parameter(emission_prior_concentration  * jnp.ones(num_classes),
                                                        is_frozen=True,
                                                        bijector=tfb.Invert(tfb.Softplus()))
 
@@ -71,5 +71,5 @@ class MultinomialHMM(StandardHMM):
     def log_prior(self):
         lp = tfd.Dirichlet(self._initial_probs_concentration.value).log_prob(self.initial_probs.value)
         lp += tfd.Dirichlet(self._transition_matrix_concentration.value).log_prob(self.transition_matrix.value).sum()
-        lp += tfd.Dirichlet(self._emission_probs_concentration.value).log_prob(self._emission_probs.value).sum()
+        lp += tfd.Dirichlet(self._emission_prior_concentration.value).log_prob(self._emission_probs.value).sum()
         return lp

--- a/ssm_jax/hmm/models/multinomial_hmm.py
+++ b/ssm_jax/hmm/models/multinomial_hmm.py
@@ -4,13 +4,20 @@ import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
 from jax.tree_util import register_pytree_node_class
 from ssm_jax.abstractions import Parameter
-from ssm_jax.hmm.models.base import BaseHMM
+from ssm_jax.hmm.models.base import StandardHMM
 
 
 @register_pytree_node_class
-class MultinomialHMM(BaseHMM):
+class MultinomialHMM(StandardHMM):
 
-    def __init__(self, initial_probabilities, transition_matrix, emission_probs, num_trials=1):
+    def __init__(self,
+                 initial_probabilities,
+                 transition_matrix,
+                 emission_probs,
+                 num_trials=1,
+                 initial_probs_concentration=1.1,
+                 transition_matrix_concentration=1.1,
+                 emission_probs_concentration=1.1):
         """_summary_
 
         Args:
@@ -18,13 +25,19 @@ class MultinomialHMM(BaseHMM):
             transition_matrix (_type_): _description_
             emission_probs (_type_): _description_
         """
-        super().__init__(initial_probabilities, transition_matrix)
+        super().__init__(initial_probabilities, transition_matrix,
+                         initial_probs_concentration=initial_probs_concentration,
+                         transition_matrix_concentration=transition_matrix_concentration)
 
         # Check shapes
         assert emission_probs.ndim == 3, \
             "emission_probs must be (num_states x num_emissions x num_classes)"
+        num_classes = emission_probs.shape[2]
         self._num_trials = num_trials
         self._emission_probs = Parameter(emission_probs, bijector=tfb.Invert(tfb.SoftmaxCentered()))
+        self._emission_probs_concentration = Parameter(emission_probs_concentration  * jnp.ones(num_classes),
+                                                       is_frozen=True,
+                                                       bijector=tfb.Invert(tfb.Softplus()))
 
     @classmethod
     def random_initialization(cls, key, num_states, num_emissions, num_classes, num_trials=1):
@@ -54,3 +67,9 @@ class MultinomialHMM(BaseHMM):
         return tfd.Independent(tfd.Multinomial(self._num_trials,
                                                probs=self.emission_probs.value[state]),
                                retinterpreted_batch_ndims=1)
+
+    def log_prior(self):
+        lp = tfd.Dirichlet(self._initial_probs_concentration.value).log_prob(self.initial_probs.value)
+        lp += tfd.Dirichlet(self._transition_matrix_concentration.value).log_prob(self.transition_matrix.value).sum()
+        lp += tfd.Dirichlet(self._emission_probs_concentration.value).log_prob(self._emission_probs.value).sum()
+        return lp

--- a/ssm_jax/hmm/models/poisson_hmm.py
+++ b/ssm_jax/hmm/models/poisson_hmm.py
@@ -11,13 +11,20 @@ from jax.tree_util import register_pytree_node_class
 from ssm_jax.abstractions import Parameter
 from ssm_jax.hmm.inference import compute_transition_probs
 from ssm_jax.hmm.inference import hmm_smoother
-from ssm_jax.hmm.models.base import BaseHMM
+from ssm_jax.hmm.models.base import StandardHMM
 
 
 @register_pytree_node_class
-class PoissonHMM(BaseHMM):
+class PoissonHMM(StandardHMM):
 
-    def __init__(self, initial_probabilities, transition_matrix, emission_rates):
+    def __init__(self,
+                 initial_probabilities,
+                 transition_matrix,
+                 emission_rates,
+                 initial_probs_concentration=1.1,
+                 transition_matrix_concentration=1.1,
+                 emission_rates_prior_concentration=1.1,
+                 emission_rates_prior_rate=0.1):
         """_summary_
 
         Args:
@@ -25,8 +32,17 @@ class PoissonHMM(BaseHMM):
             transition_matrix (_type_): _description_
             emission_rates (_type_): _description_
         """
-        super().__init__(initial_probabilities, transition_matrix)
+        super().__init__(initial_probabilities, transition_matrix,
+                         initial_probs_concentration=initial_probs_concentration,
+                         transition_matrix_concentration=transition_matrix_concentration)
+
         self._emission_rates = Parameter(emission_rates, bijector=tfb.Invert(tfb.Softplus()))
+        self._emission_rates_prior_concentration = Parameter(emission_rates_prior_concentration,
+                                                             is_frozen=True,
+                                                             bijector=tfb.Invert(tfb.Softplus()))
+        self._emission_rates_prior_rate = Parameter(emission_rates_prior_rate,
+                                                    is_frozen=True,
+                                                    bijector=tfb.Invert(tfb.Softplus()))
 
     @classmethod
     def random_initialization(cls, key, num_states, emission_dim):
@@ -44,6 +60,13 @@ class PoissonHMM(BaseHMM):
     def emission_distribution(self, state):
         return tfd.Independent(tfd.Poisson(rate=self.emission_rates.value[state]),
                                reinterpreted_batch_ndims=1)
+
+    def log_prior(self):
+        lp = tfd.Dirichlet(self._initial_probs_concentration.value).log_prob(self.initial_probs.value)
+        lp += tfd.Dirichlet(self._transition_matrix_concentration.value).log_prob(self.transition_matrix.value).sum()
+        lp += tfd.Gamma(self._emission_rates_prior_concentration.value,
+                          self._emission_rates_prior_rate.value).log_prob(self._emission_rates.value).sum()
+        return lp
 
     def e_step(self, batch_emissions):
         """The E-step computes expected sufficient statistics under the
@@ -64,7 +87,7 @@ class PoissonHMM(BaseHMM):
             # Run the smoother
             posterior = hmm_smoother(self.initial_probs.value,
                                      self.transition_matrix.value,
-                                     self._conditional_logliks(emissions))
+                                     self._compute_conditional_logliks(emissions))
 
             # Compute the initial state and transition probabilities
             initial_probs = posterior.smoothed_probs[0]
@@ -87,10 +110,11 @@ class PoissonHMM(BaseHMM):
         # Map the E step calculations over batches
         return vmap(_single_e_step)(batch_emissions)
 
-    def m_step(self, batch_emissions, batch_posteriors, **kwargs):
+    def _m_step_emissions(self, batch_emissions, batch_posteriors, **kwargs):
         # Sum the statistics across all batches
         stats = tree_map(partial(jnp.sum, axis=0), batch_posteriors)
+
         # Then maximize the expected log probability as a fn of model parameters
-        self._initial_probs.value = tfd.Dirichlet(1.0001 + stats.initial_probs).mode()
-        self._transition_matrix.value = tfd.Dirichlet(1.0001 + stats.trans_probs).mode()
-        self._emission_rates.value = tfd.Gamma(1.1 + stats.sum_x, 1.1 + stats.sum_w).mode()
+        post_concentration = self._emission_rates_prior_concentration.value + stats.sum_x
+        post_rate = self._emission_rates_prior_rate.value + stats.sum_w
+        self._emission_rates.value = tfd.Gamma(post_concentration, post_rate).mode()

--- a/ssm_jax/hmm/models/tests/gaussian_hmm_test.py
+++ b/ssm_jax/hmm/models/tests/gaussian_hmm_test.py
@@ -1,32 +1,31 @@
 import jax.numpy as jnp
-from jax import random
+import jax.random as jr
 from jax import vmap
-from sklearn.datasets import make_spd_matrix
 from ssm_jax.hmm.models.gaussian_hmm import GaussianHMM
 
 
 def get_random_gaussian_hmm_params(key, num_states, num_emissions):
-    initial_key, transition_key, means_key = random.split(key, 3)
-    initial_probabilities = random.uniform(initial_key, shape=(num_states,))
+    initial_key, transition_key, means_key, covs_key = jr.split(key, 4)
+    initial_probabilities = jr.uniform(initial_key, shape=(num_states,))
     initial_probabilities = initial_probabilities / initial_probabilities.sum()
-    transition_matrix = random.uniform(transition_key, shape=(num_states, num_states))
+    transition_matrix = jr.uniform(transition_key, shape=(num_states, num_states))
     transition_matrix = transition_matrix / jnp.sum(initial_probabilities, axis=-1, keepdims=True)
-    emission_means = random.randint(means_key, shape=(num_states, num_emissions), minval=-20.,
+    emission_means = jr.randint(means_key, shape=(num_states, num_emissions), minval=-20.,
                                     maxval=20).astype(jnp.float32)
-    emission_covars = jnp.array([
-        (make_spd_matrix(num_emissions) + 0.1 * jnp.eye(num_emissions)) for _ in range(num_states)
-    ])
+    emission_covar_sqrts = jr.normal(covs_key, (num_states, num_emissions))
+    emission_covars = jnp.einsum('ki, kj->kij', emission_covar_sqrts, emission_covar_sqrts)
+    emission_covars += 1e-1 * jnp.eye(num_emissions)
     return initial_probabilities, transition_matrix, emission_means, emission_covars
 
 
-def test_fit_means(key=random.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
+def test_fit_means(key=jr.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
 
-    init_key, sample_key = random.split(key, 2)
+    init_key, sample_key = jr.split(key, 2)
     initial_probabilities, transition_matrix, emission_means, emission_covars = get_random_gaussian_hmm_params(
         init_key, num_states, num_emissions)
     hmm = GaussianHMM(initial_probabilities, transition_matrix, emission_means, emission_covars)
 
-    keys = random.split(sample_key, num_samples)
+    keys = jr.split(sample_key, num_samples)
     batch_states, batch_emissions = vmap(lambda rng: hmm.sample(rng, 10))(keys)
 
     # Mess up the parameters and see if we can re-learn them.
@@ -40,14 +39,14 @@ def test_fit_means(key=random.PRNGKey(0), num_states=3, num_emissions=3, num_sam
     assert jnp.allclose(hmm.emission_covariance_matrices.value, emission_covars)
 
 
-def test_fit_covars(key=random.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
+def test_fit_covars(key=jr.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
 
-    init_key, sample_key = random.split(key, 2)
+    init_key, sample_key = jr.split(key, 2)
     initial_probabilities, transition_matrix, emission_means, emission_covars = get_random_gaussian_hmm_params(
         init_key, num_states, num_emissions)
     hmm = GaussianHMM(initial_probabilities, transition_matrix, emission_means, emission_covars)
 
-    keys = random.split(sample_key, num_samples)
+    keys = jr.split(sample_key, num_samples)
     batch_states, batch_emissions = vmap(lambda rng: hmm.sample(rng, 10))(keys)
 
     # Mess up the parameters and see if we can re-learn them.
@@ -62,14 +61,14 @@ def test_fit_covars(key=random.PRNGKey(0), num_states=3, num_emissions=3, num_sa
     assert jnp.allclose(hmm.emission_means.value, emission_means)
 
 
-def test_fit_transition_matrix(key=random.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
+def test_fit_transition_matrix(key=jr.PRNGKey(0), num_states=3, num_emissions=3, num_samples=10):
 
-    init_key, sample_key = random.split(key, 2)
+    init_key, sample_key = jr.split(key, 2)
     initial_probabilities, transition_matrix, emission_means, emission_covars = get_random_gaussian_hmm_params(
         init_key, num_states, num_emissions)
     hmm = GaussianHMM(initial_probabilities, transition_matrix, emission_means, emission_covars)
 
-    keys = random.split(sample_key, num_samples)
+    keys = jr.split(sample_key, num_samples)
     batch_states, batch_emissions = vmap(lambda rng: hmm.sample(rng, 10))(keys)
 
     # Mess up the parameters and see if we can re-learn them.

--- a/ssm_jax/hmm/models/tests/learning_test.py
+++ b/ssm_jax/hmm/models/tests/learning_test.py
@@ -40,7 +40,7 @@ def test_hmm_fit_em(num_iters=2):
     test_hmm = GaussianHMM.random_initialization(jr.PRNGKey(1), 2 * true_hmm.num_states, true_hmm.num_obs)
     # Quick test: 2 iterations
     logprobs_em = test_hmm.fit_em(batch_emissions, num_iters=num_iters)
-    assert jnp.allclose(logprobs_em[-1], -3465.368, atol=1e-1)
+    assert jnp.allclose(logprobs_em[-1], -3704.3, atol=1e-1)
     mu = test_hmm.emission_means.value
     assert jnp.alltrue(mu.shape == (10, 2))
     assert jnp.allclose(mu[0, 0], -0.712, atol=1e-1)

--- a/ssm_jax/hmm/models/tests/learning_test.py
+++ b/ssm_jax/hmm/models/tests/learning_test.py
@@ -40,20 +40,20 @@ def test_hmm_fit_em(num_iters=2):
     test_hmm = GaussianHMM.random_initialization(jr.PRNGKey(1), 2 * true_hmm.num_states, true_hmm.num_obs)
     # Quick test: 2 iterations
     logprobs_em = test_hmm.fit_em(batch_emissions, num_iters=num_iters)
-    assert jnp.allclose(logprobs_em[-1], -3600.2395, atol=1e-1)
+    assert jnp.allclose(logprobs_em[-1], -3465.368, atol=1e-1)
     mu = test_hmm.emission_means.value
     assert jnp.alltrue(mu.shape == (10, 2))
     assert jnp.allclose(mu[0, 0], -0.712, atol=1e-1)
 
 
-def test_hmm_fit_sgd(num_iters=2):
+def test_hmm_fit_sgd(num_epochs=2):
     true_hmm, _, batch_emissions = make_rnd_model_and_data()
     print(batch_emissions.shape)
     test_hmm = GaussianHMM.random_initialization(jr.PRNGKey(1), 2 * true_hmm.num_states, true_hmm.num_obs)
     # Quick test: 2 iterations
     optimizer = optax.adam(learning_rate=1e-2)
-    losses = test_hmm.fit_sgd(batch_emissions, optimizer=optimizer, num_epochs=num_iters)
-    assert jnp.allclose(losses[-1], 2.852, atol=1e-1)
+    losses = test_hmm.fit_sgd(batch_emissions, optimizer=optimizer, num_epochs=num_epochs)
+    assert jnp.allclose(losses[-1], 1.3912, atol=1e-1)
     mu = test_hmm.emission_means.value
     assert jnp.alltrue(mu.shape == (10, 2))
     assert jnp.allclose(mu[0, 0], -1.827, atol=1e-1)


### PR DESCRIPTION
- [x] Split `BaseHMM` into `BaseHMM` and `StandardHMM`. The former allows generic initial and transition distributions (e.g., ones that could change with covariates) whereas the latter assumes fixed initial distribution and stationary transition matrix.
- [x] Add priors to HMM models
  - [x] Initial distribution and transition matrix (Dirichlet prior)
  - [x] Bernoulli emissions (Beta prior)
  - [x] Categorical emissions (Dirichlet prior)
  - [x] Gaussian emissions (NIW prior)
  - [x] Multinomial emissions (Dirichlet prior)
  - [x] Poisson emissions (Gamma prior)
- [x] Move `log_prob` and `sample` functions to generic `SSM` class (formerly named `Module`)