### PR TITLE
Modify the base LinearGaussianSSM class and adjust 'inputs' in inference algorithms

### DIFF
--- a/ssm_jax/linear_gaussian_ssm/models.py
+++ b/ssm_jax/linear_gaussian_ssm/models.py
@@ -1,13 +1,11 @@
-from functools import partial
-
 from jax import numpy as jnp
 from jax import random as jr
-from jax import lax, vmap
-from jax.tree_util import register_pytree_node_class, tree_map
+from jax import lax
+from jax.tree_util import register_pytree_node_class
 
 from distrax import MultivariateNormalFullCovariance as MVN
 
-from ssm_jax.linear_gaussian_ssm.inference import lgssm_filter, lgssm_smoother
+from ssm_jax.linear_gaussian_ssm.inference import lgssm_filter, lgssm_smoother, LGSSMParams
 from ssm_jax.utils import PSDToRealBijector
 
 
@@ -43,9 +41,9 @@ class LinearGaussianSSM:
         initial_mean=None,
         initial_covariance=None,
         dynamics_input_weights=None,
-        dynamics_bias=None,
+        dynamics_bias=False,
         emission_input_weights=None,
-        emission_bias=None,
+        emission_bias=False,
     ):
         self.emission_dim, self.state_dim = _get_shape(emission_matrix, 2)
         dynamics_input_dim = dynamics_input_weights.shape[1] if dynamics_input_weights is not None else 0
@@ -63,70 +61,70 @@ class LinearGaussianSSM:
         self.initial_mean = default(initial_mean, jnp.zeros(self.state_dim))
         self.initial_covariance = default(initial_covariance, jnp.eye(self.state_dim))
         self.dynamics_input_weights = default(dynamics_input_weights, jnp.zeros((self.state_dim, self.input_dim)))
-        self.dynamics_bias = default(dynamics_bias, jnp.zeros(self.state_dim))
+        self.dynamics_bias = jnp.zeros(self.state_dim)
         self.emission_input_weights = default(emission_input_weights, jnp.zeros((self.emission_dim, self.input_dim)))
-        self.emission_bias = default(emission_bias, jnp.zeros(self.emission_dim))
+        self.emission_bias = jnp.zeros(self.emission_dim)
 
+        # Add a bias column at the end of the weights if needed
+        self._indic_dyn_bias = dynamics_bias
+        self._indic_ems_bias = emission_bias
+        if self._indic_dyn_bias:
+            self.dynamics_input_weights = jnp.hstack((self.dynamics_input_weights, jnp.ones(self.state_dim, 1)))
+            dynamics_input_dim += 1
+        if self._indic_ems_bias:
+            self.emission_input_weights = jnp.hstack((self.emission_input_weights, jnp.ones(self.emission_dim, 1)))
+            emission_input_dim += 1
+        
         # Check shapes
         assert self.initial_mean.shape == (self.state_dim,)
         assert self.initial_covariance.shape == (self.state_dim, self.state_dim)
         assert self.dynamics_matrix.shape[-2:] == (self.state_dim, self.state_dim)
         assert self.dynamics_input_weights.shape[-2:] == (self.state_dim, self.input_dim)
-        assert self.dynamics_bias.shape[-1:] == (self.state_dim,)
         assert self.dynamics_covariance.shape == (self.state_dim, self.state_dim)
         assert self.emission_input_weights.shape[-2:] == (self.emission_dim, self.input_dim)
-        assert self.emission_bias.shape[-1:] == (self.emission_dim,)
         assert self.emission_covariance.shape == (self.emission_dim, self.emission_dim)
 
     @classmethod
     def random_initialization(cls, key, state_dim, emission_dim, input_dim=0):
-        k1, k2, k3 = jr.split(key, num=3)
         m1 = jnp.zeros(state_dim)
         Q1 = jnp.eye(state_dim)
         # TODO: Sample a random rotation matrix
-        A = 0.99 * jnp.eye(state_dim)
+        F = 0.99 * jnp.eye(state_dim)
         B = jnp.zeros((state_dim, input_dim))
-        b = jnp.zeros(state_dim)
         Q = 0.1 * jnp.eye(state_dim)
-        C = jr.normal(k2, (emission_dim, state_dim))
+        H = jr.normal(key, (emission_dim, state_dim))
         D = jnp.zeros((emission_dim, input_dim))
-        d = jr.normal(k3, (emission_dim,))
         R = 0.1 * jnp.eye(emission_dim)
         return cls(
-            dynamics_matrix=A,
+            dynamics_matrix=F,
             dynamics_covariance=Q,
-            emission_matrix=C,
+            emission_matrix=H,
             emission_covariance=R,
             initial_mean=m1,
             initial_covariance=Q1,
             dynamics_input_weights=B,
-            dynamics_bias=b,
-            emission_input_weights=D,
-            emission_bias=d,
+            emission_input_weights=D
         )
 
     def sample(self, key, num_timesteps, inputs=None):
-        if inputs is None:
-            inputs = jnp.zeros((num_timesteps, 0))
+        inputs_dynamics, inputs_emission = self._inputs_with_bias(num_timesteps, inputs)
 
         # Shorthand for parameters
-        A = self.dynamics_matrix
+        F = self.dynamics_matrix
         B = self.dynamics_input_weights
-        b = self.dynamics_bias
         Q = self.dynamics_covariance
-        C = self.emission_matrix
+        H = self.emission_matrix
         D = self.emission_input_weights
-        d = self.emission_bias
         R = self.emission_covariance
 
         def _step(carry, key_and_input):
             state = carry
-            key, u = key_and_input
+            key, u_dyn, u_ems = key_and_input
 
             # Sample data and next state
             key1, key2 = jr.split(key, 2)
-            emission = MVN(C @ state + D @ u + d, R).sample(seed=key1)
-            next_state = MVN(A @ state + B @ u + b, Q).sample(seed=key2)
+            emission = MVN(H @ state + D @ u_ems, R).sample(seed=key1)
+            next_state = MVN(F @ state + B @ u_dyn, Q).sample(seed=key2)
             return next_state, (state, emission)
 
         # Initialize
@@ -135,7 +133,7 @@ class LinearGaussianSSM:
 
         # Run the sampler
         keys = jr.split(key, num_timesteps)
-        _, (states, emissions) = lax.scan(_step, init_state, (keys, inputs))
+        _, (states, emissions) = lax.scan(_step, init_state, (keys, inputs_dynamics, inputs_emission))
         return states, emissions
 
     def log_prob(self, states, emissions, inputs=None):
@@ -144,15 +142,16 @@ class LinearGaussianSSM:
         # Check shapes
         assert states.shape == (num_timesteps, self.state_dim)
         assert emissions.shape == (num_timesteps, self.emission_dim)
-        if inputs is None:
-            inputs = jnp.zeros((num_timesteps, 0))
-        assert inputs.shape == (num_timesteps, self.input_dim)
+        
+        inputs_dynamics, inputs_emission = self._inputs_with_bias(num_timesteps, inputs)
+        assert inputs_dynamics.shape == (num_timesteps, self.input_dim+self.dynamics_bias)
+        assert inputs_emission.shape == (num_timesteps, self.input_dim+self.emission_bias)
 
         # Compute log prob
         lp = MVN(self.initial_mean, self.initial_covariance).log_prob(states[0])
         lp += (
             MVN(
-                states[:-1] @ self.dynamics_matrix.T + inputs[:-1] @ self.dynamics_input_weights.T + self.dynamics_bias,
+                states[:-1] @ self.dynamics_matrix.T + inputs_dynamics[:-1] @ self.dynamics_input_weights.T,
                 self.dynamics_covariance,
             )
             .log_prob(states[1:])
@@ -160,7 +159,7 @@ class LinearGaussianSSM:
         )
         lp += (
             MVN(
-                states @ self.emission_matrix.T + inputs @ self.emission_input_weights.T + self.emission_bias,
+                states @ self.emission_matrix.T + inputs_emission @ self.emission_input_weights.T,
                 self.emission_covariance,
             )
             .log_prob(emissions)
@@ -169,14 +168,20 @@ class LinearGaussianSSM:
         return lp
 
     def marginal_log_prob(self, emissions, inputs=None):
-        filtered_posterior = lgssm_filter(self, emissions, inputs)
+        num_timesteps = len(emissions)
+        inputs_dynamics, inputs_emission = self._inputs_with_bias(num_timesteps, inputs)
+        filtered_posterior = lgssm_filter(self, emissions, inputs_dynamics, inputs_emission)
         return filtered_posterior.marginal_loglik
 
     def filter(self, emissions, inputs=None):
-        return lgssm_filter(self, emissions, inputs)
+        num_timesteps = len(emissions)
+        inputs_dynamics, inputs_emission = self._inputs_with_bias(num_timesteps, inputs)
+        return lgssm_filter(self, emissions, inputs_dynamics, inputs_emission)
 
     def smoother(self, emissions, inputs=None):
-        return lgssm_smoother(self, emissions, inputs)
+        num_timesteps = len(emissions)
+        inputs_dynamics, inputs_emission = self._inputs_with_bias(num_timesteps, inputs)
+        return lgssm_smoother(self, emissions, inputs_dynamics, inputs_emission)
 
     # Properties to allow unconstrained optimization and JAX jitting
     @property
@@ -187,11 +192,9 @@ class LinearGaussianSSM:
             PSDToRealBijector.forward(self.initial_covariance),
             self.dynamics_matrix,
             self.dynamics_input_weights,
-            self.dynamics_bias,
             PSDToRealBijector.forward(self.dynamics_covariance),
             self.emission_matrix,
             self.emission_input_weights,
-            self.emission_bias,
             PSDToRealBijector.forward(self.emission_covariance),
         )
 
@@ -201,12 +204,10 @@ class LinearGaussianSSM:
         initial_covariance = PSDToRealBijector.inverse(unconstrained_params[1])
         dynamics_matrix = unconstrained_params[2]
         dynamics_input_weights = unconstrained_params[3]
-        dynamics_bias = unconstrained_params[4]
-        dynamics_covariance = PSDToRealBijector.inverse(unconstrained_params[5])
-        emission_matrix = unconstrained_params[6]
-        emission_input_weights = unconstrained_params[7]
-        emission_bias = unconstrained_params[8]
-        emission_covariance = PSDToRealBijector.inverse(unconstrained_params[9])
+        dynamics_covariance = PSDToRealBijector.inverse(unconstrained_params[4])
+        emission_matrix = unconstrained_params[5]
+        emission_input_weights = unconstrained_params[6]
+        emission_covariance = PSDToRealBijector.inverse(unconstrained_params[7])
         return cls(
             dynamics_matrix=dynamics_matrix,
             dynamics_covariance=dynamics_covariance,
@@ -215,9 +216,7 @@ class LinearGaussianSSM:
             initial_mean=initial_mean,
             initial_covariance=initial_covariance,
             dynamics_input_weights=dynamics_input_weights,
-            dynamics_bias=dynamics_bias,
             emission_input_weights=emission_input_weights,
-            emission_bias=emission_bias,
         )
 
     @property
@@ -234,3 +233,16 @@ class LinearGaussianSSM:
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         return cls.from_unconstrained_params(children, aux_data)
+    
+    def _inputs_with_bias(self, num_timesteps, inputs):
+        if inputs is None:
+            inputs = jnp.zeros((num_timesteps, 0))
+        
+        inputs_dynamics = inputs if not self._indic_dyn_bias else \
+            jnp.hstack((inputs, jnp.ones((num_timesteps, 1))))
+        
+        inputs_emission = inputs if not self._indic_ems_bias else \
+            jnp.hstack((inputs, jnp.ones((num_timesteps, 1))))
+            
+        return inputs_dynamics, inputs_emission
+


### PR DESCRIPTION
This PR makes the following change:

1. Modify the base LinearGaussianSSM class such that the parameters "dynamics_bias=False" and 'emission_bias=False' are now both boolean variables, instead of vectors of biases.
2. The inputs are now separated into "inputs_dynamics" and "inputs_emission". If 'dynamics_bias=True', then "inputs_dynamics" is appended with a column of 1s at the end, and B is extended by a column of 1s. The change when 'emission_bias=True' is similar.
3. When calling the inference algorithms (filter and smoother) inside the class, two inputs are passed. So the arguments of the inference algorithms are modified accordingly. 
4. However, inside the class, the feature "self.dynamics_bias = self.emission_bias = jnp.zeros()", and the indicator variable 'dynamics_bias' is saved in the feature under the name ''self._indic_dyn_bias". While strange at first glance, this makes sure that the inference algorithms still run when called as independent functions that take an lgssm object as inputs (as it has code like 'params.dynamics_bias'). 

Tests in inference_test.py and demos_test.py are passed, except for tests related to learning. 