### PR TITLE
Add cmgf_multiclass_logreg_demo.ipynb

### DIFF
--- a/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
+++ b/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
@@ -52,7 +52,7 @@
       "metadata": {
         "id": "Vo3x6Kglg4IY"
       },
-      "execution_count": 40,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -70,7 +70,7 @@
       "metadata": {
         "id": "uEBbL-EJnWxZ"
       },
-      "execution_count": 32,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -92,7 +92,7 @@
       "metadata": {
         "id": "NDRvXsqQpcDv"
       },
-      "execution_count": 33,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -126,7 +126,7 @@
       "metadata": {
         "id": "4kS6np-HELar"
       },
-      "execution_count": 34,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -164,7 +164,7 @@
       "metadata": {
         "id": "q713feGREIXA"
       },
-      "execution_count": 35,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -214,7 +214,7 @@
       "metadata": {
         "id": "saBspc73FGNf"
       },
-      "execution_count": 36,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -238,7 +238,7 @@
           "base_uri": "https://localhost:8080/"
         }
       },
-      "execution_count": 37,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -284,7 +284,7 @@
         "id": "RZJFUH_kEgSy",
         "outputId": "f833924a-afcf-49c4-bd9a-864086ee0169"
       },
-      "execution_count": 38,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -311,7 +311,7 @@
         "id": "vnsOc-wiGQ1U",
         "outputId": "2da8b5a0-a77c-4014-ee1f-4899364b813d"
       },
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",

--- a/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
+++ b/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
@@ -1,0 +1,355 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Online Multiclass Logistic Regression using CMGF"
+      ],
+      "metadata": {
+        "id": "4c2rXBc6oQKt"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##0. Imports"
+      ],
+      "metadata": {
+        "id": "D15lpL3fD7f1"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Silence WARNING:root:The use of `check_types` is deprecated and does not have any effect.\n",
+        "# https://github.com/tensorflow/probability/issues/1523\n",
+        "import logging\n",
+        "\n",
+        "logger = logging.getLogger()\n",
+        "\n",
+        "\n",
+        "class CheckTypesFilter(logging.Filter):\n",
+        "    def filter(self, record):\n",
+        "        return \"check_types\" not in record.getMessage()\n",
+        "\n",
+        "\n",
+        "logger.addFilter(CheckTypesFilter())"
+      ],
+      "metadata": {
+        "id": "Vo3x6Kglg4IY"
+      },
+      "execution_count": 40,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "try:\n",
+        "    from ssm_jax.cond_moments_gaussian_filter.inference import *\n",
+        "    from ssm_jax.cond_moments_gaussian_filter.containers import *\n",
+        "except ModuleNotFoundError:\n",
+        "    print('installing ssm_jax')\n",
+        "    %pip install -qq git+https://github.com/probml/ssm-jax.git\n",
+        "    from ssm_jax.cond_moments_gaussian_filter.inference import *\n",
+        "    from ssm_jax.cond_moments_gaussian_filter.containers import *"
+      ],
+      "metadata": {
+        "id": "uEBbL-EJnWxZ"
+      },
+      "execution_count": 32,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import jax.random as jr\n",
+        "from sklearn.datasets import make_classification\n",
+        "from sklearn.model_selection import cross_val_score\n",
+        "from sklearn.model_selection import RepeatedStratifiedKFold\n",
+        "from sklearn.linear_model import LogisticRegression\n",
+        "from sklearn import preprocessing\n",
+        "from sklearn.base import BaseEstimator, ClassifierMixin\n",
+        "from sklearn.preprocessing import OneHotEncoder"
+      ],
+      "metadata": {
+        "id": "NDRvXsqQpcDv"
+      },
+      "execution_count": 33,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 1. CMGF Online Multiclass Logistic Regression"
+      ],
+      "metadata": {
+        "id": "2MIMhuR-EF47"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "First, we generate and standardize random dataset with 10 features and 4 classes."
+      ],
+      "metadata": {
+        "id": "W0rBl8IwEg6w"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_points, num_features, num_classes = 10000, 5, 4\n",
+        "input, output = make_classification(n_samples=num_points, n_features=num_features, \n",
+        "                                    n_informative=num_features, n_redundant=0, n_classes=num_classes, random_state=2)\n",
+        "scaler = preprocessing.StandardScaler().fit(input)\n",
+        "input, output = jnp.array(scaler.transform(input)), jnp.array(output)\n",
+        "input_with_bias = jnp.concatenate([jnp.ones((num_points, 1)), input], axis=1)"
+      ],
+      "metadata": {
+        "id": "4kS6np-HELar"
+      },
+      "execution_count": 34,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that the moments of a (one-hot-encoded) categorical distribution with $K$ possible classes are as follows:\n",
+        "\n",
+        "$$\\mathbb{E}[\\vec{y}|\\vec{x}, \\textbf{W}] =  \\begin{pmatrix} \\sigma_2(\\textbf{W}^T\\vec{x}) \\\\ \\sigma_3(\\textbf{W}^T\\vec{x}) \\\\ \\vdots \\\\ \\sigma_K(\\textbf{W}^T\\vec{x}) \\end{pmatrix}\n",
+        "$$\n",
+        "$$Cov[\\vec{y}|\\vec{x}, \\textbf{W}] = \\begin{pmatrix} p_2 (1 - p_2) & -p_2 p_3 & \\dots & -p_2 p_K \\\\\n",
+        "-p_2 p_3 & p_3 (1 - p_3) & \\dots  & -p_3 p_K \\\\\n",
+        "\\vdots & \\vdots & \\ddots & \\vdots \\\\\n",
+        "-p_2 p_K & -p_3 p_K & \\dots & p_K (1 - p_K)\n",
+        " \\end{pmatrix}$$\n",
+        "where $\\vec{\\sigma}(\\cdot)$ is the softmax function.\n",
+        "\n",
+        "Note that in order to prevent the \"Dummy Variable Trap,\" we drop the first column.\n",
+        "\n",
+        "Thus, we can build a generic multiclass CMGF classifier that works with the `scikit-learn` cross validation tool as follows.\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "xExedRgYEv6X"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def fill_diagonal(A, elts):\n",
+        "    # Taken from https://github.com/google/jax/issues/2680\n",
+        "    elts = jnp.ravel(elts)\n",
+        "    i, j = jnp.diag_indices(min(A.shape[-2:]))\n",
+        "    return A.at[..., i, j].set(elts)"
+      ],
+      "metadata": {
+        "id": "q713feGREIXA"
+      },
+      "execution_count": 35,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class CMGFEstimator(BaseEstimator, ClassifierMixin):\n",
+        "    def __init__(self, params, mean=None, cov=None):\n",
+        "        self.params = params\n",
+        "        self.mean = mean\n",
+        "        self.cov = cov\n",
+        "\n",
+        "    def fit(self, X, y):\n",
+        "        X_bias = jnp.concatenate([jnp.ones((len(X), 1)), X], axis=1)\n",
+        "        # Encode output as one-hot-encoded vectors with first column dropped,\n",
+        "        # i.e., [0, ..., 0] correspondes to 1st class\n",
+        "        # This is done to prevent the \"Dummy Variable Trap\".\n",
+        "        enc = OneHotEncoder(drop='first')\n",
+        "        y_oh = jnp.array(enc.fit_transform(y.reshape(-1, 1)).toarray())\n",
+        "        input_dim = X_bias.shape[-1]\n",
+        "        num_classes = y_oh.shape[-1] + 1\n",
+        "        weight_dim = input_dim * num_classes\n",
+        "        \n",
+        "        initial_mean, initial_covariance = jnp.zeros(weight_dim), jnp.eye(weight_dim)\n",
+        "        dynamics_function = lambda w, x: w\n",
+        "        dynamics_covariance = jnp.zeros((weight_dim, weight_dim))\n",
+        "        emission_mean_function = lambda w, x: jax.nn.softmax(x @ w.reshape(input_dim, -1))[1:]\n",
+        "        def emission_var_function(w, x):\n",
+        "            ps = jnp.atleast_2d(emission_mean_function(w, x))\n",
+        "            return fill_diagonal(ps.T @ -ps, ps * (1-ps))\n",
+        "        cmgf_params = self.params(\n",
+        "            initial_mean = initial_mean,\n",
+        "            initial_covariance = initial_covariance,\n",
+        "            dynamics_function = dynamics_function,\n",
+        "            dynamics_covariance = dynamics_covariance,\n",
+        "            emission_mean_function = emission_mean_function,\n",
+        "            emission_var_function = emission_var_function\n",
+        "        )\n",
+        "        post = conditional_moments_gaussian_filter(cmgf_params, y_oh, inputs = X_bias)\n",
+        "        post_means, post_covs = post.filtered_means, post.filtered_covariances\n",
+        "        self.mean, self.cov = post_means[-1], post_covs[-1]\n",
+        "        return self\n",
+        "    \n",
+        "    def predict(self, X, y=None):\n",
+        "        X_bias = jnp.concatenate([jnp.ones((len(X), 1)), X], axis=1)\n",
+        "        return jnp.argmax(jax.nn.softmax(X_bias @ self.mean.reshape(X_bias.shape[-1], -1)), axis=1)"
+      ],
+      "metadata": {
+        "id": "saBspc73FGNf"
+      },
+      "execution_count": 36,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Helper function to compute accuracy measure\n",
+        "def compute_accuracy(model, input, output, fit=True):\n",
+        "    if fit:\n",
+        "        model = model.fit(input, output)\n",
+        "    return jnp.count_nonzero(model.predict(input) - output == 0) / len(output)\n",
+        "\n",
+        "# Print training accuracy\n",
+        "cmgf_model, sgd_model = CMGFEstimator(EKFParams), LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1)\n",
+        "print(f'CMGF training accuracy: {compute_accuracy(cmgf_model, input, output)}')\n",
+        "print(f'SGD training accuracy: {compute_accuracy(sgd_model, input, output)}')"
+      ],
+      "metadata": {
+        "id": "QEUK_pUGmOkN",
+        "outputId": "500b8546-9af6-4531-e518-db3c678e5601",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 37,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "CMGF training accuracy: 0.5953999757766724\n",
+            "SGD training accuracy: 0.4936999976634979\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/sklearn/linear_model/_sag.py:354: ConvergenceWarning: The max_iter was reached which means the coef_ did not converge\n",
+            "  ConvergenceWarning,\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We test the accuracy using 3 repeated trials of 10-fold cross validation."
+      ],
+      "metadata": {
+        "id": "Rm88s6oSFagu"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1)\n",
+        "\n",
+        "cmgf_est = CMGFEstimator(EKFParams)\n",
+        "n_scores = cross_val_score(cmgf_est, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise')\n",
+        "print(f'{num_points} data points, {num_features} features, {num_classes} classes.')\n",
+        "print(f'EKF-CMGF estimate average accuracy = {n_scores.mean()}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RZJFUH_kEgSy",
+        "outputId": "f833924a-afcf-49c4-bd9a-864086ee0169"
+      },
+      "execution_count": 38,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "10000 data points, 5 features, 4 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.5935999999999999\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = LogisticRegression(multi_class='multinomial', solver='sag')\n",
+        "n_scores = cross_val_score(model, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise')\n",
+        "print(f'{num_points} data points, {num_features} features, {num_classes} classes.')\n",
+        "print(f'sag estimate average accuracy = {n_scores.mean()}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vnsOc-wiGQ1U",
+        "outputId": "2da8b5a0-a77c-4014-ee1f-4899364b813d"
+      },
+      "execution_count": 41,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "10000 data points, 5 features, 4 classes.\n",
+            "sag estimate average accuracy = 0.5938\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# def repeated_kfold_cv(model, X, y, n_splits=10, n_repeats=3, key=1):\n",
+        "#     if isinstance(key, int):\n",
+        "#         key = jr.PRNGKey(key)\n",
+        "#     key, subkey = jr.split(key, 2)\n",
+        "#     num_points = len(y)\n",
+        "#     accuracy_score = 0\n",
+        "#     for _ in range(n_repeats):\n",
+        "#         idx = jr.permutation(key, jnp.arange(num_points))\n",
+        "#         kfolds = jnp.array_split(idx, n_splits)\n",
+        "#         for i in range(n_splits):\n",
+        "#             test_idx = kfolds[i]\n",
+        "#             train_idx = jnp.concatenate(kfolds[:i] + kfolds[i+1:])\n",
+        "#             X_train, y_train = X[train_idx], y[train_idx]\n",
+        "#             X_test, y_test = X[test_idx], y[test_idx]\n",
+        "#             model = model.fit(X_train, y_train)\n",
+        "#             y_predict = model.predict(X_test)\n",
+        "#             accuracy_score += 1 - (jnp.abs(y_predict - y_test).sum() / len(test_idx))\n",
+        "#     return accuracy_score / (n_splits * n_repeats)"
+      ],
+      "metadata": {
+        "id": "dd5ixTIILah_"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description
- Implemented CMGF online multi-class logistic regression demo as `cmgf_logistic_regression_demo.ipynb`.
- Performs more accurate inference than single-pass sgd, near-identical performance to many-pass (`max_iter=100`) sgd
- 3-repeated 10-fold cross validation results:
  - 10000 data points, 5 features, 2 classes:
    - ``EKF-CMGF estimate average accuracy = 0.869``
    - ``one-pass sag estimate average accuracy = 0.849``
    - ``many-pass sag estimate average accuracy = 0.869``
  - 10000 data points, 5 features, 3 classes:
    - ``EKF-CMGF estimate average accuracy = 0.681``
    - ``one-pass sag estimate average accuracy = 0.61``
    - ``many-pass sag estimate average accuracy = 0.681``
  - 10000 data points, 5 features, 4 classes:
    - ``EKF-CMGF estimate average accuracy = 0.594``
    - ``one-pass sag estimate average accuracy = 0.533``
    - ``many-pass sag estimate average accuracy = 0.594``
  - 10000 data points, 5 features, 5 classes:
    - ``EKF-CMGF estimate average accuracy = 0.576``
    - ``one-pass sag estimate average accuracy = 0.537``
    - ``many-pass sag estimate average accuracy = 0.576``


## Issue 
#178 
