### PR TITLE
Remove redundant Posterior containers

### DIFF
--- a/ssm_jax/cond_moments_gaussian_filter/containers.py
+++ b/ssm_jax/cond_moments_gaussian_filter/containers.py
@@ -26,28 +26,6 @@ class CMGFParams:
 
 
 @chex.dataclass
-class CMGFPosterior:
-    """Simple wrapper for properties of an CMGF posterior distribution.
-
-    Attributes:
-            marginal_loglik: marginal log likelihood of the data
-            filtered_means: (T,D_hid) array,
-                E[x_t | y_{1:t}, u_{1:t}].
-            filtered_covariances: (T,D_hid,D_hid) array,
-                Cov[x_t | y_{1:t}, u_{1:t}].
-            smoothed_means: (T,D_hid) array,
-                E[x_t | y_{1:T}, u_{1:T}].
-            smoothed_covs: (T,D_hid,D_hid) array of smoothed marginal covariances,
-                Cov[x_t | y_{1:T}, u_{1:T}].
-    """
-    marginal_loglik: chex.Scalar = None
-    filtered_means: chex.Array = None
-    filtered_covariances: chex.Array = None
-    smoothed_means: chex.Array = None
-    smoothed_covariances: chex.Array = None
-
-
-@chex.dataclass
 class EKFParams(CMGFParams):
     """
     Lightweight container for extended Kalman filter/smoother parameters.

--- a/ssm_jax/cond_moments_gaussian_filter/containers.py
+++ b/ssm_jax/cond_moments_gaussian_filter/containers.py
@@ -20,7 +20,7 @@ class CMGFParams:
     dynamics_function: Callable
     dynamics_covariance: chex.Array
     emission_mean_function: Callable
-    emission_var_function: Callable
+    emission_cov_function: Callable
     gaussian_expectation: Callable
     gaussian_cross_covariance: Callable
 

--- a/ssm_jax/cond_moments_gaussian_filter/inference.py
+++ b/ssm_jax/cond_moments_gaussian_filter/inference.py
@@ -1,7 +1,7 @@
 from jax import numpy as jnp
 from jax import lax
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
-from ssm_jax.cond_moments_gaussian_filter.containers import CMGFPosterior
+from ssm_jax.containers import GSSMPosterior
 
 
 # Helper functions
@@ -134,7 +134,7 @@ def conditional_moments_gaussian_filter(params, emissions, num_iter=1, inputs=No
         inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: CMGFPosterior instance containing,
+        filtered_posterior: GSSMPosterior instance containing,
             marginal_log_lik
             filtered_means (T, D_hid)
             filtered_covariances (T, D_hid, D_hid)
@@ -171,7 +171,7 @@ def conditional_moments_gaussian_filter(params, emissions, num_iter=1, inputs=No
     # Run the general linearization filter
     carry = (0.0, params.initial_mean, params.initial_covariance)
     (ll, _, _), (filtered_means, filtered_covs) = lax.scan(_step, carry, jnp.arange(num_timesteps))
-    return CMGFPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
+    return GSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
 
 
 def iterated_conditional_moments_gaussian_filter(params, emissions, num_iter=2, inputs=None):
@@ -184,7 +184,7 @@ def iterated_conditional_moments_gaussian_filter(params, emissions, num_iter=2, 
         inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: CMGFPosterior instance containing,
+        filtered_posterior: GSSMPosterior instance containing,
             marginal_log_lik
             filtered_means (T, D_hid)
             filtered_covariances (T, D_hid, D_hid)
@@ -204,7 +204,7 @@ def conditional_moments_gaussian_smoother(params, emissions, filtered_posterior=
         inputs (T,D_in): array of inputs.
 
     Returns:
-        nlgssm_posterior: CMGFPosterior instance containing properties of
+        nlgssm_posterior: GSSMPosterior instance containing properties of
             filtered and smoothed posterior distributions.
     """
     num_timesteps = len(emissions)
@@ -249,7 +249,7 @@ def conditional_moments_gaussian_smoother(params, emissions, filtered_posterior=
     # Reverse the arrays and return
     smoothed_means = jnp.row_stack((smoothed_means[::-1], filtered_means[-1][None, ...]))
     smoothed_covs = jnp.row_stack((smoothed_covs[::-1], filtered_covs[-1][None, ...]))
-    return CMGFPosterior(
+    return GSSMPosterior(
         marginal_loglik=ll,
         filtered_means=filtered_means,
         filtered_covariances=filtered_covs,
@@ -268,7 +268,7 @@ def iterated_conditional_moments_gaussian_smoother(params, emissions, num_iter=1
         inputs (T,D_in): array of inputs.
 
     Returns:
-        nlgssm_posterior: CMGFPosterior instance containing properties of
+        nlgssm_posterior: GSSMPosterior instance containing properties of
             filtered and smoothed posterior distributions.
     """
     def _step(carry, _):

--- a/ssm_jax/cond_moments_gaussian_filter/inference.py
+++ b/ssm_jax/cond_moments_gaussian_filter/inference.py
@@ -43,7 +43,7 @@ def _predict(m, P, f, Q, u, g_ev, g_cov):
     return mu_pred, Sigma_pred, cross_pred
 
 
-def _condition_on(m, P, y_cond_mean, y_cond_var, u, y, g_ev, g_cov, num_iter):
+def _condition_on(m, P, y_cond_mean, y_cond_cov, u, y, g_ev, g_cov, num_iter):
     """Condition a Gaussian potential on a new observation with arbitrary
        likelihood with given functions for conditional moments and make a
        Gaussian approximation.
@@ -63,7 +63,7 @@ def _condition_on(m, P, y_cond_mean, y_cond_var, u, y, g_ev, g_cov, num_iter):
         m (D_hid,): prior mean.
         P (D_hid,D_hid): prior covariance.
         y_cond_mean (Callable): conditional emission mean function.
-        y_cond_var (Callable): conditional emission variance function.
+        y_cond_cov (Callable): conditional emission covariance function.
         u (D_in,): inputs.
         y (D_obs,): observation.
         g_ev (Callable): Gaussian expectation value function.
@@ -76,13 +76,13 @@ def _condition_on(m, P, y_cond_mean, y_cond_var, u, y, g_ev, g_cov, num_iter):
         Sigma_cond (D_hid,D_hid): conditioned covariance.
     """
     m_Y = lambda x: y_cond_mean(x, u)
-    Var_Y = lambda x: y_cond_var(x, u)
+    Cov_Y = lambda x: y_cond_cov(x, u)
     identity_fn = lambda x: x
 
     def _step(carry, _):
         prior_mean, prior_cov = carry
         yhat = g_ev(m_Y, prior_mean, prior_cov)
-        S = g_ev(Var_Y, prior_mean, prior_cov) + g_cov(m_Y, m_Y, prior_mean, prior_cov)
+        S = g_ev(Cov_Y, prior_mean, prior_cov) + g_cov(m_Y, m_Y, prior_mean, prior_cov)
         log_likelihood = MVN(yhat, S).log_prob(jnp.atleast_1d(y))
         C = g_cov(identity_fn, m_Y, prior_mean, prior_cov)
         K = jnp.linalg.solve(S, C.T).T
@@ -143,8 +143,8 @@ def conditional_moments_gaussian_filter(params, emissions, num_iter=1, inputs=No
 
     # Process dynamics function and conditional emission moments to take in control inputs
     f = params.dynamics_function
-    m_Y, Var_Y = params.emission_mean_function, params.emission_var_function
-    f, m_Y, Var_Y  = (_process_fn(fn, inputs) for fn in (f, m_Y, Var_Y))
+    m_Y, Cov_Y = params.emission_mean_function, params.emission_cov_function
+    f, m_Y, Cov_Y  = (_process_fn(fn, inputs) for fn in (f, m_Y, Cov_Y))
     inputs = _process_input(inputs, num_timesteps)
 
     # Gaussian expectation value function
@@ -160,7 +160,7 @@ def conditional_moments_gaussian_filter(params, emissions, num_iter=1, inputs=No
         y = emissions[t]
 
         # Condition on the emission
-        log_likelihood, filtered_mean, filtered_cov = _condition_on(pred_mean, pred_cov, m_Y, Var_Y, u, y, g_ev, g_cov, num_iter)
+        log_likelihood, filtered_mean, filtered_cov = _condition_on(pred_mean, pred_cov, m_Y, Cov_Y, u, y, g_ev, g_cov, num_iter)
         ll += log_likelihood
 
         # Predict the next state

--- a/ssm_jax/cond_moments_gaussian_filter/inference_test.py
+++ b/ssm_jax/cond_moments_gaussian_filter/inference_test.py
@@ -23,7 +23,7 @@ def test_ekf(key=0, num_timesteps=15):
         dynamics_function = nlgssm.dynamics_function,
         dynamics_covariance = nlgssm.dynamics_covariance,
         emission_mean_function = nlgssm.emission_function,
-        emission_var_function = lambda x: nlgssm.emission_covariance,
+        emission_cov_function = lambda x: nlgssm.emission_covariance,
     )
     ggf_post = conditional_moments_gaussian_smoother(ekf_params, emissions)
 
@@ -48,7 +48,7 @@ def test_ukf(key=1, num_timesteps=15):
         dynamics_function = nlgssm.dynamics_function,
         dynamics_covariance = nlgssm.dynamics_covariance,
         emission_mean_function = nlgssm.emission_function,
-        emission_var_function = lambda x: nlgssm.emission_covariance,
+        emission_cov_function = lambda x: nlgssm.emission_covariance,
     )
     ggf_post = conditional_moments_gaussian_smoother(ukf_params, emissions)
 

--- a/ssm_jax/containers.py
+++ b/ssm_jax/containers.py
@@ -1,0 +1,26 @@
+import chex
+
+@chex.dataclass
+class GSSMPosterior:
+    """Simple wrapper for properties of an GSSM posterior distribution.
+
+    Attributes:
+            marginal_loglik: marginal log likelihood of the data
+            filtered_means: (T,D_hid) array,
+                E[x_t | y_{1:t}, u_{1:t}].
+            filtered_covariances: (T,D_hid,D_hid) array,
+                Cov[x_t | y_{1:t}, u_{1:t}].
+            smoothed_means: (T,D_hid) array,
+                E[x_t | y_{1:T}, u_{1:T}].
+            smoothed_covs: (T,D_hid,D_hid) array of smoothed marginal covariances,
+                Cov[x_t | y_{1:T}, u_{1:T}].
+            smoothed_cross: (T-1, D_hid, D_hid) array of smoothed cross products,
+                E[x_t x_{t+1}^T | y_{1:T}, u_{1:T}].
+    """
+
+    marginal_loglik: chex.Scalar = None
+    filtered_means: chex.Array = None
+    filtered_covariances: chex.Array = None
+    smoothed_means: chex.Array = None
+    smoothed_covariances: chex.Array = None
+    smoothed_cross_covariances: chex.Array = None

--- a/ssm_jax/extended_kalman_filter/demos/ekf_mlp.py
+++ b/ssm_jax/extended_kalman_filter/demos/ekf_mlp.py
@@ -18,7 +18,7 @@ import flax.linen as nn
 from jax.flatten_util import ravel_pytree
 from jax import vmap
 
-from ssm_jax.nonlinear_gaussian_ssm.containers import NLGSSMParams, NLGSSMPosterior
+from ssm_jax.nonlinear_gaussian_ssm.containers import NLGSSMParams
 from ssm_jax.extended_kalman_filter.inference import extended_kalman_filter
 
 
@@ -154,7 +154,7 @@ def main():
     )
 
     # Run EKF on training set to train MLP
-    ekf_post = extended_kalman_filter(ekf_params, emissions, inputs)
+    ekf_post = extended_kalman_filter(ekf_params, emissions, inputs=inputs)
     w_means, w_covs = ekf_post.filtered_means, ekf_post.filtered_covariances
 
     # Plot predictions

--- a/ssm_jax/extended_kalman_filter/inference.py
+++ b/ssm_jax/extended_kalman_filter/inference.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 from jax import lax
 from jax import jacfwd
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
-from ssm_jax.nonlinear_gaussian_ssm.containers import NLGSSMPosterior
+from ssm_jax.containers import GSSMPosterior
 
 
 # Helper functions
@@ -89,7 +89,7 @@ def extended_kalman_filter(params, emissions, num_iter=1, inputs=None):
         inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: LGSSMPosterior instance containing,
+        filtered_posterior: GSSMPosterior instance containing,
             marginal_log_lik
             filtered_means (T, D_hid)
             filtered_covariances (T, D_hid, D_hid)
@@ -125,7 +125,7 @@ def extended_kalman_filter(params, emissions, num_iter=1, inputs=None):
     # Run the extended Kalman filter
     carry = (0.0, params.initial_mean, params.initial_covariance)
     (ll, _, _), (filtered_means, filtered_covs) = lax.scan(_step, carry, jnp.arange(num_timesteps))
-    return NLGSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
+    return GSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
 
 
 def iterated_extended_kalman_filter(params, emissions, num_iter=2, inputs=None):
@@ -138,7 +138,7 @@ def iterated_extended_kalman_filter(params, emissions, num_iter=2, inputs=None):
         inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: LGSSMPosterior instance containing,
+        filtered_posterior: GSSMPosterior instance containing,
             marginal_log_lik
             filtered_means (T, D_hid)
             filtered_covariances (T, D_hid, D_hid)
@@ -153,12 +153,12 @@ def extended_kalman_smoother(params, emissions, filtered_posterior=None, inputs=
     Args:
         params: an NLGSSMParams instance (or object with the same fields)
         emissions (T,D_hid): array of observations.
-        filtered_posterior (NLGSSMPosterior): filtered posterior to use for smoothing.
+        filtered_posterior (GSSMPosterior): filtered posterior to use for smoothing.
             If None, the smoother computes the filtered posterior directly.
         inputs (T,D_in): array of inputs.
 
     Returns:
-        nlgssm_posterior: LGSSMPosterior instance containing properties of
+        nlgssm_posterior: GSSMPosterior instance containing properties of
             filtered and smoothed posterior distributions.
     """
     num_timesteps = len(emissions)
@@ -204,7 +204,7 @@ def extended_kalman_smoother(params, emissions, filtered_posterior=None, inputs=
     # Reverse the arrays and return
     smoothed_means = jnp.row_stack((smoothed_means[::-1], filtered_means[-1][None, ...]))
     smoothed_covs = jnp.row_stack((smoothed_covs[::-1], filtered_covs[-1][None, ...]))
-    return NLGSSMPosterior(
+    return GSSMPosterior(
         marginal_loglik=ll,
         filtered_means=filtered_means,
         filtered_covariances=filtered_covs,
@@ -223,7 +223,7 @@ def iterated_extended_kalman_smoother(params, emissions, num_iter=2, inputs=None
         inputs (T,D_in): array of inputs.
 
     Returns:
-        nlgssm_posterior: LGSSMPosterior instance containing properties of
+        nlgssm_posterior: GSSMPosterior instance containing properties of
             filtered and smoothed posterior distributions.
     """
 

--- a/ssm_jax/linear_gaussian_ssm/inference.py
+++ b/ssm_jax/linear_gaussian_ssm/inference.py
@@ -3,6 +3,7 @@ import jax.random as jr
 from jax import lax
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
 import chex
+from ssm_jax.containers import GSSMPosterior
 
 
 @chex.dataclass
@@ -23,32 +24,6 @@ class LGSSMParams:
     emission_input_weights: chex.Array
     emission_bias: chex.Array
     emission_covariance: chex.Array
-
-
-@chex.dataclass
-class LGSSMPosterior:
-    """Simple wrapper for properties of an LGSSM posterior distribution.
-
-    Attributes:
-            marginal_loglik: marginal log likelihood of the data
-            filtered_means: (T,D_hid) array,
-                E[x_t | y_{1:t}, u_{1:t}].
-            filtered_covariances: (T,D_hid,D_hid) array,
-                Cov[x_t | y_{1:t}, u_{1:t}].
-            smoothed_means: (T,D_hid) array,
-                E[x_t | y_{1:T}, u_{1:T}].
-            smoothed_covs: (T,D_hid,D_hid) array of smoothed marginal covariances,
-                Cov[x_t | y_{1:T}, u_{1:T}].
-            smoothed_cross: (T-1, D_hid, D_hid) array of smoothed cross products,
-                E[x_t x_{t+1}^T | y_{1:T}, u_{1:T}].
-    """
-
-    marginal_loglik: chex.Scalar = None
-    filtered_means: chex.Array = None
-    filtered_covariances: chex.Array = None
-    smoothed_means: chex.Array = None
-    smoothed_covariances: chex.Array = None
-    smoothed_cross_covariances: chex.Array = None
 
 
 # Helper functions
@@ -127,7 +102,7 @@ def lgssm_filter(params, emissions, inputs=None):
         inputs (T,D_in): array of inputs.
 
     Returns:
-        filtered_posterior: LGSSMPosterior instance containing,
+        filtered_posterior: GSSMPosterior instance containing,
             marginal_log_lik
             filtered_means (T, D_hid)
             filtered_covariances (T, D_hid, D_hid)
@@ -164,7 +139,7 @@ def lgssm_filter(params, emissions, inputs=None):
     # Run the Kalman filter
     carry = (0.0, params.initial_mean, params.initial_covariance)
     (ll, _, _), (filtered_means, filtered_covs) = lax.scan(_step, carry, jnp.arange(num_timesteps))
-    return LGSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
+    return GSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
 
 
 def lgssm_posterior_sample(rng, params, emissions, inputs=None):
@@ -231,7 +206,7 @@ def lgssm_smoother(params, emissions, inputs=None):
         inputs (T,D_in): array of inputs.
 
     Returns:
-        lgssm_posterior: LGSSMPosterior instance containing properites of
+        lgssm_posterior: GSSMPosterior instance containing properites of
             filtered and smoothed posterior distributions.
     """
     num_timesteps = len(emissions)
@@ -276,7 +251,7 @@ def lgssm_smoother(params, emissions, inputs=None):
     smoothed_means = jnp.row_stack((smoothed_means[::-1], filtered_means[-1][None, ...]))
     smoothed_covs = jnp.row_stack((smoothed_covs[::-1], filtered_covs[-1][None, ...]))
     smoothed_cross = smoothed_cross[::-1]
-    return LGSSMPosterior(
+    return GSSMPosterior(
         marginal_loglik=ll,
         filtered_means=filtered_means,
         filtered_covariances=filtered_covs,

--- a/ssm_jax/linear_gaussian_ssm/inference_test.py
+++ b/ssm_jax/linear_gaussian_ssm/inference_test.py
@@ -80,3 +80,5 @@ def test_kalman_filter(num_timesteps=5, seed=0):
     assert jnp.allclose(ssm_posterior.smoothed_means, tfp_smoothed_means, rtol=1e-2)
     assert jnp.allclose(ssm_posterior.smoothed_covariances, tfp_smoothed_covs, rtol=1e-2)
     assert jnp.allclose(ssm_posterior.marginal_loglik, tfp_lls.sum())
+
+test_kalman_filter()

--- a/ssm_jax/nonlinear_gaussian_ssm/containers.py
+++ b/ssm_jax/nonlinear_gaussian_ssm/containers.py
@@ -12,26 +12,3 @@ class NLGSSMParams:
     dynamics_covariance: chex.Array
     emission_function: Callable
     emission_covariance: chex.Array
-
-
-@chex.dataclass
-class NLGSSMPosterior:
-    """Simple wrapper for properties of an NLGSSM posterior distribution.
-
-    Attributes:
-            marginal_loglik: marginal log likelihood of the data
-            filtered_means: (T,D_hid) array,
-                E[x_t | y_{1:t}, u_{1:t}].
-            filtered_covariances: (T,D_hid,D_hid) array,
-                Cov[x_t | y_{1:t}, u_{1:t}].
-            smoothed_means: (T,D_hid) array,
-                E[x_t | y_{1:T}, u_{1:T}].
-            smoothed_covs: (T,D_hid,D_hid) array of smoothed marginal covariances,
-                Cov[x_t | y_{1:T}, u_{1:T}].
-    """
-
-    marginal_loglik: chex.Scalar = None
-    filtered_means: chex.Array = None
-    filtered_covariances: chex.Array = None
-    smoothed_means: chex.Array = None
-    smoothed_covariances: chex.Array = None

--- a/ssm_jax/unscented_kalman_filter/inference.py
+++ b/ssm_jax/unscented_kalman_filter/inference.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 from jax import lax
 from jax import vmap
 from tensorflow_probability.substrates.jax.distributions import MultivariateNormalFullCovariance as MVN
-from ssm_jax.nonlinear_gaussian_ssm.containers import NLGSSMPosterior
+from ssm_jax.containers import GSSMPosterior
 import chex
 
 
@@ -186,7 +186,7 @@ def unscented_kalman_filter(params, emissions, hyperparams, inputs=None):
     # Run the UKF
     carry = (0.0, params.initial_mean, params.initial_covariance)
     (ll, _, _), (filtered_means, filtered_covs) = lax.scan(_step, carry, jnp.arange(num_timesteps))
-    return NLGSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
+    return GSSMPosterior(marginal_loglik=ll, filtered_means=filtered_means, filtered_covariances=filtered_covs)
 
 
 def unscented_kalman_smoother(params, emissions, hyperparams, inputs=None):
@@ -199,7 +199,7 @@ def unscented_kalman_smoother(params, emissions, hyperparams, inputs=None):
         inputs (T,D_in): array of inputs.
 
     Returns:
-        nlgssm_posterior: NLGSSMPosterior instance containing properties of
+        nlgssm_posterior: GSSMPosterior instance containing properties of
             filtered and smoothed posterior distributions.
     """
     num_timesteps = len(emissions)
@@ -248,7 +248,7 @@ def unscented_kalman_smoother(params, emissions, hyperparams, inputs=None):
     # Reverse the arrays and return
     smoothed_means = jnp.row_stack((smoothed_means[::-1], filtered_means[-1][None, ...]))
     smoothed_covs = jnp.row_stack((smoothed_covs[::-1], filtered_covs[-1][None, ...]))
-    return NLGSSMPosterior(
+    return GSSMPosterior(
         marginal_loglik=ll,
         filtered_means=filtered_means,
         filtered_covariances=filtered_covs,


### PR DESCRIPTION
- Unified `LGSSMPosterior`, `NLGSSMPosterior`, and `CMGFPosterior` to `GSSMPosterior` in `ssm_jax/containers.py`.
- Updated references to the redundant `Posterior` objects.
- Since `CMGFParams` takes `Callable` function as its emission covariance whereas `NLGSSMParams` takes an array, I did not unify those two.
- Updated name `emission_var_function` in `CMGFParams` to `emission_cov_function`.

Issue #204 