### PR TITLE
added tolerance term to covariance

### DIFF
--- a/ssm_jax/hmm/models/gaussian_hmm.py
+++ b/ssm_jax/hmm/models/gaussian_hmm.py
@@ -176,5 +176,6 @@ class GaussianHMM(ExponentialFamilyHMM):
             return niw_posterior.mode()
 
         covs, means = vmap(_single_m_step)(stats.sum_w, stats.sum_x, stats.sum_xxT)
-        self.emission_covariance_matrices.value = covs
+        dim = covs.shape[-1]
+        self.emission_covariance_matrices.value = covs + jnp.eye(dim) * 1e-5
         self.emission_means.value = means


### PR DESCRIPTION
**Problem.** Stochastic EM algorithm would learn a nearly semi-positive definite covariance matrix in a 100-state, 15-dim Gaussian HMM real-world dataset when fit to a real-world dataset, resulting in NaN parameters in all subsequent updates
**Solution.** Added a `1e-5 * jnp.eye(dim)` SPD tolerance term to the emission covariance matrices update.
**Alternatives/additions.** Let the covariance tolerance be a user-settable value, with default value of e.g. `1e-6`. Where would the best place to introduce this parameter be?

--- 
**Details**
- NaN arose in first unconstrained parameter (i.e. `self.emission_covariance_matrices.unconstrained_value`) after a `self._m_step_emissions`. This was due to `self.emission_covariance_matrices.value` having a single negative eigenvalue (specifically, `-3e-06`)

- Unable to reproduce with synthetic dataset (used the 5 state, 2-D sine/cosine generative model found in many of the Gaussian HMM tests and examples, and specified test dataset to have 100 states). Any suggestions for how to generate data that might reproduce this?