### PR TITLE
Functional Loopy bp in a Gaussian Factor Graph.

### DIFF
--- a/ssm_jax/bp/gauss_factor_graph.py
+++ b/ssm_jax/bp/gauss_factor_graph.py
@@ -1,0 +1,247 @@
+import functools
+from functools import partial
+from typing import NamedTuple, Union, List, Dict
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import jit
+from jax.tree_util import register_pytree_node_class, tree_leaves, tree_map
+from ssm_jax.bp.gauss_bp_utils import (info_divide,
+                                       info_marginalize,
+                                       info_multiply)
+
+def _tree_reduce(function, tree, initializer=None, is_leaf=None):
+    """Copy of jax.tree_utils.reduce which accepts an `is_leaf` argument."""
+    if initializer is None:
+        return functools.reduce(function, tree_leaves(tree, is_leaf))
+    else:
+        return functools.reduce(function, tree_leaves(tree, is_leaf), initializer)
+
+class CanonicalPotential(NamedTuple):
+    """Container class for a Canonical Potential.
+
+    eta: (N,) array.
+    Lambda: (N, N) array.
+    """
+    eta: jnp.ndarray
+    Lambda: jnp.ndarray
+
+def zeros_canonical_pot(dim):
+    """Construct a Canonical potential with all entries zero."""
+    eta = jnp.zeros(dim)
+    Lambda = jnp.zeros((dim, dim))
+    return CanonicalPotential(eta=eta, Lambda=Lambda)
+
+
+@jit
+def sum_reduce_cpots(cpots, initializer=None):
+    """Sum over the corresponding parameters for potential in `cpots`."""
+    return _tree_reduce(info_multiply, cpots, initializer,
+                        is_leaf=lambda l: isinstance(l, CanonicalPotential))
+
+
+class GaussianVariableNode(NamedTuple):
+    """A Gaussian variable node in a factor graph."""
+    varID : Union[int, str]
+    dim : int
+    prior : CanonicalPotential # Currently using prior to 'roll in' single variable factors.
+
+class CanonicalFactor(NamedTuple):
+    """A canonical factor involving `len(adj_varIDs)` variables."""
+    # TODO: Not totally clear what the best way is to handle the var_scopes.
+    # Could use a dataclass with a __post_init__ to construct automatically...
+    #  I'm not sure how this plays with rolling/unrolling...
+    factorID : Union[int, str]
+    adj_varIDs : Union[List[int], List[str]]
+    potential : CanonicalPotential
+    var_scopes : Dict # {varID : (var_start, var_stop)}
+
+def make_canonical_factor(factorID, var_nodes, cpot):
+    """ Helper function to construct a Canonical Factor."""
+    # It should be possible to replace this with the right constructor for CanonicalFactor
+    varIDs = [var.varID for var in var_nodes]
+    var_scopes = _calculate_var_scopes(var_nodes)
+    return CanonicalFactor(factorID, varIDs, cpot, var_scopes)
+
+class GaussianFactorGraph(NamedTuple):
+    """ A container for variables and factor in a factor graph."""
+    var_nodes : List[GaussianVariableNode]
+    factors : List[CanonicalFactor]
+    # factor_to_var_edges are already implicitly contained factors... 
+    factor_to_var_edges : Dict
+    var_to_factor_edges : Dict
+
+def make_factor_graph(var_nodes, factors):
+    """Helper function to construct a factor graph."""
+    # TODO: Another place where maybe this belongs as a constructor in the GFG class.
+    factor_to_var_edges = {factor.factorID: factor.adj_varIDs for factor in factors}
+    var_to_factor_edges = {var.varID: [fID for fID, vIDs in factor_to_var_edges.items() if var.varID in vIDs]
+                           for var in var_nodes}
+    return GaussianFactorGraph(var_nodes,factors,
+                               factor_to_var_edges,
+                               var_to_factor_edges)
+
+def init_messages(factor_graph):
+    """ Initial factor to variable messages as zeros."""
+    var_dims = {var.varID : var.dim for var in factor_graph.var_nodes}
+    return {factor.factorID : {vID: zeros_canonical_pot(var_dims[vID]) for vID in factor.adj_varIDs}
+            for factor in factor_graph.factors}
+
+@partial(jit, static_argnums=2)
+def absorb_canonical_message(cpot, message, message_scope):
+    """Absorb a canonical message into a potential."""
+    var_start, var_stop = message_scope
+    eta = cpot.eta.at[var_start:var_stop].add(message.eta)
+    Lambda = cpot.Lambda.at[var_start:var_stop, var_start:var_stop].add(message.Lambda)
+    return CanonicalPotential(eta, Lambda)
+
+def absorb_var_to_factor_messages(factor, messages):
+    """Absorb all the messages into a factor potential."""
+    pot = tree_map(jnp.copy,factor.potential)
+    for varID, message in messages.items():
+        pot = absorb_canonical_message(pot, message, factor.var_scopes[varID])
+    return pot
+
+def marginalise_onto_var(potential, var_scope):
+    """Marginalise a joint canonical form Gaussian onto a variable."""
+    (K11, K12, K22), (h1, h2) = extract_canonical_potential_blocks(potential, var_scope)
+    K_marg, h_marg = info_marginalize(K22, K12.T, K11, h2, h1)
+    return CanonicalPotential(eta=h_marg, Lambda=K_marg)
+
+def update_belief(var, messages):
+    """Combine incoming messages to calculate a variable's belief state."""
+    return sum_reduce_cpots(messages, initializer=var.prior)
+
+def calculate_var_belief(var,messages, var_to_factor_edges):
+    """Combine incoming messages to calculate a variable's belief state."""
+    incoming_messages = [messages[f][var.varID] for f in var_to_factor_edges[var.varID]]
+    return update_belief(var, incoming_messages)
+
+def calculate_all_beliefs(factor_graph, messages):
+    """Absorb messages for all variables to calculate all belief states."""
+    return {var.varID: calculate_var_belief(var, messages, factor_graph.var_to_factor_edges)
+            for var in factor_graph.var_nodes}
+
+def update_factor_to_var_messages(factor,var_beliefs,messages_to_vars,damping=0):
+    """Given current variable belief state and the previous messages sent to each variable
+     calculate the update messages to send to variables.
+     
+     Note: Ordinarily the message sent to the ith variable, var_i, is given by summing the incoming 
+      messages of all *other* variables and then marginalising onto var_i.
+
+      In Canonical Gaussian form we can sum *all* messages and marginalise onto var_i before simply 
+       substracting the message from var_i. This trick allows us perform a single message absorption  
+       step instead of repeating for each variable.
+
+    Args:
+        factor: A CanonicalFactor object.
+        var_beliefs: A dictionary `{varID: CanonicalPotential}` containing marginal variable belief 
+                     states.
+        messages_to_vars: A dictionary {varID: CanonicalPotential} containing messages from `factor`
+                          to each variable from the previous step.
+        damping: float.
+
+    Returns:
+        messages_to_vars: A dictionary {varID: CanonicalPotential} containing the updated messages 
+                           from `factor` to each variable.
+      """
+    # Divide var.beliefs by messages --> message_v_to_f.
+    var_messages = info_divide(var_beliefs, messages_to_vars)
+    # Absorb all messages into factor.
+    pot_plus_messages = absorb_var_to_factor_messages(factor, var_messages)
+    for vID in factor.adj_varIDs:
+        # Marginalise message_v_to_f onto var.
+        var_marginal = marginalise_onto_var(pot_plus_messages, factor.var_scopes[vID])
+        raw_message = info_divide(var_marginal, var_messages[vID]) # Substract message_f_to_v
+        damped_message = jax.tree_map(
+            lambda x, y: damping * x + (1 - damping) * y,
+            messages_to_vars[vID], raw_message
+        )
+        messages_to_vars[vID] = damped_message
+    return messages_to_vars
+
+def update_all_messages(factor_graph, messages, damping=0):
+    """Loop over all factors in the graph calculated updated messages to variables.
+   
+    Args:
+        factor_graph: A GaussianFactorGraph object.
+        messages: a dict of dicts containing messages for each factor -
+                 {factorID : {varID: message, ...}, ...}
+    
+    Returns:
+        new_messages: dict with the same form as `messages` containing updated factor to variable
+                       messages.
+    """
+    var_beliefs = calculate_all_beliefs(factor_graph, messages)
+    new_messages = {}
+    for factor in factor_graph.factors:
+        factor_var_beliefs = {vID:var_beliefs[vID] for vID in factor.adj_varIDs}
+        messages_to_vars = messages[factor.factorID]
+        new_messages[factor.factorID] = update_factor_to_var_messages(
+            factor, factor_var_beliefs, messages_to_vars, damping
+            )
+    return new_messages
+
+def extract_canonical_potential_blocks(can_pot, var_scope):
+    """Split a precision matrix into blocks for marginalising / conditionalising.
+
+    E.g. K = [[ 0,  1,  2,  3,  4],
+              [ 5,  6,  7,  8,  9],
+              [10, 11, 12, 13, 14],
+              [15, 16, 17, 18, 19],
+              [20, 21, 22, 23, 24]]
+        h = [0, 1, 2, 3, 4, 5]
+        idxs = [1,2]
+        gets split into:
+            K11 - [[ 6,  7],
+                   [11, 12]]
+
+            K12 - [[ 5,  8,  9],
+                   [10, 13, 14]]
+
+            K22 - [[ 0,  3,  4],
+                   [15, 18, 19],
+                   [20, 23, 24]]
+        and
+            h1 - [1, 2]
+            h2 - [0, 3, 4]
+
+    Args:
+        can_pot - a CanonicalPotential object (or similar tuple) with elements (h, K) where,
+                    K - (D x D) precision matrix.
+                    h - (D,) potential vector.
+        idxs (N,) array of indices in 1,...,D.
+    Returns:
+        (K11, K12, K22), (h1, h2) - blocks of the potential parameters where:
+            K11 (N x N) block of precision elements with row and column in `indxs`
+            K12 (N x D-N) block of precision elements with row in `indxs` but column not in `indxs`.
+            K22 (D-N x D-N) block of precision elements with neither row nor column in `indxs`.
+            h1 (N,) elements of potential vector in `indxs`.
+            h2 (D-N,) elements of potential vector not in `indxs`.
+    """
+    # TODO: Investigate using jax.lax.dynamic_slice instead.
+    # TODO: also maybe precompute the ~b indices.
+    h, K = can_pot
+    # Using np instead of jnp so that these aren't traced.
+    idxs = np.arange(*var_scope)
+    idx_range = np.arange(len(h))
+    b = np.isin(idx_range, idxs)
+    K11 = K[b, :][:, b]
+    K12 = K[b, :][:, ~b]
+    K22 = K[~b, :][:, ~b]
+    h1 = h[b]
+    h2 = h[~b]
+    return (K11, K12, K22), (h1, h2)
+
+
+def _calculate_var_scopes(var_nodes):
+    """Helper function to calculate the variable scopes for a factor involving `var_nodes`."""
+    var_ids = np.array([var.varID for var in var_nodes])
+    var_dims = np.array([var.dim for var in var_nodes], dtype=np.int32)
+    # Use numpy so it is not traced.
+    var_starts = np.concatenate((np.zeros(1, dtype=np.int32), np.cumsum(var_dims)[:-1]))
+    var_stops = var_starts + var_dims
+    var_scopes = {var_id: (start, stop)
+                    for var_id, start, stop in zip(var_ids, var_starts, var_stops)}
+    return var_scopes

--- a/ssm_jax/bp/gauss_factor_graph_test.py
+++ b/ssm_jax/bp/gauss_factor_graph_test.py
@@ -88,7 +88,7 @@ def test_gauss_factor_graph_lgssm():
 
     key = jr.PRNGKey(111)
     num_timesteps = 5 # Fewer timesteps so that we can run fewer iterations.
-    input_size = lgssm.dynamics_input_weights.shape[1]
+    input_size = lgssm.dynamics_input_weights.value.shape[1]
     inputs = jnp.zeros((num_timesteps, input_size))
     _, y = lgssm.sample(key, num_timesteps, inputs)
 

--- a/ssm_jax/bp/gauss_factor_graph_test.py
+++ b/ssm_jax/bp/gauss_factor_graph_test.py
@@ -90,7 +90,7 @@ def test_gauss_factor_graph_lgssm():
     num_timesteps = 5 # Fewer timesteps so that we can run fewer iterations.
     input_size = lgssm.dynamics_input_weights.value.shape[1]
     inputs = jnp.zeros((num_timesteps, input_size))
-    _, y = lgssm.sample(key, num_timesteps, inputs)
+    _, y = lgssm.sample(key, num_timesteps, inputs=inputs)
 
     lgssm_info_posterior = lgssm_info_smoother(lgssm_info, y, inputs)
 

--- a/ssm_jax/bp/gauss_factor_graph_test.py
+++ b/ssm_jax/bp/gauss_factor_graph_test.py
@@ -1,0 +1,210 @@
+from concurrent.futures.process import _MAX_WINDOWS_WORKERS
+from functools import partial
+from jax import numpy as jnp
+from jax import random as jr
+from jax import vmap, jit
+
+from ssm_jax.distributions import InverseWishart
+from ssm_jax.bp.gauss_bp_utils import info_multiply, potential_from_conditional_linear_gaussian, pair_cpot_condition
+from ssm_jax.bp.gauss_factor_graph import (GaussianVariableNode,
+                                           CanonicalFactor,
+                                           CanonicalPotential,
+                                           GaussianFactorGraph,
+                                           zeros_canonical_pot,
+                                           update_all_messages,
+                                           make_factor_graph,
+                                           init_messages,
+                                           calculate_all_beliefs,
+                                           make_canonical_factor)
+
+from ssm_jax.linear_gaussian_ssm.info_inference import lgssm_info_smoother
+from ssm_jax.linear_gaussian_ssm.info_inference_test import build_lgssm_moment_and_info_form
+
+_all_close = lambda x,y: jnp.allclose(x,y,rtol=1e-3, atol=1e-3)
+
+def canonical_factor_from_clg(A, u, Lambda, x, y, factorID):
+    """Construct a CanoncialFactor from the parameters of a conditional linear Gaussian."""
+    (Kxx, Kxy, Kyy), (hx, hy) = potential_from_conditional_linear_gaussian(A, u, Lambda)
+    K = jnp.block([[Kxx, Kxy], [Kxy.T, Kyy]])
+    h = jnp.concatenate((hx, hy))
+    cpot = CanonicalPotential(eta=h, Lambda=K)
+    return make_canonical_factor(factorID, [x, y], cpot)
+
+
+def factor_graph_from_lgssm(lgssm_params, inputs, obs, T=None):
+    """Unroll a linear gaussian state-space model into a factor graph."""
+    if inputs is None:
+        if T is not None:
+            D_in = lgssm_params.dynamics_input_weights.shape[1]
+            inputs = jnp.zeros((T, D_in))
+        else:
+            raise ValueError("One of `inputs` or `T` must not be None.")
+
+    num_timesteps = len(inputs)
+    Lambda0, mu0 = lgssm_params.initial_precision, lgssm_params.initial_mean
+    latent_dim = len(mu0)
+
+    latent_vars = [GaussianVariableNode(f"x{i}", latent_dim, zeros_canonical_pot(latent_dim))
+                    for i in range(num_timesteps)]
+    # Add informative prior to first time point.
+    x0_prior = CanonicalPotential(eta=Lambda0 @ mu0, Lambda=Lambda0)
+    latent_vars[0] = GaussianVariableNode("x0", latent_dim, x0_prior)
+
+    B, b = lgssm_params.dynamics_input_weights, lgssm_params.dynamics_bias
+    F, Q_prec = lgssm_params.dynamics_matrix, lgssm_params.dynamics_precision
+    latent_net_inputs = vmap(jnp.dot, (None, 0))(B, inputs) + b
+    latent_factors = [
+        canonical_factor_from_clg(
+            F, latent_net_inputs[i], Q_prec, latent_vars[i], latent_vars[i + 1], f"latent_{i},{i+1}"
+        )
+        for i in range(num_timesteps - 1)
+    ]
+
+    D, d = lgssm_params.emission_input_weights, lgssm_params.emission_bias
+    H, R_prec = lgssm_params.emission_matrix, lgssm_params.emission_precision
+
+    emission_net_inputs = vmap(jnp.dot, (None, 0))(D, inputs) + d
+    emission_pots = vmap(potential_from_conditional_linear_gaussian, (None, 0, None))(
+                         H, emission_net_inputs, R_prec)
+    local_evidence_pot_chain = vmap(partial(pair_cpot_condition, obs_var=2))(emission_pots, obs)
+    local_evidence_pots = [CanonicalPotential(eta, Lambda) for Lambda, eta in zip(*local_evidence_pot_chain)]
+
+    def incorporate_local_evidence(var, pot):
+        """Incorporate local evidence potential into Gaussian variable."""
+        prior_plus_pot = info_multiply(var.prior, pot)
+        return GaussianVariableNode(var.varID, var.dim, prior_plus_pot)
+    
+    latent_vars = [incorporate_local_evidence(var,pot) for var, pot in zip(latent_vars, local_evidence_pots)]
+
+    fg = make_factor_graph(latent_vars, latent_factors)
+
+    return fg
+
+def test_gauss_factor_graph_lgssm():
+    """Test that Gaussian chain belief propagation gets the same results as 
+     information form RTS smoother."""
+
+    lgssm, lgssm_info = build_lgssm_moment_and_info_form()
+
+    key = jr.PRNGKey(111)
+    num_timesteps = 5 # Fewer timesteps so that we can run fewer iterations.
+    input_size = lgssm.dynamics_input_weights.shape[1]
+    inputs = jnp.zeros((num_timesteps, input_size))
+    _, y = lgssm.sample(key, num_timesteps, inputs)
+
+    lgssm_info_posterior = lgssm_info_smoother(lgssm_info, y, inputs)
+
+    fg = factor_graph_from_lgssm(lgssm_info,inputs, y)
+
+    # Loopy bp.
+    messages = init_messages(fg)
+    for _ in range(num_timesteps):
+        messages = update_all_messages(fg,messages)
+
+    # Calculate final beliefs 
+    final_beliefs = calculate_all_beliefs(fg,messages)
+    fg_etas = jnp.vstack([cpot.eta for cpot in final_beliefs.values()])
+    fg_Lambdas = jnp.stack([cpot.Lambda for cpot in final_beliefs.values()])
+
+    assert _all_close(fg_etas, lgssm_info_posterior.smoothed_etas)
+    assert _all_close(fg_Lambdas, lgssm_info_posterior.smoothed_precisions)
+
+
+def test_tree_factor_graph():
+
+    key = jr.PRNGKey(0)
+    dim = 2
+
+    ### Construct variables in moment form ###
+    IW = InverseWishart(dim, jnp.eye(dim)*0.1)
+    key, subkey = jr.split(key)
+    covs = jit(IW.sample,static_argnums=0)(5,subkey)
+
+    key, subkey1  = jr.split(key)
+    mu1 = jr.normal(subkey1,(dim,))
+    Sigma1 = covs[0]
+
+    key, subkey = jr.split(key)
+    mu2 = jr.normal(subkey,(dim,))
+    Sigma2 = covs[1]
+
+    # x_3 | x_1, x_2 ~ N(x_3| A_31 x_1 + A_32 x_2, Sigma_{3|1,2})
+    key, *subkeys = jr.split(key,3)
+    A31 = jr.normal(subkeys[0],(dim,dim))
+    A32 = jr.normal(subkeys[1],(dim,dim))
+    Sigma3_cond = covs[2]
+    mu3 = A31 @ mu1 + A32 @ mu2
+    Sigma3 = Sigma3_cond + A31 @ Sigma1 @ A31.T + A32 @ Sigma2 @ A32.T
+
+    # x_4 | x_3 ~ N(x_4 | A_4 x_3, Sigma_{3|4})
+    key, subkey = jr.split(key)
+    A4 = jr.normal(subkey,(dim,dim))
+    Sigma4_cond = covs[3]
+    mu4 = A4 @ mu3 
+    Sigma4 = Sigma4_cond + A4 @ Sigma3 @ A4.T
+
+    # x_5 | x_3 ~ N(x_5 | A_5 x_3, Sigma_{5|4})
+    key, subkey = jr.split(key)
+    A5 = jr.normal(subkey,(dim,dim))
+    Sigma5_cond = covs[4]
+    mu5 = A5 @ mu3 
+    Sigma5 = Sigma5_cond + A5 @ Sigma3 @ A5.T
+
+    ### Construct variables and factors in Canonical Form ###
+    Lambda1 = jnp.linalg.inv(Sigma1)
+    eta1 = Lambda1 @ mu1
+    prior_x1 = CanonicalPotential(eta1, Lambda1)
+
+    Lambda2 = jnp.linalg.inv(Sigma2)
+    eta2 = Lambda2 @ mu2
+    prior_x2 = CanonicalPotential(eta2, Lambda2)
+
+    x1_var = GaussianVariableNode(1, dim, prior_x1)
+    x2_var = GaussianVariableNode(2, dim, prior_x2)
+    x3_var = GaussianVariableNode(3, dim, zeros_canonical_pot(dim))
+    x4_var = GaussianVariableNode(4, dim, zeros_canonical_pot(dim))
+    x5_var = GaussianVariableNode(5, dim, zeros_canonical_pot(dim))
+
+    offset = jnp.zeros(dim)
+    Lambda3_cond = jnp.linalg.inv(Sigma3_cond)
+    A3_joint = jnp.hstack((A31,A32))
+    (Kxx, Kxy, Kyy), (hx,hy) = potential_from_conditional_linear_gaussian(A3_joint,
+                                                                        offset,
+                                                                        Lambda3_cond)
+    K = jnp.block([[Kxx, Kxy],
+                    [Kxy.T, Kyy]])
+    h = jnp.concatenate((hx,hy))
+    cpot_123 = CanonicalPotential(eta=h, Lambda=K)
+    factor_123 = make_canonical_factor("factor_123", [x1_var, x2_var, x3_var], cpot_123)
+
+    Lambda4_cond = jnp.linalg.inv(Sigma4_cond)
+    factor_34 = canonical_factor_from_clg(A4, offset, Lambda4_cond, x3_var, x4_var, "factor_34")
+
+    Lambda5_cond = jnp.linalg.inv(Sigma5_cond)
+    factor_35 = canonical_factor_from_clg(A5, offset, Lambda5_cond, x3_var, x5_var, "factor_35")
+
+    # Build factor graph.
+    var_nodes = [x1_var, x2_var, x3_var, x4_var, x5_var]
+    factors = [factor_123, factor_34, factor_35]
+    fg = make_factor_graph(var_nodes, factors)
+
+    # Loopy BP
+    messages = init_messages(fg)
+    for _ in range(5):
+        messages = update_all_messages(fg,messages)
+
+    # Extract marginal etas and Lambas from factor graph.
+    final_beliefs = calculate_all_beliefs(fg,messages)
+    fg_etas = jnp.vstack([cpot.eta for cpot in final_beliefs.values()])
+    fg_Lambdas = jnp.stack([cpot.Lambda for cpot in final_beliefs.values()])
+
+    # Convert to moment form
+    fg_means = vmap(jnp.linalg.solve)(fg_Lambdas, fg_etas)
+    fg_covs = jnp.linalg.inv(fg_Lambdas)
+
+    means = jnp.vstack([mu1,mu2,mu3,mu4,mu5])
+    covs = jnp.stack([Sigma1,Sigma2,Sigma3,Sigma4,Sigma5])
+
+    # Compare to moment form marginals.
+    assert jnp.allclose(fg_means,means,rtol=1e-2,atol=1e-2)
+    assert jnp.allclose(fg_covs,covs,rtol=1e-2,atol=1e-2) 


### PR DESCRIPTION
# Loopy BP
This PR contains some simple containers for Gaussian variables and Canonical form Gaussian factors as well as a light-weight wrapper to combine these into a factor graph. The containers and inference functions are currently both stored in `ssm_jax/bp/gauss_factor_graph.py`.

Loopy belief propagation is implemented is a functional manner by whereby the core functions take in a `GaussianFactorGraph` object and a dictionary of factor-to-variable messages and return updated messages. I've tried for a clean separation between the static elements (variable, factors, edges) and the dynamic elements (messages and belief states).

The core loop then looks like:
```python
messages = init_messages(factor_graph)
for _ in range(n_itr):
    messages = update_all_messages(factor_graph, messages)
```
aiming for the type of functional update design pattern seen in other jax libraries.

Belief states are also calculated in a functional manner using:
```python
beliefs = calculate_all_beliefs(factor_graph, messages)
```
This approach plays nice with jit, as a partial version of the update function can be compiled easily:
```python
jit_update = jit(lambda m: update_messages(factor_graph,m))
```

The Loopy bp results are tested against a chain lgssm and a simple tree in `ssm_jax/bp/gauss_factor_graph_test.py`.

### Future Improvements
There are a few natural places for improvements some of which are mentioned in the code, these include:
- Efficiently extracting blocks from joint precision matrix.
- Incorporate construction functions as methods for `GaussianFactorGraph` and `CanonicalFactor`.

Some longer-term improvements include:
- Improving jit integration
      - This might involve make the `GaussianFactorGraph` hashable so that jit can use `static_argnums`.
- Adding the possibility for partial updates, i.e. only passing messages along some edges.
      - This is not too far off with the current approach, for instance by looping over factors which are keys in `messages` rather than all of the factors in the graph gets you much of the way there.

