### PR TITLE
Belief Propagation on a Gaussian Chain

### DIFF
--- a/ssm_jax/bp/gauss_bp.py
+++ b/ssm_jax/bp/gauss_bp.py
@@ -1,0 +1,130 @@
+from jax import numpy as jnp
+from jax import tree_map
+
+def block_split(A, idx):
+    """Split square matrix A into four blocks at `idx`
+    
+    For example splitting
+        [[0, 1, 2],
+         [3, 4, 5],
+         [6, 7 ,8]]
+    at idx = 2 produces:
+        ([[0,1],[3,4]],
+         [[2],[5]],
+         [[6,7]],
+         [[8]]).
+
+    Args:
+        A (D, D): array.
+        idx: int.
+    Returns:
+        A11 (dim1, dim1)
+        A12 (dim2, dim1)
+        A21 (dim1, dim2)
+        A22 (dim2, dim2)
+       where `dim1 + dim2 == D` and `dim2 = D - idx`.
+    """
+    split_array = jnp.array([idx])
+    vblocks = jnp.vsplit(A,split_array)
+    # [leaf for tree in forest for leaf in tree]
+    blocks = [block for vblock in vblocks for block in jnp.hsplit(vblock,split_array)]
+    # Can also do:
+    #   blocks = tree_map(lambda arr: jnp.hsplit(arr,split_array),vblocks)
+    # followed by a tree_flatten
+    return blocks
+
+
+def block_join(A11, A12, A21, A22):
+    return jnp.block([[A11, A12],[A21,A22]])
+
+def block_rev(A,idx):
+    blocks = block_split(A,idx)
+    return block_join(*blocks[::-1])
+
+def vec_swap(a,idx):
+    return jnp.concatenate((a[idx:],a[:idx]))
+
+def info_marginalise(K_blocks, hs):
+    """Calculate the parameters of marginalised MVN.
+    
+    For x1, x2 joint distributed as
+        p(x1, x2) = Nc(x1,x2| h, K),
+    the marginal distribution of x1 is given by:
+        p(x2) = \int p(x1, x2) dx1 = Nc(x2 | h2_marg, K2_marg)
+    where,
+        h2_marg = h2 - K21 K11^{-1} h1
+        K2_marg = K22 - K21 K11^{-1} K12
+
+    Args:
+        K_blocks: blocks of the joint precision matrix, (K1, K12, K22),
+                    K1 (dim1,dim1),
+                    K12 (dim1, dim2),
+                    K22 (dim2, dim2).
+        hs (D,1): joint precision weighted mean, (h1, h2):
+                    h1 (dim1, 1),
+                    h2 (dim2, 1).
+    Returns:
+        K2_marg (dim2, dim2): marginal precision matrix.
+        h2_marg (dim2,1): marginal precision weighted mean.
+    """
+    K11, K12, K22 = K_blocks
+    h1, h2 = hs 
+    G = jnp.linalg.solve(K11,K12)
+    K2_marg = K22 - K12.T @ G
+    h2_marg = h2 - G.T @ h1
+    return K2_marg, h2_marg
+
+def info_condition(K11, K12, h1, y):
+    # TODO: Decide on (x1, x2) vs (x,y)
+    """Calculate the parameters of MVN after conditioning.
+
+    For x,y with joint mvn
+        p(x1,x2) = Nc(x1,x2 | h, K),
+    where h, K can be partitioned into,
+        h = [h1, h2]
+        K = [[K11, K12],
+            [[K21, K22]]
+    the distribution of x condition on a particular value of y is given by,
+        p(x1|x2) = Nc(x1 | h1_cond, K1_cond),
+    where
+        h1_cond = h1 - K12 x2
+        K1_cond = K11
+    """
+    return K11, h1 - K12 @ y
+
+def potential_from_conditional_linear_gaussian(A,u,Lambda):
+    """Express a conditional linear gaussian as a potential in canonical form.
+    
+    p(y|z) = N(y | Az + u, Lambda^{-1})
+           \prop exp( -0.5(y z)^T K (y z) + (y z)^T h )
+    where,
+        K = (Lambda; -Lambda A,  -A.T Lambda; A.T Lambda A)
+        h = (Lambda u, -A.T Lambda u)
+
+    Args:
+        A (dim1, dim2)
+        u (dim1,1)
+        Lambda (dim1, dim1)
+    Returns:
+        K (dim1 + dim2, dim1 + dim2)
+        h (dim1 + dim2,1)
+    """
+    Kyy = Lambda 
+    Kyz  = -Lambda @ A
+    Kzz = -A.T @ Kyz
+    hy = Lambda @ u 
+    hz = -A.T @ hy
+    # TODO: Might be more natural to frame this the other way round, return. (x2 | x1)
+    #        or at least just return Kzy because we tend to want to condition on y.
+    return (Kyy, Kyz, Kzz), (hy,hz)
+
+
+def info_multiply(params1, params2):
+    """Calculate parameters resulting from multiplying gaussians."""
+    return tree_map(lambda a,b: a + b, params1, params2)
+
+
+def info_divide(params1, params2):
+    """Calculate parameters resulting from dividing gaussians."""
+    return tree_map(lambda a,b: a - b, params1, params2)
+

--- a/ssm_jax/bp/gauss_bp_test.py
+++ b/ssm_jax/bp/gauss_bp_test.py
@@ -1,26 +1,27 @@
-from jax import numpy as jnp 
+from jax import numpy as jnp
 
-from ssm_jax.bp.gauss_bp import potential_from_conditional_linear_gaussian, info_condition
+from ssm_jax.bp.gauss_bp_utils import potential_from_conditional_linear_gaussian, info_condition
+
+_all_close = lambda x, y: jnp.allclose(x, y, rtol=1e-3, atol=1e-3)
+
 
 def test_clg_potential():
-    """Test consistency of conditional linear gaussian potential function 
+    """Test consistency of conditional linear gaussian potential function
      with joint conditioning function.
 
     p(y|z) = N(y | Az + u, Lambda^{-1})
     """
     # Parameters
-    A = jnp.array([[1., 1., 0., 1.],
-                   [0., 1., 2., 3.]])
-    z = jnp.ones((4,1))
-    u = jnp.ones((2,1))
-    Lambda = jnp.ones((2,2)) * 2
+    A = jnp.array([[1.0, 1.0, 0.0, 1.0], [0.0, 1.0, 2.0, 3.0]])
+    z = jnp.ones((4, 1))
+    offset = jnp.ones((2, 1))
+    Lambda = jnp.ones((2, 2)) * 2
 
     # Form joint potential \phi(y,z)
-    (Kzz, Kzy, Kyy), (hz,hy) = potential_from_conditional_linear_gaussian(A,u,Lambda)
+    (Kzz, Kzy, Kyy), (hz, hy) = potential_from_conditional_linear_gaussian(A, offset, Lambda)
     # Condition on z
     K_cond, h_cond = info_condition(Kyy, Kzy.T, hy, z)
 
-    # Check that we end up where we started...
-    assert jnp.allclose(Lambda, K_cond, rtol=1e-3)
-    assert jnp.allclose(Lambda @ (A @ z + u), h_cond, rtol=1e-3)
-
+    # TODO: get this comment right.
+    assert _all_close(Lambda, K_cond)
+    assert _all_close(Lambda @ (A @ z + offset), h_cond)

--- a/ssm_jax/bp/gauss_bp_test.py
+++ b/ssm_jax/bp/gauss_bp_test.py
@@ -1,0 +1,26 @@
+from jax import numpy as jnp 
+
+from ssm_jax.bp.gauss_bp import potential_from_conditional_linear_gaussian, info_condition
+
+def test_clg_potential():
+    """Test consistency of conditional linear gaussian potential function 
+     with joint conditioning function.
+
+    p(y|z) = N(y | Az + u, Lambda^{-1})
+    """
+    # Parameters
+    A = jnp.array([[1., 1., 0., 1.],
+                   [0., 1., 2., 3.]])
+    z = jnp.ones((4,1))
+    u = jnp.ones((2,1))
+    Lambda = jnp.ones((2,2)) * 2
+
+    # Form joint potential \phi(y,z)
+    K, h = potential_from_conditional_linear_gaussian(A,u,Lambda)
+    # Condition on z
+    K_cond, h_cond = info_condition(K,h,z)
+
+    # Check that we end up where we started...
+    assert jnp.allclose(Lambda, K_cond, rtol=1e-2)
+    assert jnp.allclose(Lambda @ (A @ z + u), h_cond, rtol=1e-2)
+

--- a/ssm_jax/bp/gauss_bp_test.py
+++ b/ssm_jax/bp/gauss_bp_test.py
@@ -16,11 +16,11 @@ def test_clg_potential():
     Lambda = jnp.ones((2,2)) * 2
 
     # Form joint potential \phi(y,z)
-    K, h = potential_from_conditional_linear_gaussian(A,u,Lambda)
+    (Kzz, Kzy, Kyy), (hz,hy) = potential_from_conditional_linear_gaussian(A,u,Lambda)
     # Condition on z
-    K_cond, h_cond = info_condition(K,h,z)
+    K_cond, h_cond = info_condition(Kyy, Kzy.T, hy, z)
 
     # Check that we end up where we started...
-    assert jnp.allclose(Lambda, K_cond, rtol=1e-2)
-    assert jnp.allclose(Lambda @ (A @ z + u), h_cond, rtol=1e-2)
+    assert jnp.allclose(Lambda, K_cond, rtol=1e-3)
+    assert jnp.allclose(Lambda @ (A @ z + u), h_cond, rtol=1e-3)
 

--- a/ssm_jax/bp/gauss_bp_utils_test.py
+++ b/ssm_jax/bp/gauss_bp_utils_test.py
@@ -22,6 +22,7 @@ def test_clg_potential():
     # Condition on z
     K_cond, h_cond = info_condition(Kyy, Kzy.T, hy, z)
 
-    # TODO: get this comment right.
+    # Check that conditioning phi(z,y) on z returns the same parameters as 
+    #  explicitly calculating linear conditional.
     assert _all_close(Lambda, K_cond)
     assert _all_close(Lambda @ (A @ z + offset), h_cond)

--- a/ssm_jax/bp/gauss_chain.py
+++ b/ssm_jax/bp/gauss_chain.py
@@ -1,0 +1,152 @@
+from functools import partial
+import chex
+import jax
+from jax import vmap, lax, jit
+from jax import numpy as jnp
+from ssm_jax.bp.gauss_bp import (
+    potential_from_conditional_linear_gaussian,
+    pair_cpot_condition,
+    pair_cpot_marginalise,
+    pair_cpot_absorb_message,
+    info_multiply,
+    info_divide
+)
+
+
+@chex.dataclass
+class GaussianChainPotentials:
+    """Container class for Gaussian Chain Potentials.
+
+      Both `latent_pots` and `obs_pots` contain the canonical parameters for a
+        gaussian potential over a pair of variables.
+
+     It is assumed that the latent and observed variables have the same shape
+      along the chain (but not necessarily the same as each other). As occurs for
+      instance in temporal models. This means that the potential parameters can be
+      stacked as rows for and used with `jax.vmap` and `jax.lax.scan`.
+
+      lambda_pots: A tuple containing the parameters for each pairwise latent
+                    clique potential - ((K11, K12, K22),(h1, h2)). The ith row
+                    of each array contains parameters for the clique containing
+                    the pair of latent states at times (i, i+1).
+                    Arrays have shapes:
+                        K11, K12, K22 - (T-1, D_hid, D_hid)
+                        h1, h2 - (T-1, D_hid)
+
+      obs_pots: A tuple containing the parameters for each pairwise
+                      emission clique potential - ((K11, K12, K22),(h1, h2)).
+                      Arrays have shapes:
+                         K11 - (T, D_hid, D_hid)
+                         K12 - (T, D_hid, D_obs)
+                         K22 - (T, D_obs, D_obs)
+                         h1 - (T, D_hid)
+                         h2 - (T, D_obs)
+    """
+
+    latent_pots: chex.Array
+    obs_pots: chex.Array
+
+
+def gauss_chain_potentials_from_lgssm(lgssm_params, inputs):
+    """Construct pairwise latent and emission clique potentials from model.
+
+    Args:
+        lgssm_params: an LGSSMInfoParams instance.
+        inputs: (T,D_in): array of inputs.
+
+    Returns:
+        prior_pot: A tuple of parameters representing the prior potential,
+                    (Lambda0, eta0)
+    """
+    B, b = lgssm_params.dynamics_input_weights, lgssm_params.dynamics_bias
+    D, d = lgssm_params.emission_input_weights, lgssm_params.emission_bias
+    latent_net_inputs = vmap(jnp.dot, (None, 0))(B, inputs) + b
+    emission_net_inputs = vmap(jnp.dot, (None, 0))(D, inputs) + d
+
+    F, Q_prec = lgssm_params.dynamics_matrix, lgssm_params.dynamics_precision
+    H, R_prec = lgssm_params.emission_matrix, lgssm_params.emission_precision
+    latent_pots = vmap(potential_from_conditional_linear_gaussian, (None, 0, None))(F, latent_net_inputs[:-1], Q_prec)
+    emission_pots = vmap(potential_from_conditional_linear_gaussian, (None, 0, None))(H, emission_net_inputs, R_prec)
+    gauss_chain_potentials = GaussianChainPotentials(latent_pots=latent_pots, obs_pots=emission_pots)
+
+    Lambda0, mu0 = lgssm_params.initial_precision, lgssm_params.initial_mean
+    prior_pot = (Lambda0, Lambda0 @ mu0)
+
+    return prior_pot, gauss_chain_potentials
+
+
+def gauss_chain_bp(gauss_chain_pots, prior_pot, obs):
+    """Belief propagation on a Gaussian chain.
+
+    Calculate the canonical parameters for the marginal probability of latent
+    states conditioned on the full set of observation,
+      p(x_t | y_{1:T}).
+
+    Args:
+        gauss_chain_pots: GaussianChainPotentials object containing pairwise
+                            potentials for the latent and observed variables.
+        prior_pot: parameters of the prior potential for the first state in
+                    the chain, (Lambda0, eta0).
+        obs (T,D_obs): Array containing the observations.
+
+    Returns:
+        bels_down: canonical parameters of marginal distribution of each latent 
+                    state condition on all observations, (K_down, h_down) with
+                    shapes,
+                       K_down (T, D_hid, D_hid)
+                       h_down (T, D_hid).
+    """
+    latent_pots, emission_pots = gauss_chain_pots.to_tuple()
+
+    # Extract first emission  potential
+    init_emission_pot = jax.tree_map(lambda a: a[0], emission_pots)
+    emission_pots_rest = jax.tree_map(lambda a: a[1:], emission_pots)
+
+    # Combine first emission message with prior
+    init_emission_message = pair_cpot_condition(init_emission_pot, obs[0], obs_var=2)
+    init_carry = info_multiply(prior_pot, init_emission_message)
+
+    def _forward_step(carry, x):
+        prev_bel = carry
+        latent_pot, emission_pot, y = x
+
+        # Calculate latent message
+        latent_pot = pair_cpot_absorb_message(latent_pot, prev_bel, message_var=1)
+        latent_message = pair_cpot_marginalise(latent_pot, marg_var=2)
+
+        # Calculate emission message
+        emission_message = pair_cpot_condition(emission_pot, y, obs_var=2)
+
+        # Combine messages
+        bel = info_multiply(latent_message, emission_message)
+
+        return bel, (bel, latent_message)
+
+    # Message pass forwards along chain
+    _, (bels, messages) = lax.scan(_forward_step, init_carry, (latent_pots, emission_pots_rest, obs[1:]))
+    # Append first belief
+    bels_up = jax.tree_map(lambda h, t: jnp.row_stack((h[None, ...], t)), init_carry, bels)
+
+    # Extract final belief
+    init_carry = jax.tree_map(lambda a: a[-1], bels_up)
+    bels_rest = jax.tree_map(lambda a: a[:-1], bels_up)
+
+    def _backward_step(carry, x):
+        prev_bel = carry
+        bel, message_up, latent_pot = x
+
+        # Divide out forward message
+        bel_minus_message_up = info_divide(prev_bel, message_up)
+        # Absorb into joint potential
+        latent_pot = pair_cpot_absorb_message(latent_pot, bel_minus_message_up, message_var=2)
+        message_down = pair_cpot_marginalise(latent_pot, marg_var=1)
+
+        bel = info_multiply(bel, message_down)
+        return bel, bel
+
+    # Message pass back along chain
+    _, bels_down = lax.scan(_backward_step, init_carry, (bels_rest, messages, latent_pots), reverse=True)
+    # Append final belief
+    bels_down = jax.tree_map(lambda h, t: jnp.row_stack((h, t[None, ...])), bels_down, init_carry)
+
+    return bels_down

--- a/ssm_jax/bp/gauss_chain_test.py
+++ b/ssm_jax/bp/gauss_chain_test.py
@@ -5,6 +5,8 @@ from ssm_jax.bp.gauss_chain import gauss_chain_potentials_from_lgssm, gauss_chai
 from ssm_jax.linear_gaussian_ssm.info_inference import lgssm_info_smoother
 from ssm_jax.linear_gaussian_ssm.info_inference_test import build_lgssm_moment_and_info_form
 
+_all_close = lambda x,y: jnp.allclose(x,y,rtol=1e-3, atol=1e-3)
+
 def test_gauss_chain_bp():
     """Test that Gaussian chain belief propagation gets the same results as 
      information form RTS smoother."""
@@ -19,13 +21,12 @@ def test_gauss_chain_bp():
 
     lgssm_info_posterior = lgssm_info_smoother(lgssm_info, y, inputs)
 
-    prior_pot, chain_pots = gauss_chain_potentials_from_lgssm(lgssm_info, inputs)
+    chain_pots = gauss_chain_potentials_from_lgssm(lgssm_info, inputs)
 
-    bels = gauss_chain_bp(chain_pots, prior_pot, y)
-    Ks, hs = bels
+    smoothed_bels = gauss_chain_bp(chain_pots, y)
+    Ks, hs = smoothed_bels
 
-    assert jnp.allclose(lgssm_info_posterior.smoothed_precisions,Ks,
-                       rtol=1e-3)
-    assert jnp.allclose(lgssm_info_posterior.smoothed_etas,hs,
-                       rtol=1e-3)
+    assert _all_close(lgssm_info_posterior.smoothed_precisions,Ks)
+    assert _all_close(lgssm_info_posterior.smoothed_etas,hs)
+                    
 

--- a/ssm_jax/bp/gauss_chain_test.py
+++ b/ssm_jax/bp/gauss_chain_test.py
@@ -1,0 +1,31 @@
+from jax import numpy as jnp
+from jax import random as jr
+
+from ssm_jax.bp.gauss_chain import gauss_chain_potentials_from_lgssm, gauss_chain_bp
+from ssm_jax.lgssm.info_inference import lgssm_info_smoother
+from ssm_jax.lgssm.info_inference_test import build_lgssm_moment_and_info_form
+
+def test_gauss_chain_bp():
+    """Test that Gaussian chain belief propagation gets the same results as 
+     information form RTS smoother."""
+
+    lgssm, lgssm_info = build_lgssm_moment_and_info_form()
+
+    key = jr.PRNGKey(111)
+    num_timesteps = 15
+    input_size = lgssm.dynamics_input_weights.shape[1]
+    inputs = jnp.zeros((num_timesteps, input_size))
+    z, y = lgssm.sample(key, num_timesteps, inputs)
+
+    lgssm_info_posterior = lgssm_info_smoother(lgssm_info, y, inputs)
+
+    prior_pot, chain_pots = gauss_chain_potentials_from_lgssm(lgssm_info, inputs)
+
+    bels = gauss_chain_bp(chain_pots, prior_pot, y)
+    Ks, hs = bels
+
+    assert jnp.allclose(lgssm_info_posterior.smoothed_precisions,Ks,
+                       rtol=1e-3)
+    assert jnp.allclose(lgssm_info_posterior.smoothed_etas,hs,
+                       rtol=1e-3)
+

--- a/ssm_jax/bp/gauss_chain_test.py
+++ b/ssm_jax/bp/gauss_chain_test.py
@@ -2,8 +2,8 @@ from jax import numpy as jnp
 from jax import random as jr
 
 from ssm_jax.bp.gauss_chain import gauss_chain_potentials_from_lgssm, gauss_chain_bp
-from ssm_jax.lgssm.info_inference import lgssm_info_smoother
-from ssm_jax.lgssm.info_inference_test import build_lgssm_moment_and_info_form
+from ssm_jax.linear_gaussian_ssm.info_inference import lgssm_info_smoother
+from ssm_jax.linear_gaussian_ssm.info_inference_test import build_lgssm_moment_and_info_form
 
 def test_gauss_chain_bp():
     """Test that Gaussian chain belief propagation gets the same results as 

--- a/ssm_jax/linear_gaussian_ssm/info_inference_test.py
+++ b/ssm_jax/linear_gaussian_ssm/info_inference_test.py
@@ -23,9 +23,9 @@ def info_to_moment_form(etas, Lambdas):
     return means, covs
 
 
-class TestInfoFilteringAndSmoothing:
-    """Test information form filtering and smoothing by comparing it to moment
-    form.
+def build_lgssm_moment_and_info_form():
+    """Construct example LinearGaussianSSM and equivalent LGSSMInfoParams 
+    object for testing.
     """
 
     delta = 1.0
@@ -79,10 +79,20 @@ class TestInfoFilteringAndSmoothing:
         emission_input_weights=D,
         emission_bias=d,
     )
+    return lgssm, lgssm_info
+
+
+class TestInfoFilteringAndSmoothing:
+    """Test information form filtering and smoothing by comparing it to moment
+    form.
+    """
+
+    lgssm, lgssm_info = build_lgssm_moment_and_info_form()
 
     # Sample data from model.
     key = jr.PRNGKey(111)
     num_timesteps = 15
+    input_size = lgssm.dynamics_input_weights.shape[1]
     inputs = jnp.zeros((num_timesteps, input_size))
     x, y = lgssm.sample(key, num_timesteps, inputs)
 


### PR DESCRIPTION
This PR contains a starting point for gaussian belief propagation and a working implementation of message passing on a Gaussian chain.

There are two main components to the PR:

## Functions to manipulate Gaussian canonical potentials
These are contained in `bp/gaus_bp.py`.

These consist of the fundamental building blocks used to manipulate/construct canonical potentials:
- `info_condition`
- `info_marginalise`
- `info_multiply`
- `info_divide`
- `potential_from_conditional_linear_gaussian`

which do what they say on the tin. The consistency of `info_condition` and `potential_from_conditional_linear_gaussian` is tested in `gaus_bp_test.py`.

`gaus_bp` also contains some wrapper functions to apply these basic operations to the special case of canonical potentials over a pair of multivariate normal variables `pair_cpot_*`.

Going forward with the more general case it will likely be helpful to have functions to manipulate/extract the blocks of a precision matrix, `gaus_bp.py` contains some of these functions even though they are not currently in use.

## Belief propagation on a Gaussian chain.

Contained in `gaus_chain.py`.

At present it is limited to cases where dimensions remain constant along the chain (as is the case for chains representing state-space models).

In the current implementation gaussians potentials have a very lightweight representation:
- Potentials including a single variable are represented as a tuple `(K, h)` of the precision matrix and potential vector.
- Potentials over two variables are represented as a nested tuple of `((K11, K12, K22), (h1, h2))` containing blocks of the precision matrix and segments of the potential vector.

These are treated as simple `PyTrees` by jax and  the approach plays quite nicely with `vmap` and `scan` as for chains each leaf can just be replaced with a stacked rows of the corresponding parameter, with each row containing the parameters for a single time point.

A simple container dataclass `GaussianChainPotentials` provides a wrapper for the pairwise latent and emission potentials associated with a state-space model.

`gaus_chain_test.py` tests this implementation against `lgssm/info_inference` RTS smoothing.

## Further comments

- I am not particularly wedded to the current file structure or name conventions.
  - For instance `GaussianChainPotentials` could be moved to a `potentials.py` file.
  - Names could better reflect the limitation of fixed dimension along the chain.
- Could add wrapper classes the individual potentials (something currently only enjoyed by the entire chain) but in the current implementation they are immediately pulled out as rows from the leaves of the chain potential PyTrees and so the wrapping/unwrapping as a special object feels a bit superfluous.
  - The exception to this is the `prior_potential` which at present does 'float out in the open' as just an unnamed tuple.
- Perhaps should register `GaussianChainPotentials` as a `PyTree` node.