### PR TITLE
Add accuracy, speed comparison with SGD for CMGF multiclass logistic regression

### DIFF
--- a/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
+++ b/ssm_jax/cond_moments_gaussian_filter/demos/cmgf_multiclass_logreg_demo.ipynb
@@ -37,7 +37,7 @@
       "source": [
         "# Silence WARNING:root:The use of `check_types` is deprecated and does not have any effect.\n",
         "# https://github.com/tensorflow/probability/issues/1523\n",
-        "import logging\n",
+        "import logging, sys, warnings, os\n",
         "\n",
         "logger = logging.getLogger()\n",
         "\n",
@@ -47,7 +47,11 @@
         "        return \"check_types\" not in record.getMessage()\n",
         "\n",
         "\n",
-        "logger.addFilter(CheckTypesFilter())"
+        "logger.addFilter(CheckTypesFilter())\n",
+        "\n",
+        "if not sys.warnoptions:\n",
+        "    warnings.simplefilter(\"ignore\")\n",
+        "    os.environ[\"PYTHONWARNINGS\"] = \"ignore\" # Also affect subprocesses"
       ],
       "metadata": {
         "id": "Vo3x6Kglg4IY"
@@ -76,6 +80,8 @@
     {
       "cell_type": "code",
       "source": [
+        "from warnings import simplefilter\n",
+        "\n",
         "import matplotlib.pyplot as plt\n",
         "\n",
         "import jax\n",
@@ -87,7 +93,8 @@
         "from sklearn.linear_model import LogisticRegression\n",
         "from sklearn import preprocessing\n",
         "from sklearn.base import BaseEstimator, ClassifierMixin\n",
-        "from sklearn.preprocessing import OneHotEncoder"
+        "from sklearn.preprocessing import OneHotEncoder\n",
+        "from sklearn.exceptions import ConvergenceWarning"
       ],
       "metadata": {
         "id": "NDRvXsqQpcDv"
@@ -98,36 +105,11 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## 1. CMGF Online Multiclass Logistic Regression"
+        "## 1. CMGF Model for Online Multiclass Logistic Regression"
       ],
       "metadata": {
         "id": "2MIMhuR-EF47"
       }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "First, we generate and standardize random dataset with 10 features and 4 classes."
-      ],
-      "metadata": {
-        "id": "W0rBl8IwEg6w"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "num_points, num_features, num_classes = 10000, 5, 4\n",
-        "input, output = make_classification(n_samples=num_points, n_features=num_features, \n",
-        "                                    n_informative=num_features, n_redundant=0, n_classes=num_classes, random_state=2)\n",
-        "scaler = preprocessing.StandardScaler().fit(input)\n",
-        "input, output = jnp.array(scaler.transform(input)), jnp.array(output)\n",
-        "input_with_bias = jnp.concatenate([jnp.ones((num_points, 1)), input], axis=1)"
-      ],
-      "metadata": {
-        "id": "4kS6np-HELar"
-      },
-      "execution_count": null,
-      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -220,112 +202,6 @@
     {
       "cell_type": "code",
       "source": [
-        "# Helper function to compute accuracy measure\n",
-        "def compute_accuracy(model, input, output, fit=True):\n",
-        "    if fit:\n",
-        "        model = model.fit(input, output)\n",
-        "    return jnp.count_nonzero(model.predict(input) - output == 0) / len(output)\n",
-        "\n",
-        "# Print training accuracy\n",
-        "cmgf_model, sgd_model = CMGFEstimator(EKFParams), LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1)\n",
-        "print(f'CMGF training accuracy: {compute_accuracy(cmgf_model, input, output)}')\n",
-        "print(f'SGD training accuracy: {compute_accuracy(sgd_model, input, output)}')"
-      ],
-      "metadata": {
-        "id": "QEUK_pUGmOkN",
-        "outputId": "500b8546-9af6-4531-e518-db3c678e5601",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "CMGF training accuracy: 0.5953999757766724\n",
-            "SGD training accuracy: 0.4936999976634979\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/sklearn/linear_model/_sag.py:354: ConvergenceWarning: The max_iter was reached which means the coef_ did not converge\n",
-            "  ConvergenceWarning,\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We test the accuracy using 3 repeated trials of 10-fold cross validation."
-      ],
-      "metadata": {
-        "id": "Rm88s6oSFagu"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=3, random_state=1)\n",
-        "\n",
-        "cmgf_est = CMGFEstimator(EKFParams)\n",
-        "n_scores = cross_val_score(cmgf_est, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise')\n",
-        "print(f'{num_points} data points, {num_features} features, {num_classes} classes.')\n",
-        "print(f'EKF-CMGF estimate average accuracy = {n_scores.mean()}')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "RZJFUH_kEgSy",
-        "outputId": "f833924a-afcf-49c4-bd9a-864086ee0169"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "10000 data points, 5 features, 4 classes.\n",
-            "EKF-CMGF estimate average accuracy = 0.5935999999999999\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model = LogisticRegression(multi_class='multinomial', solver='sag')\n",
-        "n_scores = cross_val_score(model, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise')\n",
-        "print(f'{num_points} data points, {num_features} features, {num_classes} classes.')\n",
-        "print(f'sag estimate average accuracy = {n_scores.mean()}')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "vnsOc-wiGQ1U",
-        "outputId": "2da8b5a0-a77c-4014-ee1f-4899364b813d"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "10000 data points, 5 features, 4 classes.\n",
-            "sag estimate average accuracy = 0.5938\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
         "# def repeated_kfold_cv(model, X, y, n_splits=10, n_repeats=3, key=1):\n",
         "#     if isinstance(key, int):\n",
         "#         key = jr.PRNGKey(key)\n",
@@ -350,6 +226,1086 @@
       },
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##2. Accuracy Comparison with SGD"
+      ],
+      "metadata": {
+        "id": "gL591ok4Hs5s"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We compare classification accuracy of CMGF with those of one-pass SGD and multi-pass SGD using 10-fold cross validation."
+      ],
+      "metadata": {
+        "id": "ziBWqA7HYHx8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# # Helper function to compute accuracy measure\n",
+        "# def compute_accuracy(model, input, output, fit=True):\n",
+        "#     if fit:\n",
+        "#         model = model.fit(input, output)\n",
+        "#     return jnp.count_nonzero(model.predict(input) - output == 0) / len(output)\n",
+        "\n",
+        "# # Print training accuracy\n",
+        "# cmgf_model, sgd_model = CMGFEstimator(EKFParams), LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1)\n",
+        "# print(f'CMGF training accuracy: {compute_accuracy(cmgf_model, input, output)}')\n",
+        "# print(f'SGD training accuracy: {compute_accuracy(sgd_model, input, output)}')"
+      ],
+      "metadata": {
+        "id": "i7ScoJbZe7rR"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_cv_accuracies(num_points, num_classes):\n",
+        "    input, output = make_classification(n_samples=num_points, n_features=num_classes+1, \n",
+        "                                        n_informative=num_classes+1, n_redundant=0, n_classes=num_classes, random_state=2)\n",
+        "    scaler = preprocessing.StandardScaler().fit(input)\n",
+        "    input, output = jnp.array(scaler.transform(input)), jnp.array(output)\n",
+        "\n",
+        "    cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=1, random_state=1)\n",
+        "\n",
+        "    cmgf_est = CMGFEstimator(EKFParams)\n",
+        "\n",
+        "    cmgf_score = cross_val_score(cmgf_est, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "    sag_op_score = cross_val_score(LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1), input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "    sag_mp_score = cross_val_score(LogisticRegression(multi_class='multinomial', solver='sag'), input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "\n",
+        "    return cmgf_score, sag_op_score, sag_mp_score\n"
+      ],
+      "metadata": {
+        "id": "JFvfXOraIJoQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_points = 1000\n",
+        "class_range = range(2, 19)\n",
+        "\n",
+        "cmgf_accuracies, sgd_onepass_accuracies, sgd_multipass_accuracies = [], [], []\n",
+        "for num_classes in class_range:\n",
+        "    print(f'{num_points} data points, {num_classes} classes.')\n",
+        "    cmgf_ac, sgd_op_ac, sgd_mp_ac = compute_cv_accuracies(num_points, num_classes)\n",
+        "    cmgf_accuracies.append(cmgf_ac)\n",
+        "    print(f'EKF-CMGF estimate average accuracy = {cmgf_ac}')\n",
+        "    sgd_onepass_accuracies.append(sgd_op_ac)\n",
+        "    print(f'One-pass sag estimate average accuracy = {sgd_op_ac}')\n",
+        "    sgd_multipass_accuracies.append(sgd_mp_ac)\n",
+        "    print(f'Multi-pass sag estimate average accuracy = {sgd_mp_ac}')\n",
+        "    "
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LFIhl10fH8z6",
+        "outputId": "3329a7e0-120b-4230-fdae-3c948facc406"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "1000 data points, 2 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.9040000000000001\n",
+            "One-pass sag estimate average accuracy = 0.89\n",
+            "Multi-pass sag estimate average accuracy = 0.905\n",
+            "1000 data points, 3 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.627\n",
+            "One-pass sag estimate average accuracy = 0.5710000000000001\n",
+            "Multi-pass sag estimate average accuracy = 0.628\n",
+            "1000 data points, 4 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.5499999999999999\n",
+            "One-pass sag estimate average accuracy = 0.48900000000000005\n",
+            "Multi-pass sag estimate average accuracy = 0.5489999999999998\n",
+            "1000 data points, 5 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.48999999999999994\n",
+            "One-pass sag estimate average accuracy = 0.45199999999999996\n",
+            "Multi-pass sag estimate average accuracy = 0.483\n",
+            "1000 data points, 6 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.5640000000000001\n",
+            "One-pass sag estimate average accuracy = 0.519\n",
+            "Multi-pass sag estimate average accuracy = 0.5670000000000001\n",
+            "1000 data points, 7 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.45\n",
+            "One-pass sag estimate average accuracy = 0.409\n",
+            "Multi-pass sag estimate average accuracy = 0.445\n",
+            "1000 data points, 8 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.373\n",
+            "One-pass sag estimate average accuracy = 0.357\n",
+            "Multi-pass sag estimate average accuracy = 0.384\n",
+            "1000 data points, 9 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.46499999999999997\n",
+            "One-pass sag estimate average accuracy = 0.426\n",
+            "Multi-pass sag estimate average accuracy = 0.4629999999999999\n",
+            "1000 data points, 10 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.4130000000000001\n",
+            "One-pass sag estimate average accuracy = 0.368\n",
+            "Multi-pass sag estimate average accuracy = 0.41\n",
+            "1000 data points, 11 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.387\n",
+            "One-pass sag estimate average accuracy = 0.35\n",
+            "Multi-pass sag estimate average accuracy = 0.393\n",
+            "1000 data points, 12 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.35900000000000004\n",
+            "One-pass sag estimate average accuracy = 0.289\n",
+            "Multi-pass sag estimate average accuracy = 0.365\n",
+            "1000 data points, 13 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.33199999999999996\n",
+            "One-pass sag estimate average accuracy = 0.3\n",
+            "Multi-pass sag estimate average accuracy = 0.33999999999999997\n",
+            "1000 data points, 14 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.31100000000000005\n",
+            "One-pass sag estimate average accuracy = 0.28400000000000003\n",
+            "Multi-pass sag estimate average accuracy = 0.31900000000000006\n",
+            "1000 data points, 15 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.257\n",
+            "One-pass sag estimate average accuracy = 0.24899999999999997\n",
+            "Multi-pass sag estimate average accuracy = 0.261\n",
+            "1000 data points, 16 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.257\n",
+            "One-pass sag estimate average accuracy = 0.24500000000000002\n",
+            "Multi-pass sag estimate average accuracy = 0.272\n",
+            "1000 data points, 17 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.2840000000000001\n",
+            "One-pass sag estimate average accuracy = 0.29\n",
+            "Multi-pass sag estimate average accuracy = 0.291\n",
+            "1000 data points, 18 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.257\n",
+            "One-pass sag estimate average accuracy = 0.225\n",
+            "Multi-pass sag estimate average accuracy = 0.25600000000000006\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot result\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(class_range, cmgf_accuracies, 'r', label='CMGF-EKF')\n",
+        "ax.plot(class_range, sgd_onepass_accuracies, 'y', label='SGD (single pass)')\n",
+        "ax.plot(class_range, sgd_multipass_accuracies, 'b--', label='SGD (multi pass)')\n",
+        "ax.set_xticks(class_range)\n",
+        "ax.set_xlabel('Number of output classes')\n",
+        "ax.set_ylabel('10-fold cv average accuracy')\n",
+        "ax.set_title('10-fold cv accuracy (CMGF vs SGD )')\n",
+        "ax.legend();"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        },
+        "id": "Gzb7T-PFIE3w",
+        "outputId": "47299b8f-6ff2-4f43-c0f7-53b6021baaa3"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd3gU1frA8e+bRtqG0ALSewslQIIKFrAgYkEFKWJBBcUrKijeq1z0YkFFVO4P0YugSBMRC4oKKigoINJrEEgIvdcUCCHJvr8/ZhM2ySbZhCxp5/M8+5idOTPzToJzZuac8x5RVQzDMIzyy6u4AzAMwzCKl6kIDMMwyjlTERiGYZRzpiIwDMMo50xFYBiGUc6ZisAwDKOcMxVBOSMir4vICRE54kbZPSJyUy7ruojIgaKPsHwSkWoisl1EAoo7lrJKRCo4fsfVijuWksZUBCWciAwVkbUikiIi01ysv9Hxj/uciCwRkXp57Ksu8BzQUlVreDBso+BeAKapanLGAhG5RUT+EJFEETkuIr+LyJ2OdQNFREVkvPNORKSnY/k0p2V+IvKyiOwQkbMiclBEFopIN6cye0QkWUSSnD41PXWyInKNiPwpIvEickpEVohIlNP6K0RkiogccsQSJyLTRKS5Y319x3lmxHpURH4QkZtzO6aqpgBTsX7XhhNTEZR8h4DXsf4BZyEiVYFvgJeAysBa4Is89lUXOKmqxzwQZ5kjIj6X6TgVgIeAWU7LegNfAjOA2kB14GXgDqdNdwF9ssX5ELAz2yG+AnoCDwKVgAbA/wG3ZSt3h6oGO30OXeq5uSIiIcAPwPtY/25rAa8AKY71VYA/gUDgWsAGtAd+B7Jf6ENVNRhoCywC5onIwDwOPxt4yPE7NzKoqvmUgg9WZTAt27LHgD+dvgcByUBzF9vf5FhnB5Iy9gXcCUQDZ4ClQAunbfYANzl+DgCmAaeBbcDzwIE84g3H+h/zFHAUGAnUdMRQ2alcO+AE4OtiHx2BlY7YDgMTAb+8juFY7u043i4gEVgH1AHqAwr4OO1jKTDI8fNAYAUwHjjp+J03An5zfD8BfIZ18cnYvg5WZXzcUWYi4OeIqbVTuTDgHFDNxXleB8Q6fRdgH/B8Hr/fgcBy4CfgNseyysARYJzT3zfj7147n39fmX/rfMr9Ddzu9N3Hce7tAX+syuyk42+2BqjuYh+RwJl8/q1vArzyKJPjb+lYPsLxbyGvbWOA64v7/+mS9DFPBKVbONb/MACo6lmsi1949oKquhi4FTik1t3eQBFpCnwODAOqAQuA70XEz8Wx/oN1UWwE3IJ15+mSiNiAxVgXqZpAY+BXte4wVwK9nIrfB3ylqqkudpUODAeqAlcDNwL/yOsYju2eBfoDPYAQ4BGsi7A7rgTisO7Ax2BdlN90HKMF1oV/tCMGb6w7271YF6ZawBxVvQDMAe532m9/x+/guItjtgZ2OH1v5jjOV27EOwPrTh+gH/Adjjtrh5uAVapaVO05n2OdS4ZbgBOquh7r30RFrNirAEOwKqHsdgLpIjJdRG4VkUrZ1t8EzFNVeyHi+war0m2WR5m/sZ4gDAdTEZRuwUB8tmXxWI/S7ugL/KiqixwX4new7vw7uSjbBxijqqdUdT8wIY/93g4cUdV3VfW8qiaq6irHutk4LiQiIlgXr9mudqKq61T1L1VNU9U9wEfA9W4cYxAwSlV3qGWTqp5071fCIVV933HMZFWNdfx+UhwX8fecYuiIVUE8r6pnHXEsd6ybDvR3nCPAA8DMXI4ZivXkkqGK47+H3Yh3HtBFRCpiVQgzsq2vivWUAICIVBaRM4538+ezlf3Wse6MiHyby/FmA3eKSKDj+31YlQNAqiP2xqqa7vj7JWTfgWPZNVh39FOA4yIyX0Sq5xLznY6YEkXklzx/G9arVLCejnKTiPU7NxxMRVC6JWHd8ToLARJF5FqnhrToXLaviXU3C4DjDmw/1p2tq7L7nb7vdVEmQx2sJxNXvgauFpErsF6J2IFlrgqKSFNHA+AREUkA3sC6SOR3jLzW5cf5HBGR6iIyx9HAmoD16sM5hr2qmpZ9J45K6RzWRbo51hPL/FyOeZqslXdGpXVFfsGq1bj8IzAKqKKqK7IVOem8H0dFHgp0ALK/J79LVUMdn7tyOV4s1h31HY7K4E4uVuQzgZ+BOY5G3rdFxDeX/fytqgNVtTbQCuvf139ziXm+I+bhWK/d8pLxb/dUHmVsWK+uDAdTEZRu0Tg94opIENarm2hVXaYXG/1yvCpyOATUc9pesC5uB12UPexYl6FuHnHtBxq6WqGqp4FfsJ5G7sN6lZJbCtz/AduBJqoagvXeP+MOO9djONY1crH8rOO/gU7Lsveeyh7LG45lrR0x3J8thrp5NCpPd5R/AOv1V/Y78AybgaZO33c49t3LdfEcZmD1BpvlYt2vQJSI1HZzX+7IeD3UE9jmqBxQ1VRVfUVVW2I9Vd7OxddWuVLV7VjtT62cYr5LRApzfbobOEbWV23ZtcDplaphKoIST0R8RMQfqwHUW0T8nS4884BWItLLUeZlYLPjfyx3zAVuc3RB9cW6mKRg9dhwVfZFEankuKg8lcd+fwCuEJFhYvXdtonIlU7rZ2NdIHqTy2shBxuQACQ57qqfcPMYHwOviUgTsbQRkSqOVzsHgftFxFtEHsF1hZE9hiQgXkRqYTWSZ1iNVUG+JSJBjr9NZ6f1s7AuTPeT85WNs9VAqGP/OCrGZ4GXRORhEQkRES9Hl8vJLrbP6E3zfvYVqvoLsATrtc+VYnUl9QWuyue88zIH6Ib198j8+4lIVxFp7Wg7ScB6VZTjPb+INBeR5zIqJxGpg1Wx/OUo8h5W76aZItLI8Te0ARG5BeR4chuK1Zb1Ym7tC47fcWWnYxlgeg2V9A9Ww6Rm+4x2Wn8T1l1zMlYPmPp57KsL2Xr6YF2otmG1LfwOhDut28PFXkOBWBezM7jXa6gV1p3daaz3vS84rQvAek8bnc+5X+c4tySs10evAsvzOwZWpTkK2O04zhocvWawGsx3O87jXcc5O/caWp4thnCsXkdJwEasyvKA0/q6wLdc7FU0Idv2ix2/R8nnXMcB/8q2rLvjvJOweuYs5WIPoRyxOm2XpYcZ1uuU0Vi9Zc4BB4CFQDdXf2s3/13+CqQBNZyW9ce6Ez+L1XNnAtl69TjK1cK6sTjoKHsQq/0nxKlMTeATrIo2CetV33Qcvdq42GsoybGPY1idHbrnE/fzwHvF/f91SfuI45djGIYHiMhUrAboUfmUq4Z10W+nToPKjKLjGDuwCbhOzViaLExFYBgeIiL1sZ4i2qnq7uKNxjByZ9oIDMMDROQ1YCswzlQCRklnnggMwzDKOfNEYBiGUc5dlqRaRalq1apav3794g7DMAyjVFm3bt0JVXWZgrvUVQT169dn7dq1xR2GYRhGqSIiuWYDMK+GDMMwyjlTERiGYZRzpiIwDMMo50pdG4FhGAWTmprKgQMHOH8+t5x3Rlni7+9P7dq18fV1mfjVJVMRGEYZd+DAAWw2G/Xr1+fi9AhGWaSqnDx5kgMHDtCgQQO3tzOvhgyjjDt//jxVqlQxlUA5ICJUqVKlwE9/piIwjHLAVALlR2H+1h6tCESku4jsEJFYEXnBxfp6IvKriGwWkaVFPHlGVvHx8PvvHtu9YRhGaeWxisAxOcUHWPnfW2LN39oyW7F3gBmq2gYr1/ybnopn2bPzaNclhD2bsk/xaxjG5XDkyBH69etHo0aN6NChAz169GDnzp2ICKNGXczSfeLECXx9fRk6dGjmslmzZtGmTRvCw8Np27YtgwYN4swZa7bJLl260KxZMyIiIoiIiOCrr77Kcexp06ZRrVq1zDIRERFs27aNPXv20KpVq8xyU6ZMoUOHDpw+fZqBAwfSoEGDzPITJuQ1TXfp5snG4o5ArKrGAYjIHBxT2zmVaYk1ExM4ZlHyVDAhV7dk49R2LJ+5kfptc53oyDAMD1BV7r77bh566CHmzJkDwKZNmzh69CgNGjTgxx9/5PXXXwfgyy+/JDz84uyqP/30E+PHj2fhwoXUqlWL9PR0pk+fztGjRwkNteag/+yzz4iMjMwzhr59+zJx4sQsy/bs2ZP588yZM3n//ff57bffqFSpEgDjxo2jd+/el3z+JZ0nXw3VIutE4AfIOSn6JuAex893AzYRqZJ9RyLymIisFZG1x48fL1Qwrfq2IoR4lv2aUqjtDcMovCVLluDr68uQIUMyl7Vt25Y6deoQGBhIixYtMlPHfPHFF/Tp0yez3JgxY3jnnXeoVcu6fHh7e/PII4/QrFmzIotv7ty5vPXWW/zyyy9UrVq1yPZbWhR399ERwEQRGQj8gTVlXXr2Qqo6GZgMEBkZWai82RLkzVVh61i+w3PNEIZR4g0bBhs3Fu0+IyLgv//Ns8jWrVvp0KFDruv79evHnDlzqF69Ot7e3tSsWZNDhw4BEB0dTfv27fPc/4ABAwgICADg119/pUqVHPeTfPHFFyxfvjzz+8qVKwHYu3cvQ4cOZcOGDdSoUSPLNs8//3zmk8rMmTNp3bp1nnGUVp58IjgI1HH6XtuxLJOqHlLVe1S1HfBvx7Iznghm3763qHPHQrYlN+DkQTOwxjBKku7du7No0SLmzJlD3759cy23ZcsWIiIiaNSoEV988UXm8s8++4yNGzeyceNGl5UAWK+GMsps3Lgxs+KoVq0adevWZe7cuTm2GTduXGb5sloJgGefCNYATUSkAVYF0A+4z7mAiFQFTqmqHXgRmOqpYGy2SDp0eIVTX7UlYXkDqvTt6KlDGUbJlc+du6eEh4e7bMTN4OfnR4cOHXj33XfZtm0b8+fPz7Lt+vXr6dq1K61bt2bjxo0MHTqU5OTcp3b+4IMPmDJlCgALFizIM7bAwEAWLFjAtddeS1hYGAMGDCjg2ZV+HnsiUNU0YCjwM/A3MFdVo0XkVRG501GsC7BDRHYC1YExnorHZoukRYs1/F+3fjSI+9VThzEMw4UbbriBlJQUJk+enLls8+bN7N9/sRnxueeeY+zYsVSuXDnLti+++CIjRozgwIEDmcvyqgQAnnzyycw7+Zo1a+YbX1hYGD/99BMjR47k559/dve0ygyPthGo6gJgQbZlLzv9/BWQ+21CEfLzq06FCnVIjIrn2E+bCXvxchzVMAywBjnNmzePYcOGMXbsWPz9/alfvz7/dXpCCQ8Pz9JbKEOPHj04fvw4t956K+np6YSGhtKqVStuueWWAsWQvY3gww8/zFJJNGjQgPnz59OjRw/mzZtXiLMsvUrdnMWRkZFa2Ilptm7txcSxbZk66wXOJHgTaPMu4ugMo+T5+++/adGiRXGHYVxGrv7mIrJOVV32sS1XKSZstkjqtVxFKn6snrunuMMxDMMoEcpZRRBFq1Z/IthZ/m3hxiMYhmGUNeWsIuiAzXaGZpW3sXxtQHGHYxiGUSKUq4rA17cSAQGNadt2PX8ebUh6WulqHzEMw/CEclURgNVOcPNdM/ifDiE9bm9xh2MYhlHsymFFEEWjNr9yb6XZ+K1aVtzhGIZhFLtyWBFYvafWNW3HT5+fLuZoDKN8GDNmDOHh4bRp04aIiAhWrVoFQFpaGiNHjqRJkyaZ6Z7HjLk4rtTb25uIiIjM9NPvvvsudrvd5TEOHz7M7bffnmccnTp1KvQ5TJs2LUtq7OL0ww8/8PLLL+df0E3lriIIDm4PCGPP/4eHf+lPKRtGYRilzsqVK/nhhx9Yv349mzdvZvHixdSpY6UhGzVqFIcOHWLLli1s3LiRZcuWkZqamrltQEAAGzduJDo6mkWLFrFw4UJeeeUVl8d57733GDx4cJ6x/Pnnn0V3YsXotttu4/vvv+fcuXNFsr9yVxH4+AQTGNiC1let50h6NXatOVXcIRlGmXb48GGqVq1KhQoVAKhatSo1a9bk3LlzTJkyhffffx9/f38AbDYbo0ePdrmfsLAwJk+ezMSJE3E1EPbrr7+me/fugJWxtGPHjkRERNCmTRtiYmIACA4OBmDp0qV06dKF3r1707x5cwYMGJC5zwULFtC8eXM6dOjA008/7fIp4/jx4/Tq1YuoqCiioqJYsWJFjjLTpk2jZ8+edOnShSZNmmSpwO666y46dOhAeHh4ZtqN9PR0Bg4cSKtWrWjdujXjx48HYMKECbRs2ZI2bdrQr18/wBqp3aVLF3744Yd8fvvuKe401MXCZoui6ZWL4KNXWD5rD407Vs5/I8MoA2JihpGUVLRpqIODI2jSJPdkdt26dePVV1+ladOm3HTTTfTt25frr7+e2NhY6tati81mc/tYDRs2JD09nWPHjlG9evXM5bt376ZSpUqZlc2kSZN45plnGDBgABcuXCA9PUd2ezZs2EB0dDQ1a9akc+fOrFixgsjISB5//HH++OMPGjRoQP/+/V3G8cwzzzB8+HCuueYa9u3bxy233MLff/+do9zq1avZunUrgYGBREVFcdtttxEZGcnUqVOpXLkyycnJREVF0atXL/bs2cPBgwfZunUrQOYMbG+99Ra7d++mQoUKmcsAIiMjWbZsWZa5Gwqr3D0RgNVOUKveX1SWkyxfmpr/BoZhFFpwcDDr1q1j8uTJVKtWjb59+zJt2rQc5T799FMiIiKoU6dOlmR07jh8+DDVqlXL/H711VfzxhtvMHbsWPbu3ZuZctpZx44dqV27Nl5eXkRERLBnzx62b99Ow4YNadCgAUCuFcHixYsZOnQoERER3HnnnSQkJJCUlJSj3M0330yVKlUICAjgnnvuycx1NGHCBNq2bctVV13F/v37iYmJoWHDhsTFxfHUU0/x008/ERISAkCbNm0YMGAAs2bNwsfn4r17WFhY5pwNl6pcPhGEhETh5aVE1dnEipiGxR2OYVw2ed25e5K3tzddunShS5cutG7dmunTp9OnTx/27dtHYmIiNpuNhx9+mIcffphWrVq5vIMHiIuLw9vbm7CwsCzLAwICOH/+4jwj9913H1deeSU//vgjPXr04KOPPuKGG27Isk3G00NGfGlpaW6fj91u56+//sp8pZUbEcnxfenSpSxevJiVK1cSGBhIly5dOH/+PJUqVWLTpk38/PPPTJo0iblz5zJ16lR+/PFH/vjjD77//nvGjBnDli1b8PHx4fz58y4ruMIol08EQUFtEfHhxX9MZGVqJBRRg4thGDnt2LEj8x09wMaNG6lXrx6BgYE8+uijDB06NPMinp6ezoULF1zu5/jx4wwZMoShQ4fmuMA2bdo0y/zDcXFxNGzYkKeffpqePXuyefNmt2Jt1qwZcXFxmftynvzGWbdu3Xj//feznJMrixYt4tSpUyQnJ/Ptt9/SuXNn4uPjqVSpEoGBgWzfvp2//voLgBMnTmC32+nVqxevv/4669evx263s3//frp27crYsWOJj4/PfPLYuXMnrVq1cuu88lMunwi8vf0JCmqNb+RuQtNPwqpV0LVrcYdlGGVSUlISTz31FGfOnMHHx4fGjRtnNpCOGTOGl156iVatWmGz2QgICOChhx7KTA+dnJxMREQEqamp+Pj48MADD/Dss8/mOEZQUBCNGjUiNjaWxo0bM3fuXGbOnImvry81atRg5MiRbsUaEBDAhx9+SPfu3QkKCiIqKspluQkTJvDkk0/Spk0b0tLSuO6665g0aVKOch07dqRXr14cOHCA+++/n8jISFq3bs2kSZNo0aIFzZo146qrrgLg4MGDPPzww5ndY998803S09O5//77iY+PR1V5+umnCQ0NBax5oN988023zis/5SoNtbMdOx7j+LG5/HXdo4Tc2ZXHvsu7/7FhlFblJQ31vHnzWLduXeYcw4WVlJREcHAwqsqTTz5JkyZNGD58eIH3M23aNNauXcvEiRMvKR5Xjh49yn333cevv7qeZMukoXaTzRZFWno880P7MGVpk+IOxzCMS3T33XdTv379S97PlClTMgexxcfH8/jjj196cEVs3759vPvuu0W2v3L7RJCYuIF169oz/9VZTFjSlzOnITi0XL4pM8q48vJEYFxkngjcFBTUCpEKtO6ynXR8+Gt2XHGHZBiGUSzKbUXg5eVLcHAEjTuvwIt0ls83I4wNwyifPFoRiEh3EdkhIrEi8oKL9XVFZImIbBCRzSLSw5PxZBcSEoX6rubqCutJjDMzlhmGUT55rCIQEW/gA+BWoCXQX0RaZis2Cpirqu2AfsCHnorHFZstErv9LD8NepV3EwZjMtAZhlEe5VsRiMhTIlKpEPvuCMSqapyqXgDmAD2zlVEgxPFzRaBoxku7yWaz+ggnda4CR4/Crl2X8/CGUW6UlDTU7lq6dGnmvpYuXZola+mkSZOYMWNGkRzHXSNGjOC3337z2P7d6SZTHVgjIuuBqcDP6l5Xo1qAc8KQA8CV2cqMBn4RkaeAIOAmVzsSkceAxwDq1q3rxqHdExjYDG/vYI7WhJ78xYCXT/D07MZFtn/DMLKmoa5QoQInTpzIHD08atQojhw5wpYtW/D39ycxMTFLt8iMNNQAx44d47777iMhIcFlKmp30lAXxtKlSwkODs6cy2DIkCFFfoz8PPXUUwwePDhHmoyiku8TgaqOApoAnwADgRgReUNEGhXB8fsD01S1NtADmCkiOWJS1cmqGqmqkc6JpS6ViDfBwe1JC97OSa9qLFnhV2T7NgzDUhxpqKdNm8Zdd93FzTffTP369Zk4cSLvvfce7dq146qrruLUKatzSJcuXcjojn7ixIkc4xD27NnDpEmTGD9+PBERESxbtozRo0fzzjvv5Dj+wIEDGTJkCJGRkTRt2jQzRfSePXu49tprad++Pe3bt898ujh8+DDXXXcdERERtGrVimXLluWairpevXqcPHmSI0eOFORX7za3Os6rqorIEeAIkAZUAr4SkUWq+s9cNjsI1HH6XtuxzNmjQHfHMVaKiD9QFTjm/ilcGpstioMHJ3JN7Th+PNgeVciWxsQwypQuXXIu69MH/vEPK+1WDxddNgYOtD4nTkDv3lnXLV2a9/GKIw01wNatW9mwYQPnz5+ncePGjB07lg0bNjB8+HBmzJjBsGHD8j1e/fr1GTJkCMHBwYwYMQIg19G8YF30V69eza5du+jatSuxsbGEhYWxaNEi/P39iYmJoX///qxdu5bZs2dzyy238O9//5v09HTOnTvHxo0bXaaiBmjfvj0rVqygV69ebv++3OVOG8EzIrIOeBtYAbRW1SeADkBeEa0BmohIAxHxw2oMnp+tzD7gRsdxWgD+wGXtvmOzRaKaQtQ1xzmRXpkdK05czsMbRplXHGmoAbp27YrNZqNatWpUrFiRO+64A4DWrVtnSVBXlPr06YOXlxdNmjShYcOGbN++ndTUVAYPHkzr1q2599572bZtGwBRUVF8+umnjB49mi1btmCz2XJNRQ1Fm3Y6O3eeCCoD96jqXueFqmoXkVxbZlQ1TUSGAj8D3sBUVY0WkVeBtao6H3gOmCIiw7Eajge62f5QZEJCrAbjNrcdhNmw/LO9NL+m6uUMwTAuq7zu4AMD815ftWr+TwCuXO401JA1zbSXl1fmdy8vr8yU0z4+PpmNz9m3LwxXaafHjx9P9erV2bRpE3a7PfM12HXXXccff/zBjz/+yMCBA3n22Wd58MEHXaaizoivqNJOZ+dO99GFQOZoKxEJEZErAVQ155Q8TlR1gao2VdVGqjrGsexlRyWAqm5T1c6q2lZVI1T1l8KfSuH4+zfEx6cS1SL+5gHvz6h95NLTVxiGcVFxpKF2V/369Vm3bh0AX331lcsyNpuNxMREt/b35ZdfYrfb2bVrF3FxcTRr1oz4+HiuuOIKvLy8mDlzZmYlt3fvXqpXr87gwYMZNGgQ69evd5mKOkNRpp3Ozp0ngv8B7Z2+J7lYVmqJCDZbJEnn1jPj2jjYnwiUvCRThlFaFUcaaneNGDGCPn36MHnyZG677TaXZe644w569+7Nd999l2UOAlfq1q1Lx44dSUhIYNKkSfj7+/OPf/yDXr16MWPGjMz01mD1Rho3bhy+vr4EBwczY8YMl6moAVJTU4mNjSUy0mWqoEuWb9I5EdmoqhHZlm1W1TYeiSgfRZV0zllc3Ej27x/HNb89x4nXphN8aCdBNdxvwDKMkqy8JJ0rqjTUhTVw4EBuv/12emdvTS8C8+bNY/369bz22mtulfdE0rk4EXlaRHwdn2eAMpWhzWaLQjWNlVe0poYe5seJu4s7JMMwCqio0lCXRGlpaTz33HMe2787FcEQoBNW18+MQWGPeSyiYmCzWZVk7S5HCCKJ5YvM1JWGURoNGjSo2I49bdo0jzwNANx7772ZM5N5Qr5tBKp6DKvrZ5lVoUJtfH2rk6ybuSo4mmXbqhR3SIZRpFQ1RwOrUTYVpuNlvhWBY5DXo0A4Vj//jIM9UuCjlVAZDcaJiWu5puUpXlsdSfyJVCpW9S3u0Azjkvn7+3Py5EmqVKliKoMyTlU5efJkZhdVd7nTa2gmsB24BXgVGADk2W20NAoJieLUqQV06u6NfbU3K2fF0H1Y8+IOyzAuWe3atTlw4ADHj5tU6+WBv78/tWvXLtA27lQEjVX1XhHpqarTRWQ2sKxQEZZgVjuBEt77PFNffZh2ZzoCpiIwSj9fX18aNGhQ3GEYJZg7jcWpjv+eEZFWWOmiw/IoXyplNBjbQ2N4uNEyqm/8uZgjMgzDuDzcqQgmO+YjGIWVK2gbMNajURUDP7/qVKhQh8TEtRzqcAdTFjcg5byZqMYwjLIvz4rAkRI6QVVPq+ofqtpQVcNU9aPLFN9lZbNFkZCwhlVVb+Oxs+NZ983e/DcyDMMo5fKsCFTVDuSWZrrMsdkiOX9+F1cOsLqPLv/6aDFHZBiG4XnuvBpaLCIjRKSOiFTO+Hg8smKQMXWlf7PjNPOOYdlqM1GNYRhlnzu9hvo6/vuk0zIFGhZ9OMXLZusAQGLSOq6p7cU3+yOx28HLnerSMAyjlHJnqsoGLj5lrhIA8PWtREBAYxIT13Btp3RO20OJWW5eDxmGUba5M7L4QVfLVXVG0YdT/Gy2SOLjV3DP46Po8Xk1qh2eyMWHIsMwjLLHnR2TcogAACAASURBVJceUU6fa4HRwJ0ejKlY2WxRpKTsp0JUdaoFJcPy5cUdkmEYhke5k3TuKefvIhIKzPFYRMUsY2BZYvJG/mw8nG8+i+TTvOeiMAzDKNUK0wx6Fiiz49WDg9sDXiQkrGFPzU5MO92TfVsTijsswzAMj8m3IhCR70VkvuPzA7ADmOf50IqHj08wgYEtrAbjuxzjCWaUqXl4DMMwsnCn++g7Tj+nAXtV9YA7OxeR7sD/Ad7Ax6r6Vrb144Gujq+BQJiqem72BTfZbJGcOrWQK/u2xPZ4AssWp3BfcQdlGIbhIe5UBPuAw6p6HkBEAkSkvqruyWsjEfEGPgBuxprZbI2IzFfVbRllVHW4U/mngHYFP4WiFxISxdGj00mrcIpOFQ+yfEf14g7JMAzDY9xpI/gSsDt9T3csy09HIFZV41T1AlYDc888yvcHPndjvx6X2WCcuJYb25ygYvIRUpNSijkqwzAMz3CnIvBxXMgBcPzsTu6FWsB+p+8HHMtyEJF6WA3Qv+Wy/jERWSsiay/H5BpBQW0R8SExcQ3PP5vOcu2M76a1Hj+uYRhGcXCnIjguIpnjBkSkJ3CiiOPoB3ylqumuVqrqZFWNVNXIatWqFfGhc/L29icoqDWJiWuhc2crhmVmPIFhGGWTOxXBEGCkiOwTkX3Av4DH3djuIFDH6XttxzJX+lFCXgtlsNmiSExci1atyj9CP+Omd7oXd0iGYRge4U6uoV2qehXQEmipqp1UNdaNfa8BmohIAxHxw7rYz89eSESaA5WAlQUL3bNstkjS0s6QnLwLW93KLDvZguSz9vw3NAzDKGXcGUfwhoiEqmqSqiaJSCUReT2/7VQ1DRgK/Iw12f1cVY0WkVedXzVhVRBzVLVETQeWkZI6MXEN13T1JRU/1szdXcxRGYZhFD13Xg3dqqpnMr6o6mmghzs7V9UFqtpUVRup6hjHspdVdb5TmdGq+kJBA/e0oKBwvLz8SUxcS+cHGwGwbF5RN40YhmEUP3cqAm8RqZDxRUQCgAp5lC8TvLx8CQ6OIDFxDZXb1SPcZzvL15b50zYMoxxyZ0DZZ8CvIvKp4/vDwHTPhVRy2GyRHD78KYqdf7RZQXrcXiCiuMMyDMMoUu40Fo8FxgAtHJ/XVPVtTwdWEthsUdjtZzl3bjv/GHiOp868BnvNhPaGYZQt7jwRoKoLgYUejqXEcR5hHHTttZykMonzNlB/WL1ijswwDKPouNNr6CoRWSMiSSJyQUTSRaRc5GUODGyGt3cwCQlroHVr2ssG/jWxdnGHZRiGUaTcaSyeiJUHKAYIAAZhJZMr80S8CQ5ub40w9vamc41dLNtbl5LV0dUwDOPSuDUxjWMAmbeqpqvqp0C5GWZrs0WRlLQRu/0C10ae53BaGLs3nMl/Q8MwjFLCnYrgnGNk8EYReVtEhru5XZlgs0WimsLZs9Fcc7eV52jZDDOwzDCMssOdC/oDjnJDsaaprAP08mRQJUlIyMURxuF9wgnlNMuXpBZzVIZhGEXHncnrM/pLngde8Ww4JY+/f0N8fCqRmLiWmjUfY3aLUTT22g/MLe7QDMMwikS5ecVTWCKCzRZJYuIaAG69w4cm0d9CcnIxR2YYhlE0TEXgBpstkrNnt5Kenkxyx+uZntqf9bO25b+hYRhGKeB2RSAigZ4MpCSz2aJQTSMpaRNena7icT7is+mmncAwjLLBnQFlnURkG7Dd8b2tiHzo8chKEOcRxhWuqEzHwGiWbw0t5qgMwzCKhjtPBOOBW4CTAKq6CbjOk0GVNBUq1MbXt3pmO8G1zY6xPr4RsVtMO4FhGKWfuwPK9mdb5HJu4bJKRAgJsaauBBj8z0pUJJ47Op8k/rSZtcwwjNLNnYpgv4h0AlREfEVkBNaMY+WKzRbJuXN/k5aWSP1+V/HVE79RM3EHqaPHFHdohmEYl8TdyeufBGphTT4f4fherlhTVypJSRsA6PLBvSx+7EuqTngZ+yef5r2xYRhGCebOfAQnVHWAqlZX1TBVvV9VT16O4EqSiw3GVjsBIsjE90no2pObBtfnk+e3F2N0hmEYhZfvyGIRmeBicTywVlW/K/qQSiY/vzAqVKib2U4AgK8vgXOn4VM/mifeaUizdvu45r66xRekYRhGIbjzasgf63VQjOPTBqgNPCoi/81rQxHpLiI7RCRWRFxOUC8ifURkm4hEi8jsAsZ/WdlskdbcBE58qobyxfLaNPDexz0PBrFnw+liis4wDKNw3KkI2gBdVfV9VX0fuAloDtwNdMttIxHxxpq34FagJdBfRFpmK9MEeBHorKrhwLBCncVlYrNFcf78LlJTs17sK0XU4/tZCaSme3HntadIOplSTBEahmEUnDsVQSUg2Ol7EFBZVdOBvK54HYFYVY1T1QvAHKBntjKDgQ9U9TSAqh5zO/Ji4DywLLum/doz98WNnD0Lhwa9jJm9xjCM0sKdiuBtrLkIPhWRacAGYJyIBAGL89iuFuA8/uCAY5mzpkBTEVkhIn+JiMsJb0TkMRFZKyJrjx8/7kbInmGzdQBcVwQAN7/Rlb9Hzabpt2/Dm29eztAMwzAKzZ001J+IyAKsO3yAkap6yPHz80Vw/CZAF6x2hz9EpLWqZpkCTFUnA5MBIiMji+1W29e3EgEBjS/2HHLB79VRpMXuZPi/bVx1ZBUDJlx5GSM0DMMoOHeTzp0HDgOngcYi4k6KiYNYk9hkqO1Y5uwAMF9VU1V1N7ATq2IosWy2qDwrAkSwfzSFLSGdefT9tqz6ZOvlC84wDKMQ3Ek6Nwj4A/gZa2Kan4HRbux7DdBERBo4prrsB8zPVuZbrKcBRKQq1quiODdjLxY2WyQpKQdISTmSaxm/EH++WlWXmj7HuOuxahz468BljNAwDKNg3HkieAaIAvaqalegHZDv7O2qmoY1veXPWCkp5qpqtIi8KiJ3Oor9DJx0ZDddAjxf0gerWSOMc28nyFC1eVW+/zqVJHsgPbsmcO5IwuUIzzAMo8DcqQjOq+p5ABGpoKrbgWbu7FxVF6hqU1VtpKpjHMteVtX5jp9VVZ9V1Zaq2lpV5xT2RC6X4OB2gFe+FQFA+J2N+Py1Xew8X4cNd78KaWmeD9AwDKOA8m0sBg6ISCjWa5xFInIa2JvPNmWWj08wgYEt8m4ncHL7qAh2B06n6nPvwvAUeP99D0doGIZRMO70Grrb8eNoEVkCVAR+8mhUJZzNFsmpUwtRVUQk3/JVn30IDm1hyrvxVDq7gN5Te1yGKA3DMNyT56shEfEWkcxsaqr6u6rOdwwQK7dCQ68nNfUYhw5NcnubtDFjmVbpWR78tAvrJyz3YHRFQxX27SvuKAzDuBzyrAgco4d3iIjJpOakRo0HqVz5VmJjnyE+foVb2/hU8OabtXWp6htPz2H1OfzrNg9HeWmGPZlK/frKsj/MCGnDKOvcTTERLSK/isj8jI+nAyvJRLxp0WI2/v712Lq1Fykp2YdHuFa9YRDzf/DmFJW5u8d5zu/JvQtqcfp8ZhoT/ucLqvx7yIniDscwDA9zpyJ4CbgdeBV41+lTrvn6hhIePo/09CSio3tjt7uXaC6iWxgz3z7C6gsRLLz5PTh3zsORFsyO7cqgR9K5lj/4MeQ+piT0g/PnizsswzA8yJ2JaX4H9gC+jp/XAOs9HFepEBzciubNp5GQ8BcxMU+7vd09IxqybeIS7t71Djz0ENhLzrzHDWa9xrC0d/ji2dXc+s1gmh38DcaPNzn0DKMMc2dk8WDgK+Ajx6JaWF1JDSAsrDd1677I4cOTOXRostvbNX/yRhg3jj++OsqPfWd4MEL32O1wZsIM/Mb8hzGPxHHFO8/BjTeS0KMf97wUzvT/y3cMoWEYpZQ7r4aeBDoDCQCqGgOEeTKo0qZBg9eoVOkWYmKGEh+/0u3tdPizvFh9Kn2/6s3KhycXa+rqtx/ZTsQz13Gka3+YNAkc3WJt/32Ng/YavPRvO8nJxRaeYRge5E5FkOLcXVREfADzosCJiDctW86mQoU6REf3IiXlsHvbeQlfrmnAFSFnuWVaP1bdMxbS0z0cbU6/friDf09vwlWVdlD9u8ng63sxxiaNGdtnPQfOVeaDF/bnsRfDMEordyqC30VkJBAgIjcDXwLfezas0sfXtzKtWn1LWlq8o/HYvaEWNet4s2RrGGGhqXT79glWdxsFKZdvhrP9y/fSf2gVmvvu4uM1EYgtOEeZLpPvo7vfr7zxYUXOnDb3AIZR1rhTEbwAHAe2AI8DC4BRngyqtAoObk3z5p+SkPAnsbHPuL1d7TrCks1VqFpFmfFbLejRAxITPRipJeXgCe69+TTJ6s/X3/kS3Ki664IhIbz5r3hOp4Xw7qMle/yDYRgF505FcBcwQ1XvVdXeqjpF1fQhyU1YWB/q1Pknhw5N4tChj93erk4dWLktlP+bFgq//4526QqenI3t3DnO3XUfwRdOMe31AzS/tUGexSP+05NZdUcybFX/Etfl1TCMS+NORXAHsFNEZorI7Y42AiMPDRu+QaVK3YiJeZL4+L/c3i4sDLwfup/9H/9Mxw0fsT7yMdjrgfx+6ekwYACV1i1m0dwz9Pp38/y38fZmwMzuVDm0Bd4t98NIDKNMcWccwcNAY6y2gf7ALhFx/1a3HLIajz+nQoVajsbjgo0gTu9yI8fCwrlp/1Q2RA2G6OiiC06Vzfe9RY9vB3P0tclIr3vc3/a664i+eRhXju7Ojj+OFl1MhmEUK7emqlTVVGAhMAdYh/W6yMiD1Xg8j7S002zbdq/bjccA9evDkj/9Ca4exE0n5rDp6iGw0v1uqXk58+oE7pnbl03BnWHQoAJvX+2N4WyzN+ffD5TbTOSGUea4M6DsVhGZBsQAvYCPgRoejqtMCA5uS7NmU4mPX05s7PACbduwISxZ7kdgjRBuPPsd0Tc8BT9dWvZv+6zZPDi6AXulPl8utFE9l7ZhALs9lbNnczYMh0XWZcS1q/l6X0czH7NhlBHuPBE8iDWSuJmqDnTMOmam2nJT9er9qFNnBIcOfcjhw1MLtG2jRrDkDx+uvjGIGk1scMcdMHt24QL57TfeeuhvvudO3ntX6XRN7n96u/0C0dG9WLMmnJMnF+ZY/+wXV1LN6wQvDE9B00tOegzDMArHnTaC/qr6rapevs7tZUyDBm8SGnojO3c+QULC6gJt27gxfP9LBaos/46UTl3ZNeAlmDChYAFs3kzyXf2Z6jOY/r0uMHSYb65F7fZUtm3rz8mT3+PjU4XY2GdyJNSzXRHMS/13sTSxA4tH/lawWAzDKHHceTV0lYisEZEkEbkgIukiYmZiLwAvLx9atpyDn98VbN16DxcuFKKhNSSEfzRYQKcK69j2zCR46SX3UlLs3w89ehBg82H1Wm+mTPcjt0nV7PY0tm9/kBMnvqFx4//SsuVskpNj2L//vRxlH/84iin1x3D9rMFw9mzBz8cwjBLDnVdDE7F6C8UAAcAg4AN3di4i3UVkh4jEisgLLtYPFJHjIrLR8Sl462Up4edX1THy+BTR0X2w21MLvI9/vuiDV6WK3BCwkr9f/wqeeCLvlBRnznD+lp6MPfEoKd/9ROXWtQgKcl1UNZ0dOx7h2LE5NGw4jtq1n6Fy5W5UrXo3e/e+zvnzWdNL+Pl7Meizrvgd2gNjxxb4XAzDKDnc7TUUC3irarqqfgp0z28bEfHGqjBuBVoC/UWkpYuiX6hqhONTprul2mwRNGv2MfHxf7Br13MF3r5ZM1iyRCAkhK5Bq9n+0VLo1891SoqUFLj7bp7Z8QQvpLzCsjOtc92vqp0dOx7j6NGZNGgwhrp1R2Sua9ToPcDOrl0jcm7YqRPfXTOO617vxoUY04vIMEordyqCcyLiB2wUkbdFZLib23UEYlU1zpG0bg7Q8xJiLROqV7+P2rWHc/Dg+xw5Mr3A2zdvblUGGmSjd43l2L/6Gm67LWtKCrsdBg5k2tJ6TLYP5oUX4KabXO9PVdm58x8cOTKVevX+Q716I7OsDwioT926Izl+fC6nT/+aY3v/xx5kmV7DR31NW4FhlFbuXNAfcJQbCpwF6mB1I81PLcD5fcIBx7LseonIZhH5SkTquNqRiDwmImtFZO1xT6ZduEwaNnyb0NAb2LHjcRIS1hZ4+xYtYMkSmPFjVbymT4OlS+GGGy6mpHjhBTbM2c4TPlO44QZ47TXX+1FVYmOf5vDhj6hb90Xq1/+Py3J16jyPv39DYmKeyvFKq9v9YXStH8drG24j8ZeiGetgGMZlpqoe+QC9gY+dvj8ATMxWpgpQwfHz48Bv+e23Q4cOWhakpBzTP/+sq3/+WUdTUo5e0r7+O3irxvi1VG3aVPWllzQd0daVD2itWnY9msuu7Xa7xsQM1yVL0JiY59Rut+d5jOPH5+uSJei+fe/mWLdq6TkF1f9c8ZFqevolnYthGJ4BrNVcrqtutREU0kGsp4cMtR3LnCuhk3qxW+rHQAcPxlOi+PlVo1WreaSmHic6unfhehIBx47B6/PC6Rq6nl2HA+G11/DqeSefL6nBvHlCmIsphFSVuLgXOXBgPLVqPUWjRuOQ3LoSOVStegeVK9/Gnj2jc8y30PH6AHpF7ePdw/05+cGcQp2HYRjFx5MVwRqgiYg0cLQx9APmOxcQkSucvt4J/O3BeEocm609zZpNJSFhJatWNWbv3jdJTy/YRPFhYbB4MSSnV6Br0Cq+6fUZ+tlswtt4ExXleps9e0azf/9YatYcQuPG/5dvJZChceP/YrenEBf3zxzr3pxVh8+bvULlMc9dlhTahmEUHXfGEbQvzI7VGn08FPgZ6wI/V1WjReRVEbnTUexpEYkWkU3A08DAwhyrNKtevT9RUdGEht7A7t0jWb26OceOfZHx6swtbdtalcGJeD96fX0fn3wemGvZPXteZ+/eV6lR4xGaNPnA7UoAIDCwMXXqPM/Ro7M4c2ZZlnVNmgq3z+iDHD0Cb7zh9j4Nwyh+kt8FR0SWYOUW+gqrq2exJpiJjIzUtWsL3sBaGpw+/RuxscM5e3YzISGdaNx4PCEhHd3eftMmmDULXnkFAl3UBfv2vU1c3L+oXv0Bmjf/FKuHb8Gkp59j9eoW+PiE0qHDOry8smYlH9PuS/ZuTmByTFcrYZJhGCWCiKxT1UhX69xJMdEV6Io1S9lHIrJFRMwMZR5QqdINREaup1mzj0lO3sX69VeybduAHIO5ctO2LYwb57oS2L//v8TF/YuwsH6FrgQAvL0Dadz4Pc6e3cyhQ5NyrD97TXem2B9lw2P/K9T+DcO4/PJ9IshSWKQ18E+gr6r6eSyqPJTlJwJnaWmJ7Nv3Fvv3v4uIUKfOCOrU+Rc+PjnnFM7PwYMfEBMzlKpVe9Gy5ed4eeWea8gdqsrmzd1ITFxLx4478PO72CJ95gw0rJlMx+Tf+WlpAFx//SUdyzCMonFJTwQi0kJERovIFuB94E+sHkCGB/n42GjYcAxXXrkjM83D6tVNOXz4U1TzSCuRzaFDU4iJGUqVKnfSsuXsS64EAESExo0nkJ6eRFxc1gFooaEw8iUffqY7vz0yK+8UGIZhlAju9BqaCpwGblHVLqr6P1U95uG4DAd//3q0bDmbdu1W4u9fjx07HmHdukhOn16a77aHD09j587HqVz5VsLD5+LlVXQPcUFBLahdezhHjnxCQsKqLOuGDveldpVzjIx7FP2kYKm3L6tjx9D/jIajZrY1o3xzpyK4GWsg2CEAEfESkdy7pRgeUbHiVbRr9yctWswmNfUUmzZ1ZevWuzl3LtZl+aNHP2PHjkeoVOkmwsO/wcurQpHHVK/eS/j5XcHOnU9meUrx94epswP4qN1HyKh/Q3x8kR/7ktntfNltCtVeHconzcfB6oKlBzeMssSdimAxVtbRDIGOZcZlJiJUr96fjh2306DBGE6fXsyaNS2JjX2O1NQzmeWOHfuSv/9+kNDQ62nV6lu8vf09Eo+Pj41Gjd4hKWldjkl3bu4mtP34KThxAl5/3SPHvxRrn/+CBzc9y3lfG/u1Nlx7LXzySXGHZRjFwp2KwF9VkzK+OH42TwTFyNs7gHr1RtKxYwzVqz/IgQPjWbWqMQcOTOTYsS/Ztq0/FSt2olWr7/H29uyfKiysPxUrXkdc3Iukpp7Ksu5c8/bc33AFH49PgJgYj8ZREIcWb6Pne9cRFpBIzB4/Xo55AK6/nrWD/sfxh0a4zuZqGGWYOxXBWedBZSLSAUj2XEiGuypUqEHz5h8TGbmB4OC2xMY+xbZtfQgJiaJ16wWF6mFUUCJCkybvk5Z2ht27s/YqDgiAPZU78LJ9NOeGjcxlD5dZcjKv9d1CvITy/Y/eXFFT8KpWhQvfLaRXyCKiZgxlY8fH4NCh4o7UMC4bdyqCYcCXIrJMRJYDX2CNGDZKiODgtrRtu5hWrb6jZs0nad16IT4+tst4/DbUqvUkhw5NIjFxfeZyEXjrPT8O6xVMWNAIppaAhuMXXmD8qYf4bfxm2nStkrnYL8Cbb36rRHqVMDpt/h9ftHwFVqwoxkAN4zLKLRudZs0S6gu0cnx83dnGU5+ykn20rLlw4bQuXx6m69ZdrXZ71gykd9yWrhV9EjXGu5nqb78VU4SqX7ywXk9TUfXpp3Mtc+SIaud2SQqq/5Kxmvb+h6r5ZGY1jNKAS80+qqqpqrrV8Sn4HItGmefrG0rDhmNJSFjJ0aMzs6x75z0vfEICGVxhBtxzD+zYcdnj+276Gfq+1Y43q76X59Sa1avDb38F8fjAFGLCOiNPPQmPPALnC5YM0DBKkwKNLC4JysvI4tJI1c6GDZ1JTo7jyit34uNTMXPd339D8Kl91Lk7EkJC4K+/oGrVyxLXpo1K58jzhNu3sHRVIAFRrdzaLjXFju8br7Dn1emcD4+k+YL3oG5dD0drGJ5xSSOLDcNdIl40aTKR1NTj7N6ddbazFi2gTue6pH/zHY/uHsUvXd+8LL1zjh2DO29MIjT9JN+O3uR2JQDgW8ELXnmFxyJWc2X0J/zQ+gVrajjDKGNyrQhEpH1en8sZpFF62GwdqFnzcQ4enEhS0pYc6xPCr2ZdnZ7cvvVNvuo2GTz8RDr0wQSOn/Lmu6vHcsVLgwq1j4+/C6NxywrcmTCLN278FX1vvMfjNozLKddXQ4700wD+QCSwCRCgDVajw9WXJcJszKuhki819SSrVjUlKKg1ERFLcsx5cOYM3N52Hyv31WLyXQt5dN7tngkkJYVDHe5gy/5QbtkxAWrUyLJa1c65c9sJDGyR77wM587B4IGpzP7Sl3uZy6d9fiLo04muU70aRglUqFdDqtpVrRTUh4H2qhqpqh2AdmSbctIwnPn6VqFhwzeIj/+dY8dyTl0ZGgq/bKtDt5pbGfTt7Ux4eEORx7B0KaSPfIma0Yu4ZdYDLioBZefOIaxZE05MTNYUGa4EBsKsL3wZ97ad2CuuQ+d+CVdfDXFxRR67YVxu7rQRNFPVzGd8tSamaeG5kIyy4IorBhEc3IFdu0aQlpZz6srAIOG77c15KGwh7T97zmo8LiILFsCNNyrj3vOCJ56AO+7Isl5V2bVrBIcPTyEkpBOHDv2PrVvvIT39XJ77FYERz3uxam8Nghd+SdLek6yIeBJ++aXIYjeM4uBORbBZRD4WkS6OzxRgs6cDM0o3EW+aNJnIhQuH2LvXda4hP1sFpkVHcU2dvdCzJ4tmHsFuv7TjbtsG/fvZaeMVzVNNf4F33slRZu/eVzlw4D1q1XqKdu2W06TJRE6e/J5Nm27kwoUT+R7D1xfo3p3RvbdyfeL3vH/LD+ibb5l2A6PUcqcieBiIBp5xfLY5lhlGnipWvIoaNR7mwIHxnD273XWhqlXhxx9Zfa4V3R6swQP9LpBayJEqJ0/CnXcqARfi+Y6eBM35JMc7/P3732PPntHUqDGQxo3/i4hQq9aThId/TVLSRjZs6ERysnuve/4zPpTbb4enmcCjI8NIubsfxLrOBmsYJVpuI81K6seMLC5dUlKO6h9/VNSNG29We14jdBcv1re8XlBQva1Hup49W/Bj9eih6ueTpn9yleq4cTnWHzz4kS5Zgm7deq/a7Wk51p85s0KXLausy5eHaXz8GreOmZ6u+vJLdgXVSNbobuqp3nCD6uefq54/X/CTMAwPoTAjix1zE2/O7eNOJSMi3UVkh4jEisgLeZTrJSIqIi5btI3Sy88vjAYNXuf06UVs29aPtLQk1wVvvJF/fdSISTzOggXQvbsWeBqD0Q/vZabXQK6+MQiefTbLuqNHZ7Nz5xAqV+5BixazXM7ZXLFiJ9q1W4G3dyAbN3bh5MmF+R7TywteeVX4+ms4WL0dQSOHQVwc0/svZEjFz5l7x0yOrzRPCUYJl1sNAdTL65Pbdk7bewO7gIaAH1b305YuytmAP4C/gMj89mueCEofu92ue/e+rUuWeOnq1a307NmY3As//7zOoY/6eqfpnDnu7X/HDlVNSVHt0EG1cmXVAweyrD9+/FtdssRbN2zoomlp5/Ld3/nzh3XNmna6ZIm3Hjr0sXtBqFNKovR0feWBGLX5nFWr4UC1TVCM/vP2rWo/l+z2/gyjKFGYJwJV3ZvxAc4DrR2fZMey/HQEYlU1TlUvAHOAni7KvQaMdRzDKINEhLp1n6dNm59ISTnE+vVRnDy5wHXht96i710X2G5vRt+gH4C8pz3+9Vdo2RKm3/MdrFsHH38MtWplrj91ahHR0X2w2SJp1Wo+3t4Bue/MoUKFGkRE/E6lSjexY8cgdu8enXHTks95On7w8uLlGY05lRzIyh9PMeaW36lqP8a6Hw4jtWrCsGE82f8Uo0ZZA5VNGiOj2OVWQ+jFO/Y+wF5gOjAD2A30dmO73sDHTt8fwJry0rlMe+Brx89LyeWJAHgMWAusrVu3rueqTMPjzp2L0zVrInTJEtHdu1/LkalUVVWTklTbQ0mERQAAIABJREFUt1cNCtIV03ZqixaOu/5sdu5UrVRJNbx+ksYTojpoUJb1Z84s199/D9TVq9vohQsnCxxrevoF3bbtIV2yBP3770c1Pf1CgffhtDO1L/5VtW9fTffx0+tZot6kKqj6+9v1xhvV7ScgwygMLjH76P+3d97hVVXZAv+t5CYhJCQhIE16rwFFRBTREVRgHByDWMA+ijIzPrGOivIQuzi2UXEUsXcNxWcBxVBFOgmELoQOCSaEkEBukrveH/sELiGE5BYCZP++73z3lH3WXudk56xd1xoF9FDVm1X1JkxN/3F/DZCIhAAvAfcfL62qvq1mQds5Z5xxhr9ZW6qQyMgWnHXWPOrVG0p6+uOkpQ2mqGjfkYmiouDbbyEujsiH7mZPRjG9e8Myr3Vne/ea5QEh4mFqweXEtKkPL7986Hpu7lJSUwcSEdGYrl2nExYWX2ldQ0LCaN/+PZo1e4xdu95l5corjz3GcXxhSN9L4PPPCdmxjZkvLiGr1bl8yxWM8LxJ5vLtbFmwE4CsLLjySpgypfzWkMUSMI5lIfRwbXxFqeOQ0ueOcV8vYJrX8SPAI17HscAeIN3ZDgI7OM44gR0jOD3weDy6desrmpwcqgsWtNf9+1cfnWjZMtWoKF3bOVGbNC7WmBjVOXNMX3z//qoul0dnXvy/qi6X6sKFh27bvz9N58ypo7/+2kwPHNgSEH23b39Lk5NDdPHic7SgYFdAZKrHozpzpurQoaoREeoB1Z49denoSXpmo2IF1ebNzQSorKzAZGmpvlBOi6AihmAcMA24xdl+AJ6vwH0uYCPQgsODxZ3KST/zeEZArSE47cjKSta5c8/Q2bNraWbm5KMTTJ2qKqJb+t+h7dp5NDLS2IePP1adcNs8U4SfeeZQ8vz8DTpvXkOdN69B+YPSPpCZOVVnzYrU+fNbal5eGX1V/rBnj+rLL6t26KAKWhgdp18NeFf79DADzjVrqu7YEdgsLdULnwwBEOG1n4jpxnkJuOpY95QhYyCwDjN7aJRzbiwwqIy01hBUUw4c2KKLF/fQ5GR048bHjp7j/9JLqqAZd4/VRx9VLSpS1Q0bVKOjVfv0cU6oHjiwVefPb65z5sTr/v0rg6JrTs4CnTu3rs6ZU0f37p0f+Aw8HtPsGTZMNSxMFXT5BX/X525dYxYtqOrzz6tOmnTosS2WCuGrIVjq/H50rDRVsVlDcHpSVHRAV6++TZOT0ZSUAep2e/WFeDyqd91liuuECaqFharnnacaG6u6ebOqmoVrv/3WTmfPrlXhxWC+kpe3XufPb6WzZkVqZuaU4GW0c6fqmDGqDRqYZ2/TRt0vv66tWxYpqDZrpvrCC6p/VH4c3FIN8dUQrASGOrX5xNLbse4L9mYNwemLx+PRbdvG68yZYTp/fivNzV1x+KLbrXrppWY8YPBgU3SdaTZud5YuXNhVZ82K1Ozs2SdE14KC3U4rJkS3bXsz2JmpfvKJas+eqqCFUbH6zYB39OJzTbdRZKTqV18FVwXLqU95hqC8eAS9gWGY6aNTjx5j1tvKvDHI2HgEpz85Ob8emk3Uvv171Kt3jbmwdy9ccIHxLHfzzfD++xQV7Sc19VJyc5fSpcu3xMdfdsL0LC7OIy3tWrKyvqNp00dp0eKp48Y18JuFC+E//4EvvoDCQlIvuIvXaz3CI683pkWrEBYuhG3bYNAgcLmCq4rl1KK8eAQV6ef/2/HSnMjNtgiqBwcP7tAlS87X5GR0w4aHtLi40FxIT1d99FHVnBwtKjqgy5ZdosnJoZqRkVQlehYXF+qaNXdocjK6atUNmpe3tnyfSoFi507VJ55QbdjwULeRvvqq3jKsQEG1aVMzlrBnT/BVsZwa4EuL4BgW5W1VHR4Q8+QjtkVQffB43GzYMJIdO8ZTu3Y/Onb8nLCwOs61QtLSEvnjj+9o3/5DGjS4ocr0VFU2b36K9PTRAERENCM+/jLi4y8nLu4SwsJqBy9ztxu++ca0EubPpzgqhm8vepHX/hhK8oIoatSABx+EsWODp4Ll1KC8FkFlDcFSVa3SeMXWEFQ/du6cyLp1I4iIaESnTklERyewatUwMjO/oG3bt2jU6M6qVhGAAwc2kZU1jezs6WRnz6C4eB8QQkxMT2rXvoz4+MuoVetcQkKC1GezaNHhbiO3mxXn38nrMY/S+k+NefChENxuGD8err8e6tULjgqWk5dAGoIfVbV/wDTzAWsIqif79i0iLS2RwsI9xMb2Jjv7Z1q2HEfTpg9UtWpl4vEUkpu7kKysaWRlTSc3dxHgITQ0ltq1+xIffzm1a19GZGTzwGe+eze8/bb56u/cCa1bw4gR/Nz8di4dHIPLBVdcAbfdBgMG2LGE6kLADMHJgDUE1Re3O4O0tGvIyZlFs2ajadHiiapWqcIUFmaRnT2D7OzpZGVNo6BgKwCRkW0OGYW4uD/hckUHLlO3G5KSTCvh11+hRg1W97+X96Lv5oPpDcnIMKGcf/sNmjULXLaWkxOfDIGIxGLcQvwVqAcokAFMAZ5T1b3BUbd8rCGo3ng8heTlrSA6+qzgz9AJEqpKfv5asrNNa2Hv3pl4PPmIhBETc74zvjCQWrW6BS7T1FTTQvjoI8jLo/Dsc/nhgqf4Pv9ixr8Thgi89poJ6HbNNRATE7isLScHvhqCacAvwAequss51wC4Geirqidunp4X1hBYTjc8ngJycuaRlTWd7Oxp7N+/HIBmzR6jefOxgTV4+/YZYzB+PKSlQVwc3HILetcI+tzelrlzjTG4+mrTddSnj5d7bcspja+GYK2qtqvstWBjDYHldMft3s3GjY+ya9dEGjX6B23avIZx1htAVGHOHHjzTdN9VFiI9u3Hwn6PMvH3i/jsixByc+Ff/4Lnngts1paqoTxDUF7p2iwiD4lIfS9B9UXkX8DWQCtpsVgM4eH1adduAk2aPMCOHW+wevVNeDyFgc1ExFT3P/8ctmyBp55C1q2l5yOX8N8fmrLr7qf58NVshg0zyRcuhP79zYSk/PzAqmKpesozBNcCdYBZIpIlIlkYx3DxmNXGFoslSIgILVu+QIsWz5CR8QlpaYkUFx8ITmYNGsCoUbBxowmC0LkzNZ95jBvvO4MuT1wNv/zC7l3KqlVw3XVQty4MHgyffAIFBcFRyXJisbOGLJaTnO3bx7N+/T+Ije1Dly5TcblOwEjuhg3w3//CxIkmUk779hQPH8HMlreRND2aSZNMyyAjA8LDYfFiaNrUrk84mfG1a6g8gbf6p5LFYqkoZ545gg4dPmHfvnksX34Jbndm8DNt3RrGjTOOiz74AOLiCL3vHvpeX483dl/Nthc+ZcnMXMLDzXDDsGHQsCFcfLGZfbTVdh6fUvjUIhCRLaraNAj6HBfbIrBUV/744zvS0q6mRo3mJCT8RI0ajU+sAsuWwYQJMGmSWagWHg79+qFXJZLS8iqSZsaTlGQmI4EdaD7Z8HXWUOqx5AFtVTUiQPpVCmsILNWZvXvnsGLFFbhccXTt+jM1a7Y58Up4PGYVWlKS2TZtgpAQM/icmMjahCFMmt+A7t3h0kvh99/hr3+FxESzJSTYKalVga+GYDdwOZBd+hLwq6o2CqiWFcQaAkt1Jzd3Kamp/QEhIWFaYBeeVRZVSEkxBuGbb4yLcICePQ99+ZfktOb++81sVY8HWrUyl+6/H+rXL1+8JXD4agjeBd5T1bllXPtUVYcGVs2KYQ2BxQL5+WtJSbmUoqJ9JCR8R2zsBVWtkmHNGtN1lJRkRpABunSBxEQyLr6GKes6kDRJmDXLDD/Ex1etutUJ62vIYjkNOXhwCykpl1JQsJVOnZKoU6dK/UEezebNMHmyaSnMnWtaD61bQ2Ii+QOvpuaF3SksDmHcOBg50qxotgQPawgsltMUtzuD1NT+5OWtpEOHj6hX79qqVqlsdu82axSSkmDGDCgqgsaNmXHXV1z6+Hn07AnffmvWKFiCQ8Cnj1Yi4/4islZENojIw2Vcv0tEVojIchGZKyIdg6mPxXK6ER5ej27dkomJ6cmqVdezY8c7Va1S2dSvD8OHw48/msUHH30EdevS9/Hz+WrYZJYtU84/36xps5x4gmYIRCQUeAMYAHQEri/jQ/+pqnZR1W7AC8BLwdLHYjldcbliSUiYRnx8f9atG86WLS9UtUrlU7s23HADzJsHQ4Yw+OOrmHHxU+zZo/TqBUuWVLWC1Y9ghqQ4F9igqhsBRORz4EpgVUkCVd3nlT4K4+raYrFUktDQmnTuPJk1a25m48Z/UViYRcuWz/rtuVTVw8GDm8jLSyMvL42DB9OJiupMXFwfoqK6+OcMr2ZN4+uoSxcuePxxfk1YyRD3x4iE+aWzpfIE0xCcyZHO6bYBPUsnEpF/APcB4cAlZQkSkeHAcICmTatkHZvFctITEhJOhw4f43LFsXXr8xQV7aVt2zcwjfPyMR/8zeTlpZGfn3bow5+fvxqP57CPI5erNjt3vn1oPzb2QuLi+hAbexHR0d0qH4ZTBB57DDp2pP2NN5IS15IQnQx0Z/FiOKfMHm1LoKnyIHWq+gbwhogMBR7DxDsoneZt4G0wg8UnVkOL5dRBJJQ2bd7E5arNli3PUlS0lw4dPiQkJBwwQXEKCrYc+tAf/vCvxuPJOyQnPPxMoqI60ajRXURFdaJmzU5ERXXE5Yrh4MHN7N07m717Z5GTM5s//pgKQGhoLWJjLyA29iLi4vpQq9Y5h/I9LomJ0KoVIYMGwYUXMmnEdBJf6s2YMTB6tF2AFmyCNmtIRHoBY1T1cuf4EQBVffYY6UOAbFWNLU+unTVksVSMLVvGsXHjQ8TFXUyNGi2cj/4qiov3H0oTHt7Q60PfydnvSFhYXIXzKSjYwd69s8nJMcYhP9/0/oaERBIT04u4uIuIje1DTExPQkMjyxeWkQGDB1M49zduT1jIh6lncfvtJo7OqRJbef16+P57uOqqDeTljcXtHknNmmfTpgoWgXtT3qyhYL7aRUAbEWkBbAeuA45YhCYibVR1vXP4Z2A9FoslIDRt+iAuVxzr199NXt5qoqI60aDBrUd8+MPCavudT0REI+rXv4769a8DwO3OJCdnzqEWQ3r6GEARCScmpiexsX2Ii7uImJheR8dorlcPfv6ZsL//nfcnnk2Tdl/y9IQh7NxpYiFERfmtbsBxu2HmTPPx/+4747gVIDf3cXr3/pwnnxzErFlncccdwujRxjnfyUZQ1xGIyEDgFSAUmKiqT4vIWGCxqk4VkVeBfkAhxpXFP1U1rTyZtkVgsVQOj6eo8n33AaSwMJucnLmHWgy5uUuBYkTCaNjwdpo1G01ERIMjb1KFV1+F++/nvw3H8M/djzFlijBwYJU8wlFs3WrccLdrZ1wttWwJNWrARRcd4Kyz3qVLl5foLMW0eG0/c26PZcK3D/Htd8MJDw9h5Eh48EETJfREYheUWSyWk4aiolz27fuVzMxJ7Nr1LiLhNG58r9OCKdUzPG0aXHstm0Jb02LKK9C7NwcPmo/uidUZ5s8/XOtfscLEdf7qK3N9xgylRdOP2L51BFp4kNb/8dDw53Ck/wAKVs1h+WNZbCxqxTfjP+ObxT149FF4+ukT+wzWEFgslpOS/PwNpKc/TkbG57hc8TRrNopGjf5OaKjXl37tWvjLXyA9neR7JnPDpwNJSjJ+7YLJ/v0Q7fRcXXAB/PqrGae48EIYOBCuuALatwf3xqWsWzSUPfXXEpsK7T9tQuTgu+HWW81S6YICCiZPJCXkfg5GH4AHetC5yznEj7yJmQd6silduOkmCD3+5C6/sIbAYrGc1OTmLmXjxkfIzp5OREQTmjd/ggYNbjo89TU7G669lvU/bWJA7K/scNfliy+Ev/wlMPkXFZm+/bQ0WL7cNETWrTscge3rr42n7X79ICYG40Z1+nT2/DiatX0WURQNLX7rQJNzxyGXDTCJS+F272b5gvM5WLCFLqNd1J5/kNviJ/Ne1pV0bO/hmedCGDQoeDOkyjMEqOoptXXv3l0tFsvpSVbWDF28uIcmJ6MLFnTUzMzJ6vF4zMXCQtV77tHdnKE9YtZoSIhH33qrcvKLilTXrVNNSlJ98knVzExz/tlnVc3AhKqIaq9e5vq+faUEZGaqvvCCFnZsrqsfQJOT0YVT62nuuh8rlH9BwS5dsKCjzpoZqVnv36OeTp31axK1bcg6BdVe3fJ03rzKPVNFwYzNlvldrfIPe2U3awgsltMbj8ejGRlf62+/tdXkZHTJkvM1O3v24QTvvKP7XbH656hfFFSnTTtaRlGR6vr1qllZ5njOHNVu3VRr1Dj8wQfVWbPM9bQ01Q8+UF28WDUv7yiFVOfPV73xRtWICM3uis5PitDkX0R/X/cvLS4uqNTzFRTs1gULOumsWTU064+fVOfM0cJrh+nboXdqI7bp621eUf3qK1W3u1Jyj0d5hsB2DVkslpMSj6eIXbveIz19DG73DuLj/0zLls8QHZ0Ac+ZQdNUQPsofzM1JV5Ld4zImTDBdOytXmrAIBw7Ae+/BLbeYcw8+CJ06Hd46djw8BlAmeXnw6admEcOyZRTXjmLTs63Z1i6VyMhWtG//IbGxvXx6Nrc7k5SUvhw4sJ7Onb8lPr4f7N5N/lsfEvbuW4Rt3ciE2PuZ1fRGxr5Vjxbn+z/n1I4RWCyWU5bi4ny2b/8PW7Y8R1FRDvXrD6N58yeJ3A0MGgRpaewe/QYNxtzFmfWL6NTGfWjre/4BmjcuqlyGe/fCBx+Ybd8+6NKF3HuvYHWHSeQfXEOjRiNo1WocoaH+LWo40hhMIT7+spIHhh9+YNwDuxm9dijFhDKi1U+Mejaaelf38XkQwRoCi8VyylNYmM2WLc+xfftrqBbTqNEImtUdSfit96JTppBDLHHkBCazsDAYMgTPXXewpckcNm8eS1hYPdq3n0h8/OWByQNwu/eQktKX/Py1dOky5SjZ2+ZtZuzfdzExtTsJpLLkhV+QBx/wKS9rCCwWy2nDwYPb2Lz5CXbunEhoaE2aNL6fxis74NrrDkwGoaHQrx/50dmsXn0zubkLqFdvKG3avB6QldilKSz8g5SUfuTlraZz58llRppbk1LAnq9n0vvOTtC4sU/5WENgsVhOO/Ly1rBp0yj27EnC5apDVFQHXK44XK44QkNjD+2bLbbM/bKc4ql62L79TTZufIiQkEjath1PvXrXBPVZjDG4lLy8NDp3nkSdOoFfQm0NgcViOW3Zt28h27a9gtu9k6KiHIqK9jpbDuAp996QkBpHGIzQ0FiKirLIzV1EfPwA2rWbQEREoxPyHIWFWY4xWEnnzknUqfPngMq3hsBisVQ7VJXi4v2HjEKJgSguPtJYlN73eA5y5pn/oGHDO/wO7FNZjDG4jLy8FXTq9A11614RMNlV5X3UYrFYqgwRweWqhctVC2hS1epUiLCweLp2/YnU1MtIS0t0jEGAlk+XQ1CD11ssFoulcoSF1SYh4Seio7uRljaYPXumBD1PawgsFovlJCMsLI6uXX8iOvos0tKuJjNzclDzs4bAYrFYTkJcrli6dp1OdHR3Vq0aQmbmpKDlZQ2BxWKxnKSUGINatXqwatU1QTMG1hBYLBbLSYzLFUNCwo/Urn05ERHBGfS2s4YsFovlJMcYg/8LmnzbIrBYLJZqjjUEFovFUs0JqiEQkf4islZENojIw2Vcv09EVolIqojMEJFmwdTHYrFYLEcTNEMgJtjoG8AAoCNwvYh0LJVsGXCOqiYAXwMvBEsfi8VisZRNMFsE5wIbVHWjqrqBz4ErvROoarKq5juHvwG++Ve1WCwWi88E0xCcCWz1Ot7mnDsWfwN+KOuCiAwXkcUisjgzMzOAKlosFovlpBgsFpEbgHOAcWVdV9W3VfUcVT3njDPOOLHKWSwWy2lOMNcRbOdIl3+NnXNHICL9gFHARapaEER9LBaLxVIGQYtHICIuYB3QF2MAFgFDVTXNK81ZmEHi/qq6voJyM4HNPqpVF9jj471WlpV1qsoKtDwr69SU1UxVy+5SUdWgbcBAjDH4HRjlnBsLDHL2fwZ2A8udbWqQ9VlsZVlZ1U3WyayblVW15aJkC6qLCVX9Hvi+1LnRXvv9gpm/xWKxWI7PSTFYbLFYLJaqo7oZgretLCurGsoKtDwr6/SQdYhTLni9xWKxWAJLdWsRWCwWi6UU1hBYLBZLNadaGAIRaSIiyY6n0zQRuccPWTVEZKGIpDiyngiAfqEiskxE/Io8ISLpIrJCRJaLyGI/ZcWJyNciskZEVotILx/ltHP0Kdn2ichIP/S613nvK0XkMxGp4Yesexw5aZXVSUQmikiGiKz0OhcvIj+JyHrnt7YfsoY4enlE5Bw/9Rrn/B1TRWSSiMT5IetJR85yEZkuIo18leV17X4RURGp64deY0Rku1c5G+iPXiJyt/PO0kSkQs4wj6HXF146pYvIcj9kdROR30r+v0Xk3IrIqhDBmJN6sm1AQ+BsZ78WZm1DRx9lCRDt7IcBC4Dz/NTvPuBT4P/8lJMO1A3QO/sAuN3ZDwfiAiAzFNiFWdjiy/1nApuASOf4S+AWH2V1BlYCNTEr7H8GWlfi/j7A2cBKr3MvAA87+w8Dz/shqwPQDpiJ8dDrj16XAS5n/3k/9Yrx2v8f4C1fZTnnmwDTMItEK1R2j6HXGOABH8pBWbL+5JSHCOe4nj/P6HX938BoP/SaDgxw9gcCM30p+2Vt1aJFoKo7VXWps58LrKZ8B3jlyVJV3e8chjmbzyPuItIY+DMwwVcZgUZEYjEF8V0AVXWr6t4AiO4L/K6qvq4MB/PRjnRWrtcEdvgopwOwQFXzVbUImAUkVvRmVZ0NZJU6fSXGgOL8/tVXWaq6WlXXVlSf48ia7jwjVMLL7zFk7fM6jKKCZf8Y7wvgZeChiso5jqxKcwxZI4Dn1HF5o6oZ/uolIgJcA3zmhywFYpz9WHwv+0dRLQyBNyLSHDgLU5P3VUao08TLAH5SVZ9lAa9g/hE8fsgoQYHpIrJERIb7IacFkAm853RZTRCRqADodx0V/EcoC1XdDrwIbAF2AjmqOt1HcSuBC0WkjojUxNSw/I0MXl9Vdzr7u4D6fsoLBrdxDC+/FUVEnhaRrcAwYPTx0pcj50pgu6qm+KOPF/90uq0mVrRb7hi0xZSNBSIyS0R6BEC3C4HdWkFXOsdgJDDOefcvAo8EQC+gmhkCEYkGvgFGlqrZVApVLVbVbpia1bki0tlHfa4AMlR1ia+6lKK3qp6NCQb0DxHp46McF6ZZOl5VzwLyMF0dPiMi4cAg4Cs/ZNTG1LpbAI2AKDGeayuNqq7GdJNMB37EuDgp9lW3MuQrfrQUg4GIjAKKgE/8kaOqo1S1iSPnnz7qUhN4FD8MSSnGA62AbphKwr/9kOUC4oHzgAeBL50avT9cjx+VIIcRwL3Ou78Xp8UeCKqNIRCRMIwR+ERVkwIh0+kuSQb6+yjiAmCQiKRjAvdcIiIf+6HPduc3A5iECQ7kC9uAbV4tna8xhsEfBgBLVXW3HzL6AZtUNVNVC4Ek4Hxfhanqu6raXVX7ANmYsSN/2C0iDQGc3wp1KZwIROQW4ApgmGOkAsEnwGAf722FMegpTvlvDCwVkQa+CFPV3U4FzQO8g+9lH0z5T3K6gRdiWusVGsguC6cbMxH4wg+dAG7GlHkwFaqADRZXC0PgWPN3gdWq+pKfss4omXUhIpHApcAaX2Sp6iOq2lhVm2O6TX5RVZ9quCISJSK1SvYxA4RHzdCooF67gK0i0s451RdY5YssLwJRI9oCnCciNZ2/aV/MeI9PiEg957cp5h/1Uz/1m4r5Z8X5neKnvIAgIv0x3Y+D9HBEQF9ltfE6vBLfy/4KVa2nqs2d8r8NM6Fjl496NfQ6vAofy77DZMyAMSLSFjNZwh/vof2ANaq6zQ8ZYMYELnL2LwH86WY6kkCNOp/MG9Ab00xP5bCn04E+ykrAxFpOxRS2Cs0CqIDci/Fj1hDQEkhxtjQcb69+yOsGLHaeczJQ2w9ZUcAfQGwA3tMTmI/PSuAjnJkdPsqagzFwKUDfSt77GaYLohDzEfsbUAeY4fyD/gzE+yHrKme/AOOhd5ofsjZgogWWlP2KzvQpS9Y3zrtPBb4FzvRVVqnr6VR81lBZen0ErHD0mgo09ENWOPCx85xLgUv8eUbgfeCuAJSv3sASp7wuALr7+/9UslkXExaLxVLNqRZdQxaLxWI5NtYQWCwWSzXHGgKLxWKp5lhDYLFYLNUcawgsFoulmmMNgSWgOF4k/+11/ICIjAmQ7PdF5OpAyDpOPkPEeFxNDoCskc4qWl/v71ZRT5pe98yUSngstVisIbAEmgIgsaIuhU8UzurOivI34A5V/VMAsh6JcY7nK90wfpAslqBhDYEl0BRh4qreW/pC6Rq9iOx3fi92nHtNEZGNIvKciAwTE/dhhYi08hLTz/HFvs7x1VTiBHCciCxynI7d6SV3johMpYyV0SJyvSN/pYg875wbjVm4866IjCuVXpx8Vjr3XeuVz/95pXtdRG4Rkf/B+ERKLmldiMh+EXlZjJ/7GSJyhnP+UC1eROqK8V0fDowFrhXjg/7aUvqEisiLjj6pInJ3Gc843nlfR8TOcN7xKue+F51zQxxZKSIy+zjvtqGIzHb0WikiF5bO23LqUJlaksVSUd4AUqWCAT0cumJcQ2cBG4EJqnqumCBCd2Nq1gDNMT5WWmE+sK2BmzCeSHuISAQwT0RKvJKeDXRW1U3emYkJqPI80B3jZ2i6iPxVVceKyCUY3/alg/skYmroXTG+ZxaVfDDLQlVfE5H7gD+paomLgihgsare6xid/+UYjttU1e2kOUdVy0oz3Hkf3VS1SETiy0gzSlWzRCQUmCEiCcB2zMrl9qqqcjhQzWjgclXd7nXub5T9bhMxq52fdmT70+qxVDG2RWAJOGo8u34y7ZIDAAACxklEQVSICVxSURapiRtRAPyO8QoKxm1Ac690X6qqR407341Ae4xfpZvEuAZfgHH1UOITZ2FpI+DQAxPYI1ONr/5PMDEYyqM38Jka52a7MTEMKuui2MNh52MfOzJ9pR/wX0d/VLUsX/jXiMhSjFuUTkBHIAc4iGn1JAIl/ofmAe+LyB2YIEJw7He7CLjVGf/poibOh+UUxRoCS7B4BVOb9I5jUIRT5kQkBOPTpYQCr32P17GHI1uupX2iKCZq3N2q2s3ZWujhOAV5fj1FxTj0XA6VCZ9Z8jzeMnwOv+mNiLQAHsD4UUoAvgNqOIbjXIxX2SswbrhR1buAxzBxGZaISB2O8W7VBE7pg2ldvC8iNwVCZ0vVYA2BJSg4tdMvMcaghHRMVwyY2ARhPogeIiIhzrhBS2AtJtThCDGuxhGRtnL8QDoLgYuc/vhQjHfUWce5Zw6mvz7U6dvv48jZDHQUkQinS6Wv1z25mPCoJYQAJeMkQ4G5zn46h9+N98yo0vd78xNwZ8lAeBldQzEYQ5gjIvUxrsBL4nLEqur3mLGcrs75Vqq6QFVHYwITlYSRPOrdikgzTKCVdzDR9fx1U26pQuwYgSWY/Jsj+7/fAaaISAqmFupLbX0L5uMbg/HoeFBEJmC6j5aKiGA+YuWGiVTVnSLyMCaehADfqerx3EZPAnphvD8q8JA6bpNF5EuMt8pNmG6YEt4GfhSRHc4spDxMMKPHMPEKSgaAX8QEQBmOqbmXkAw87HTNPKuq3j7tJ2CiaaWKSCHm/b7u9YwpIrIM4611K6brB4xhmSIiNZxnv885P06Mm2nBeFFNwXjzbM7R7/Zi4EEn3/2YcRrLKYr1PmqxnEBEZL+qRle1HhaLN7ZryGKxWKo5tkVgsVgs1RzbIrBYLJZqjjUEFovFUs2xhsBisViqOdYQWCwWSzXHGgKLxWKp5vw/pRX1veKE+wAAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##3. Speed Comparison with SGD"
+      ],
+      "metadata": {
+        "id": "QFI8SWLlZB64"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "data_size_grid = list(range(20, 100, 20)) + list(range(100, 1000, 100)) + list(range(1000, 10000, 1000)) \\\n",
+        "                 + list(range(10000, 100000, 10000)) + list(range(100000, 1000000, 100000))"
+      ],
+      "metadata": {
+        "id": "vbUoTxjvZ37D"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "cmgf_est = CMGFEstimator(EKFParams)\n",
+        "sgd_op_est = LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1)\n",
+        "sgd_mp_est = LogisticRegression(multi_class='multinomial', solver='sag')\n",
+        "\n",
+        "# Plot timed results against different dataset sizes\n",
+        "# with fixed class size (K = 3)\n",
+        "import numpy as np\n",
+        "import time\n",
+        "\n",
+        "cmgf_times, sgd_op_times, sgd_mp_times = [], [], []\n",
+        "\n",
+        "it_times, vec_times = [], []\n",
+        "for data_size in data_size_grid:\n",
+        "    print(f'dataset of size {data_size}')\n",
+        "    simplefilter(\"ignore\", category=ConvergenceWarning)\n",
+        "    input, output = make_classification(n_samples=data_size, n_features=4, n_informative=4, \n",
+        "                                        n_redundant=0, n_classes=3, random_state=2)\n",
+        "    start = time.time()\n",
+        "    _ = cmgf_est.fit(input, output)\n",
+        "    cmgf_time = time.time() - start\n",
+        "    cmgf_times.append(cmgf_time)\n",
+        "    print(f'cmgf took {cmgf_time} seconds.')\n",
+        "\n",
+        "    start = time.time()\n",
+        "    _ = sgd_op_est.fit(input, output)\n",
+        "    sgd_op_time = time.time() - start\n",
+        "    sgd_op_times.append(sgd_op_time)\n",
+        "    print(f'one-pass sgd took {sgd_op_time} seconds.')\n",
+        "\n",
+        "    start = time.time()\n",
+        "    _ = sgd_mp_est.fit(input, output)\n",
+        "    sgd_mp_time = time.time() - start\n",
+        "    sgd_mp_times.append(sgd_mp_time)\n",
+        "    print(f'multi-pass sgd took {sgd_mp_time} seconds.')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xiavnsxuZrHy",
+        "outputId": "d64b8467-65bb-4d36-eefa-1deee585a092"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "dataset of size 20\n",
+            "cmgf took 1.4351356029510498 seconds.\n",
+            "one-pass sgd took 0.003902435302734375 seconds.\n",
+            "multi-pass sgd took 0.002874612808227539 seconds.\n",
+            "dataset of size 40\n",
+            "cmgf took 1.1339151859283447 seconds.\n",
+            "one-pass sgd took 0.004061222076416016 seconds.\n",
+            "multi-pass sgd took 0.002923250198364258 seconds.\n",
+            "dataset of size 60\n",
+            "cmgf took 1.0704281330108643 seconds.\n",
+            "one-pass sgd took 0.0029878616333007812 seconds.\n",
+            "multi-pass sgd took 0.002113819122314453 seconds.\n",
+            "dataset of size 80\n",
+            "cmgf took 0.9837203025817871 seconds.\n",
+            "one-pass sgd took 0.002657175064086914 seconds.\n",
+            "multi-pass sgd took 0.002251148223876953 seconds.\n",
+            "dataset of size 100\n",
+            "cmgf took 1.041109561920166 seconds.\n",
+            "one-pass sgd took 0.0031430721282958984 seconds.\n",
+            "multi-pass sgd took 0.004430055618286133 seconds.\n",
+            "dataset of size 200\n",
+            "cmgf took 1.1492512226104736 seconds.\n",
+            "one-pass sgd took 0.003290414810180664 seconds.\n",
+            "multi-pass sgd took 0.008254766464233398 seconds.\n",
+            "dataset of size 300\n",
+            "cmgf took 1.12516188621521 seconds.\n",
+            "one-pass sgd took 0.003319263458251953 seconds.\n",
+            "multi-pass sgd took 0.005869865417480469 seconds.\n",
+            "dataset of size 400\n",
+            "cmgf took 1.4406251907348633 seconds.\n",
+            "one-pass sgd took 0.0035254955291748047 seconds.\n",
+            "multi-pass sgd took 0.006236076354980469 seconds.\n",
+            "dataset of size 500\n",
+            "cmgf took 1.0015127658843994 seconds.\n",
+            "one-pass sgd took 0.004041910171508789 seconds.\n",
+            "multi-pass sgd took 0.006882667541503906 seconds.\n",
+            "dataset of size 600\n",
+            "cmgf took 1.1648836135864258 seconds.\n",
+            "one-pass sgd took 0.0038170814514160156 seconds.\n",
+            "multi-pass sgd took 0.00841665267944336 seconds.\n",
+            "dataset of size 700\n",
+            "cmgf took 1.1848526000976562 seconds.\n",
+            "one-pass sgd took 0.0038738250732421875 seconds.\n",
+            "multi-pass sgd took 0.008675813674926758 seconds.\n",
+            "dataset of size 800\n",
+            "cmgf took 1.0770740509033203 seconds.\n",
+            "one-pass sgd took 0.003551483154296875 seconds.\n",
+            "multi-pass sgd took 0.009138345718383789 seconds.\n",
+            "dataset of size 900\n",
+            "cmgf took 1.0992867946624756 seconds.\n",
+            "one-pass sgd took 0.003419637680053711 seconds.\n",
+            "multi-pass sgd took 0.016553878784179688 seconds.\n",
+            "dataset of size 1000\n",
+            "cmgf took 1.0548906326293945 seconds.\n",
+            "one-pass sgd took 0.0035805702209472656 seconds.\n",
+            "multi-pass sgd took 0.00906991958618164 seconds.\n",
+            "dataset of size 2000\n",
+            "cmgf took 1.0792348384857178 seconds.\n",
+            "one-pass sgd took 0.004471778869628906 seconds.\n",
+            "multi-pass sgd took 0.020868301391601562 seconds.\n",
+            "dataset of size 3000\n",
+            "cmgf took 1.1681466102600098 seconds.\n",
+            "one-pass sgd took 0.0053899288177490234 seconds.\n",
+            "multi-pass sgd took 0.03048872947692871 seconds.\n",
+            "dataset of size 4000\n",
+            "cmgf took 1.279848337173462 seconds.\n",
+            "one-pass sgd took 0.004639387130737305 seconds.\n",
+            "multi-pass sgd took 0.03211641311645508 seconds.\n",
+            "dataset of size 5000\n",
+            "cmgf took 1.0902647972106934 seconds.\n",
+            "one-pass sgd took 0.0058252811431884766 seconds.\n",
+            "multi-pass sgd took 0.050254106521606445 seconds.\n",
+            "dataset of size 6000\n",
+            "cmgf took 1.2159783840179443 seconds.\n",
+            "one-pass sgd took 0.007163524627685547 seconds.\n",
+            "multi-pass sgd took 0.06187009811401367 seconds.\n",
+            "dataset of size 7000\n",
+            "cmgf took 1.2411818504333496 seconds.\n",
+            "one-pass sgd took 0.0076427459716796875 seconds.\n",
+            "multi-pass sgd took 0.061913251876831055 seconds.\n",
+            "dataset of size 8000\n",
+            "cmgf took 1.2674741744995117 seconds.\n",
+            "one-pass sgd took 0.006710052490234375 seconds.\n",
+            "multi-pass sgd took 0.08196854591369629 seconds.\n",
+            "dataset of size 9000\n",
+            "cmgf took 1.2915184497833252 seconds.\n",
+            "one-pass sgd took 0.007716178894042969 seconds.\n",
+            "multi-pass sgd took 0.09117507934570312 seconds.\n",
+            "dataset of size 10000\n",
+            "cmgf took 1.2495758533477783 seconds.\n",
+            "one-pass sgd took 0.009627342224121094 seconds.\n",
+            "multi-pass sgd took 0.10564756393432617 seconds.\n",
+            "dataset of size 20000\n",
+            "cmgf took 1.3694109916687012 seconds.\n",
+            "one-pass sgd took 0.018322229385375977 seconds.\n",
+            "multi-pass sgd took 0.24538874626159668 seconds.\n",
+            "dataset of size 30000\n",
+            "cmgf took 1.4606256484985352 seconds.\n",
+            "one-pass sgd took 0.02458357810974121 seconds.\n",
+            "multi-pass sgd took 0.2954592704772949 seconds.\n",
+            "dataset of size 40000\n",
+            "cmgf took 1.4179437160491943 seconds.\n",
+            "one-pass sgd took 0.03982257843017578 seconds.\n",
+            "multi-pass sgd took 0.7346532344818115 seconds.\n",
+            "dataset of size 50000\n",
+            "cmgf took 1.644007921218872 seconds.\n",
+            "one-pass sgd took 0.04092288017272949 seconds.\n",
+            "multi-pass sgd took 0.5279567241668701 seconds.\n",
+            "dataset of size 60000\n",
+            "cmgf took 1.7648649215698242 seconds.\n",
+            "one-pass sgd took 0.06592655181884766 seconds.\n",
+            "multi-pass sgd took 0.9716782569885254 seconds.\n",
+            "dataset of size 70000\n",
+            "cmgf took 1.7345643043518066 seconds.\n",
+            "one-pass sgd took 0.061029672622680664 seconds.\n",
+            "multi-pass sgd took 0.8429808616638184 seconds.\n",
+            "dataset of size 80000\n",
+            "cmgf took 1.8411712646484375 seconds.\n",
+            "one-pass sgd took 0.0584561824798584 seconds.\n",
+            "multi-pass sgd took 1.132669448852539 seconds.\n",
+            "dataset of size 90000\n",
+            "cmgf took 1.9966723918914795 seconds.\n",
+            "one-pass sgd took 0.10585570335388184 seconds.\n",
+            "multi-pass sgd took 2.0751349925994873 seconds.\n",
+            "dataset of size 100000\n",
+            "cmgf took 2.1501214504241943 seconds.\n",
+            "one-pass sgd took 0.11574029922485352 seconds.\n",
+            "multi-pass sgd took 2.619509220123291 seconds.\n",
+            "dataset of size 200000\n",
+            "cmgf took 2.9788355827331543 seconds.\n",
+            "one-pass sgd took 0.26125574111938477 seconds.\n",
+            "multi-pass sgd took 4.959406852722168 seconds.\n",
+            "dataset of size 300000\n",
+            "cmgf took 3.9050614833831787 seconds.\n",
+            "one-pass sgd took 0.29729294776916504 seconds.\n",
+            "multi-pass sgd took 6.432461738586426 seconds.\n",
+            "dataset of size 400000\n",
+            "cmgf took 4.939682722091675 seconds.\n",
+            "one-pass sgd took 0.5290918350219727 seconds.\n",
+            "multi-pass sgd took 9.403817892074585 seconds.\n",
+            "dataset of size 500000\n",
+            "cmgf took 5.8702003955841064 seconds.\n",
+            "one-pass sgd took 0.6791386604309082 seconds.\n",
+            "multi-pass sgd took 10.346223592758179 seconds.\n",
+            "dataset of size 600000\n",
+            "cmgf took 6.788238525390625 seconds.\n",
+            "one-pass sgd took 0.8247029781341553 seconds.\n",
+            "multi-pass sgd took 16.598719596862793 seconds.\n",
+            "dataset of size 700000\n",
+            "cmgf took 7.695049524307251 seconds.\n",
+            "one-pass sgd took 0.9501240253448486 seconds.\n",
+            "multi-pass sgd took 16.758854627609253 seconds.\n",
+            "dataset of size 800000\n",
+            "cmgf took 8.72581148147583 seconds.\n",
+            "one-pass sgd took 1.0926594734191895 seconds.\n",
+            "multi-pass sgd took 18.42120933532715 seconds.\n",
+            "dataset of size 900000\n",
+            "cmgf took 9.253260850906372 seconds.\n",
+            "one-pass sgd took 0.975881814956665 seconds.\n",
+            "multi-pass sgd took 20.693013668060303 seconds.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot the result\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(data_size_grid, cmgf_times, label='CMGF-EKF')\n",
+        "ax.plot(data_size_grid, sgd_op_times, label='SGD (single pass)')\n",
+        "ax.plot(data_size_grid, sgd_mp_times, label='SGD (multi pass)')\n",
+        "ax.set_xlabel('Dataset size')\n",
+        "ax.set_ylabel('Train time in s')\n",
+        "ax.set_title('Train speed vs dataset size (CMGF vs SGD)')\n",
+        "ax.legend();\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        },
+        "id": "u1DP_RYei8q3",
+        "outputId": "1958c8fd-88de-4f44-dd8a-58d7354e55b5"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEWCAYAAABhffzLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd3xUVfr48c9JIZ30hE4aBAwlkISuAioqFlRYUNFFbPgTsIFfXXddsaBgQ7HjqiAWsGHDsiqwKEVqpElLSOikkd4z5/fHvRknIQkBMpmU5/16zWtuv8+9M/PMmXPPnKu01gghhGg9nBwdgBBCiMYliV8IIVoZSfxCCNHKSOIXQohWRhK/EEK0MpL4hRCilZHE30Qopb5XSk1ydBxnSymVopS6uJH3qZVSUY25T3tRSnVRSuUrpZwbeLtuSqldSqn2Dbnd1k4p9blS6nJHx3G2JPGfA/ODWvmwKKWKbMYnnsm2tNaXa60X2SvW1kwpFWZ+Sbg01f1orQ9qrb211hUNHNadwGqt9bHKCUqpAUqp75RS2UqpLKXUBqXUZHPecPMYltluRCnV15y+ymaaUkpNU0ptU0oVKqWOK6VWKaWut1lmlVKquNpnZXADH6NtnDFKqf+ax5WtlNqslBptM99HKfWiWVApUEodVEp9ppQaaLOMNuflK6UylVK/KKUmVNvVXOApex2HvUniPwfmB9Vba+0NHASuspn2YeVy9k44QtThLmBx5YiZdFcA/wOigEDg/wG2pdd0YLBSKtBm2iRgb7VtzwfuA2aY2+kI/Au4rNpy02w/K1rrded8VLX7BvgJaAeEAPcAuWD8+sE49t7AlUBboCewhKrHD9DX/FxHAwuBV5VSj1XO1FpvANoqpeLteCz2o7WWRwM8gBTgYnN4OHAYeAg4jvHB8we+xfhQnTSHO9msvwq43Ry+BfgNeN5c9gBweR37fgg4AuQBe4CLzOmzgM+Apea8LRhv6Mr1OgCfmzEdAO6xmecEPAwkAZnAJ0CAzfybgVRz3j9tj79abAPNc+BsM+1aYJs5PADYhPHhPAG8WMdxPggcA44CtwIaiDLnXQFsNbdzCJhls95Bc9l88zEYiMRIAplABvAh4FePc1rrealpPzUcQ43HC4SZ67qY8eXbPIqBlPq8LtX21QUoAlxspv0GvFbHOR6O8d59E5hqTnM2z8W/gVXmtO5ABRB/ms/FKsz39WmW+x7jC8J22h/AdYAC5gFp5nnbDvSqYRtB5jn0q2Uft5vvH6/TxGJ9X9lMG2e+DoE2094GHnNUzjmXh8MDaCkPTk385Rg/B90AD4wS0VjAE/ABPgW+tFnf+gHBSPxlwB3mh+7/YSQ7VcN+ozESXQdzPAyINIdnmdsZB7gCMzESvKuZQDabH+Y2QASQDFxqrnsvsB7oZB7DW8DH5rzzMBLSBea8F83jPSXxm8snAZfYjH8KPGwOrwNuNoe9gUG1bOMyjETZC/ACPqJq4h+OUZJzAvqYy15jc040VRNgFHCJGX8wsBp4qR7ntK7zcsp+ajiOGo+3tnXN1+p/wDOn238N+7oC2Gkz7omRrEfUEd9wjMQ/BPjdnDYa+BEjca4yp92F+WV0ms/FKuqX+P8OrLEZPw/INo/xUoz3qh/Gl0BPoH0N21DAPoxC1TVAaLX5S4CF9YilpsTvivEev9xm2gPAF47IN+f6cHgALeXBqYm/FHCvY/lY4KTNuPUDgpH499vM8zTfjO1q2E4URknoYsC12rxZwHqbcSeMEs/5GCXxg9WW/wfwnjn8J2Yp1xxvj/El4oLxZbHEZp6Xeby1Jf6ngHfNYR+gAOhqjq8GHgeCTnN+3wXm2Ix3r+kDajP/JWCeORzG6RPyNcDWepzTus5LffZT4/HWti7whpnInE63/xr2NbHa69/R3EePOuIbDhw2h/dhfAkuMbdlm/j/Zbttc9phjGRdbPP6rgIKzenZwJZa9lv9fTHb5j0zEqOaaVDleagj/k7AqxiFDYt5vruZ836u9h6KNWPKBfbYTK/xfYXxy3WizfgdwIq64mmqD6njt590rXVx5YhSylMp9ZZSKlUplYvxhvSroxXH8coBrXWhOehdfSGt9X6MetZZQJpSaolSqoPNIodslrVgfDg7AF2BDuYFsGylVDbwCBBqLt4VWGYz70+M0mKoub7tdgswqh1q8xFwnVnHeh3Ghz/VnHcbRhLfrZTaqJS6spZtVNknRjWTlVJqoFJqpVIqXSmVg1EiDaotIKVUqHmujpivxweVy5/mnNZ1XuqjvseLUmoKRiK+0XztznT/JzESqu24BePLoj4WA9OAEcCyavMyq29Ha90J4xy6YZS+K92jtfYzH/1r2pHWOg9YDlReGL4Bo/oNrfUKjGT+GsbrsUAp1baW7RzWWk/TWkdinKsC4P2aYtZaJ2qt/TDek261ngVAKeWK8cswy2ayD8YXR7Mjid9+dLXxGRilp4Fa67YY1SRQ9QNydjvS+iOt9TCMN7rGqGKq1LlyQCnlhFEiOoqRRA/YfCD9tNY+WuvKFhCHMH7W2s5311ofwfjVYLtdT4yqrNri24WRqC8HbsT4Iqict09rfQPGhbi5wGdKKa8aNlNlnxj117Y+Ar4GOmutfTHqqCvPbfXXAuBpc3pv8/W4yWb5us5pXeelpv1UUd/jVUqdDzwJjNFa59rMqmv/1W0DwisbF5gFiHUYVY71sRi4G/jOpvBRaQXQqYEvbn4M3GBegHYHVlbO0FrP11rHYVQBdce43lMnrfUhjC+LXuakX4BRtby/TmcMRlXPBptpPTGuQzQ7kvgbjw/GhbZspVQA8FhDbFQpFa2UGmmWpovNfVhsFolTSl1nfvjvA0ow6og3AHlKqYeUUh5KKWelVC+lVIK53pvAbKVUV3M/wUqpMea8z4ArlVLDlFJtgCc4/XvpI4z66Qsw6vgr479JKRVslmgrS0+WGtb/BLhFKXWe+UVT/fz5AFla62Kl1ACML5hK6eY2I6otnw/kKKU6YpNITnNO6zovNe2nivocr1Kqs3m8f9daV29JU9f+q9BaHwb2Y1xQrvR/GOfxwcpWO2ZTzSU1rH8AuBDj4n31eXswri8sUUpdUvkewrg2cLa+w/iifQJYWvkrRymVYP6ic8UowRdTw3tEKeWvlHpcKRWllHJSSgVhNAJYby7yPkYBYpn5XndWSrkDtX55KaUClNE0+zVgrtba9pfthRgXpZsfR9c1tZQHNbTqqTa/A0Z9Zz5GfeUUbOp0qaFVT7X1a6t37IOZxDF+hn7LXxclZ1G1Vc9WoH+1mD7GqFY6ifEBqTwGJ4yLV3vMdZOAp23WnYTRiqXOVj02y3fB+LAurzb9A4z69HxgJ+YF2Vq28bAZa02tesZh/KrIM8/Bq8AHNus+gZGYszHqimMwLhjmA4kYv8gO1+Ocnu68VNlPDcdQ4/FStVXPLea5sm3Zs7M++69hf1OBN6pNG4CRsHLM4/sd40sGanjv2qxnreM3xxVGc8ntGF+OxzAuRI/nr2sSq6jHxV2bbb5jnocEm2kXYfx6yeevFljeNazrBSwy34v55nvlY6CjzTK+GNd/UjG+RFIxWrYNqPZZKzC3kYXxy+PGavtKoJbrFc3hocyDEC2QUmoWRmK8ydGxCMcwf7VsxbggfOx0y4v6UUp9Dryjtf7O0bGcDfljkRAtmNa6BKNeXDQgrXV9r5M0SVLHL4QQrYxU9QghRCsjJX4hhGhlmkUdf1BQkA4LC3N0GEII0axs3rw5Q2sdXH16s0j8YWFhbNq0ydFhCCFEs6KUSq1pulT1CCFEKyOJXwghWhlJ/EII0co0izr+mpSVlXH48GGKi4tPv7Bo1tzd3enUqROurq6ODkWIFqHZJv7Dhw/j4+NDWFgYSp1zB5eiidJak5mZyeHDhwkPD3d0OEK0CM22qqe4uJjAwEBJ+i2cUorAwED5ZSdEA2q2iR+QpN9KyOssRMNq1olfCCFaquzibOZsmENeaV6Db1sS/zk4fvw4119/PZGRkcTFxTF69Gj27t2LUop//etf1uUyMjJwdXVl2rRp1mkffPABffr0ISYmhr59+3L77beTnW3cl2P48OFER0cTGxtLbGwsn3322Sn7XrhwIcHBwdZlYmNj2bVrFykpKfTq1cu63Ntvv01cXBwnT57klltuITw83Lr8/Pnz7Xh2hBBnQ2vNd8nfMearMSzdvZTNJzY3+D6a7cVdR9Nac+211zJp0iSWLDFuXvTHH39w4sQJwsPDWb58OU899RQAn376KTExMdZ1f/jhB+bNm8f3339Px44dqaioYNGiRZw4cQI/Pz8APvzwQ+Lj676r3YQJE3j11VerTEtJSbEOL168mFdeeYUVK1bg7+8PwHPPPce4cePO+fiFEA3vWP4xnlz/JL8e+ZXeQb15e9TbdPfv3uD7kcR/llauXImrqyt33XWXdVrfvn1JSUnB09OTnj17smnTJuLj41m6dCnjx4/n6NGjAMyePZvnn3+ejh07AuDs7Mytt97aoPF98sknzJkzh19++YWgoFrvOS6EaAIqLBUs3bOUl7e8jEbzUMJD3NDjBpydnO2yvxaR+B//Zie7juaefsEzcF6Htjx2VUyt83fs2EFcXFyt86+//nqWLFlCaGgozs7OdOjQwZr4d+7cSf/+/evc/8SJE/Hw8ADgl19+ITDw1HuZL126lN9++806vm7dOgBSU1OZNm0aW7dupV27dlXWefDBB62/RBYvXkzv3r3rjEMIYV/7T+5n1rpZ/JH+B0M7DOXRwY/S0bujXfdptzp+pVRnpdRKpdQupdROpdS95vQApdRPSql95rO/vWJwpMsuu4yffvqJJUuWMGHChFqX2759O7GxsURGRrJ06VLr9A8//JDExEQSExNrTPpgVPVULpOYmGj9oggODqZLly588sknp6zz3HPPWZeXpC+E45RWlPJ64uv87du/kZqbytPDnuaNi9+we9IH+5b4y4EZWustSikfYLNS6ieMG0n/orWeo5R6GOMG2g+dy47qKpnbS0xMTI0XXSu1adOGuLg4XnjhBXbt2sXXX39dZd0tW7YwYsQIevfuTWJiItOmTaOoqKjW7b322mu8/fbbAHz3Xd23+fT09OS7777j/PPPJyQkhIkTJ57h0Qkh7CkxLZFZa2eRlJPE6PDRPDTgIQLcAxpt/3Yr8Wutj2mtt5jDecCfQEdgDLDIXGwRcI29YrCnkSNHUlJSwoIFC6zTtm3bxqFDh6zjM2bMYO7cuQQEVH1B//GPfzBz5kwOHz5snVZX0geYOnWqtaTeoUOH08YXEhLCDz/8wCOPPMKPP/5Y38MSQthRQVkBz/z+DH///u8UlBfw2kWvMfeCuY2a9KGR6viVUmFAP+B3IFRrfcycdRwIrWWdO4E7Abp06WL/IM+QUoply5Zx3333MXfuXNzd3QkLC+Oll16yLhMTE1OlNU+l0aNHk56ezuWXX05FRQV+fn706tWLSy+99IxiqF7H//rrr1f5UggPD+frr79m9OjRLFu27CyOUgjRUFYfXs2T65/kRMEJbux5I9P7TcfL1cshsdj9nrtKKW/gf8BsrfUXSqlsrbWfzfyTWus66/nj4+N19Rux/Pnnn/Ts2dMuMYumR15v0VxlFWcxZ8Mcvj/wPZG+kcwaMovYkNhG2bdSarPW+pR24XYt8SulXIHPgQ+11l+Yk08opdprrY8ppdoDafaMQQghHEFrzbfJ3/LsxmfJL8vn7r53c1vv22jj3MbRodkv8Sujg5V3gD+11i/azPoamATMMZ+/slcMQgjhCEfyj/DEuidYe3QtfYP78viQx4n0i3R0WFb2LPEPBW4GtiulEs1pj2Ak/E+UUrcBqcB4O8YghBCNpsJSwUe7P+KVra+gUDwy8BEmRE/ASTWt3nHslvi11r8BtXWreJG99iuEEI6wJ2sPs9bOYkfmDs7veD6PDnqU9t7tHR1WjVrEP3eFEMJRSipKeOuPt3hvx3u0dWvLsxc8y2VhlzXp7sQl8QshxFnafGIzs9bOIiU3hasjr+bB+Afxc/c7/YoO1rQqnpqZ2bNnExMTQ58+fYiNjeX3338HoLy8nEceeYRu3bpZu0CePXu2dT1nZ2diY2OtXTK/8MILWCyWGvdx7NgxrrzyyjrjGDJkyFkfw8KFC6t0F+1I3377Lf/+978dHYYQp5VXmseT657klh9uocxSxlsXv8XsYbObRdIHKfGftXXr1vHtt9+yZcsW3NzcyMjIoLS0FIB//etfHD9+nO3bt+Pu7k5eXh4vvPCCdV0PDw8SE43r3Wlpadx4443k5uby+OOPn7KfF198kTvuuKPOWNauXduAR+Y4V1xxBY8++igPP/wwnp6ejg5HiBqtPLiSp35/ioyiDG4+72amxU7D07V5vV+lxH+Wjh07RlBQEG5ubgAEBQXRoUMHCgsLefvtt3nllVdwd3cHwMfHh1mzZtW4nZCQEBYsWMCrr75KTX+m+/zzz7nssssAo1fPAQMGEBsbS58+fdi3bx8A3t7eAKxatYrhw4czbtw4evTowcSJE63b/O677+jRowdxcXHcc889Nf6KSE9PZ+zYsSQkJJCQkMCaNWtOWWbhwoWMGTOG4cOH061btypfVtdccw1xcXHExMRYu7KoqKjglltuoVevXvTu3Zt58+YBMH/+fM477zz69OnD9ddfDxj/hh4+fDjffvvtac6+EI0voyiDGatmcM/Ke/B18+WDyz/g/xL+r9klfWgpJf7vH4bj2xt2m+16w+Vzap09atQonnjiCbp3787FF1/MhAkTuPDCC9m/fz9dunTBx8en3ruKiIigoqKCtLQ0QkP/6sHiwIED+Pv7W79c3nzzTe69914mTpxIaWkpFRUVp2xr69at7Ny5kw4dOjB06FDWrFlDfHw8U6ZMYfXq1YSHh3PDDTfUGMe9997L/fffz7Bhwzh48CCXXnopf/755ynLbdiwgR07duDp6UlCQgJXXHEF8fHxvPvuuwQEBFBUVERCQgJjx44lJSWFI0eOsGPHDgDrXcbmzJnDgQMHcHNzs04DiI+P59dff2X8eGnlK5oGrTVf7v+S5zc9T1F5EdP7TWdyzGRcnV0dHdpZkxL/WfL29mbz5s0sWLCA4OBgJkyYwMKFC09Z7r333iM2NpbOnTtX6cCtPo4dO0ZwcLB1fPDgwTz99NPMnTuX1NRUazfMtgYMGECnTp1wcnIiNjaWlJQUdu/eTUREBOHh4QC1Jv6ff/6ZadOmERsby9VXX01ubi75+fmnLHfJJZcQGBiIh4cH1113nbW/oPnz59O3b18GDRrEoUOH2LdvHxERESQnJzN9+nR++OEH2rZtC0CfPn2YOHEiH3zwAS4uf5U/QkJCrPctEMLRDuUe4o6f7uDfa/9NlF8Un139GXf2ubNZJ31oKSX+Okrm9uTs7Mzw4cMZPnw4vXv3ZtGiRYwfP56DBw+Sl5eHj48PkydPZvLkyfTq1avGEjpAcnIyzs7OhISEVJnu4eFBcXGxdfzGG29k4MCBLF++nNGjR/PWW28xcuTIKutU/jqojK+8vLzex2OxWFi/fr21iqo21ZupKaVYtWoVP//8M+vWrcPT05Phw4dTXFyMv78/f/zxBz/++CNvvvkmn3zyCe+++y7Lly9n9erVfPPNN8yePZvt27fj4uJCcXFxjV9oQjSmcks5H+z6gNcSX8PZyZlHBz3KuO7jmtwfsc5WyzgKB9izZ4+1jh0gMTGRrl274unpyW233ca0adOsSbuiosJ64be69PR07rrrLqZNm3ZKQu3evXuVe+gmJycTERHBPffcw5gxY9i2bVu9Yo2OjiY5Odm6LdsbvtgaNWoUr7zySpVjqslPP/1EVlYWRUVFfPnllwwdOpScnBz8/f3x9PRk9+7drF+/HjBuNG+xWBg7dixPPfUUW7ZswWKxcOjQIUaMGMHcuXPJycmx/rLYu3dvlZvFC9GYLNrCL6m/cMPyG3hh8wsM6jCIr8Z8xfjo8S0m6UNLKfE7QH5+PtOnTyc7OxsXFxeioqKsFzRnz57No48+Sq9evfDx8cHDw4NJkyZZu0wuKioiNjaWsrIyXFxcuPnmm3nggQdO2YeXlxeRkZHs37+fqKgoPvnkExYvXoyrqyvt2rXjkUceqVesHh4evP7661x22WV4eXmRkJBQ43Lz589n6tSp9OnTh/Lyci644ALefPPNU5YbMGAAY8eO5fDhw9x0003Ex8fTu3dv3nzzTXr27El0dDSDBg0C4MiRI0yePNnaXPWZZ56hoqKCm266iZycHLTW3HPPPdabzK9cuZJnnnmmXsclREMpqyhj+YHlvLvjXQ7kHKCTdyeev/B5RnUd1aT/iHW27N4tc0Nozd0yL1u2jM2bN1vvk3u28vPz8fb2RmvN1KlT6datG/fff/8Zb2fhwoVs2rSJV1999ZziqcmJEye48cYb+eWXX06Z11peb9G4CssK+Xzf5yzauYgThSeI9o/m9t63c3HXi3Fxav7lYod0yyzO3bXXXktmZuY5b+ftt99m0aJFlJaW0q9fP6ZMmdIA0TWsgwcPVvm/gxD2kl2czce7P+bD3R+SU5JDfGg8s4bMYmiHoS2yhF+dlPhFsyCvt2gIxwuOs2jnIj7f9zlF5UUM7zyc23rd1mg3RmlsUuIXQrRaydnJvLvjXZYnL0ejuSLiCibHTCbKP8rRoTmEJH4hRIu1PX077+x4hxUHV+Dm7MaEHhP4+3l/p4N3h9Ov3IJJ4hdCtChaa9YdXcc7O95hw/ENtG3Tljv73MmNPW8kwD3A0eE1CZL4hRAtQoWlgp8P/sw729/hz6w/CfEIYWb8TMZ1H4eXq5ejw2tSWs4/EhygqXTLXF+rVq2ybmvVqlVVevV88803ef/99xtkP/U1c+ZMVqxY0aj7FC1PaUUpn+39jKu/vJqZ/5tJUXkRjw95nO/Hfs+kmEmS9GsgJf6z1JS6ZT4bq1atwtvb29qX/1133dXg+zid6dOnc8cdd5zS7YQQ9VFQVsCnez7l/V3vk16UznmB5/Hi8BcZ2Xkkzk7Ojg6vadNaN/lHXFycrm7Xrl2nTGtMn3/+ub7yyitPmV5QUKADAgJ0bm5uret6eXlVGU9KStIBAQHaYrGcsmx4eLguLi7WWmv93nvv6TFjxuiLL75Yd+3aVb/yyiv6hRde0LGxsXrgwIE6MzNTa631hRdeqDdu3Ki11jo9PV137dpVa631ypUr9RVXXKEPHDigQ0NDdYcOHXTfvn316tWr9WOPPaafe+65U/Y/adIkPWXKFB0XF6e7deumv/nmG6211gcOHNDDhg3T/fr10/369dNr1qzRWmt99OhRff755+u+ffvqmJgYvXr1al1eXq4nTZqkY2JidK9evfSLL75o3X7//v31sWPHaj1XlRz9eoumI7MoU7+8+WU9+KPButfCXvq2H2/Ta4+srfHz09oBm3QNObVFlPjnbpjL7qzdDbrNHgE9eGjAQ7XOd0S3zAA7duxg69atFBcXExUVxdy5c9m6dSv3338/77//Pvfdd99p9xcWFsZdd92Ft7c3M2fOBKjx37KVUlJS2LBhA0lJSYwYMYL9+/cTEhLCTz/9hLu7O/v27eOGG25g06ZNfPTRR1x66aX885//pKKigsLCQhITE2vsmhmgf//+rFmzhrFjx9b7fInW6Uj+ERbtXMSyfcsoqSjh4q4Xc2uvW+kVJH07nakWkfgdobJb5l9//ZWVK1cyYcIE5syZQ//+/ass99577/Hyyy+TmZnJ2rVr6dy5c733Ub1bZoARI0bg4+ODj48Pvr6+XHXVVQD07t273p22nanx48fj5OREt27diIiIYPfu3YSHhzNt2jQSExNxdnZm7969ACQkJHDrrbdSVlbGNddcQ2xsbJWuma+44gpGjRpl3bZ0wyxOZ9/Jfby7412+P/A9SimuiriKW3rdQoRvhKNDa7ZaROKvq2RuT43dLTNU7XbZycnJOu7k5GTtgtnFxcV6sbj6+mejpm6Y582bR2hoKH/88QcWi8XalfMFF1zA6tWrWb58ObfccgsPPPAAf//732vsmrkyPumGWdQkMS2Rd7a/w6rDq/Bw8WBiz4ncfN7NtPNq5+jQmj1p1XOWHNEtc32FhYWxefNmAD777LMal/Hx8SEvL69e2/v000+xWCwkJSWRnJxMdHQ0OTk5tG/fHicnJxYvXmz9UktNTSU0NJQ77riD22+/nS1bttTYNXMl6YZZ2NJas/rwaiZ9P4mbv7+ZxPRE7o69m/+O/S8PJjwoSb+BtIgSvyM4olvm+po5cybjx49nwYIFXHHFFTUuc9VVVzFu3Di++uqrKn3w16RLly4MGDCA3Nxc3nzzTdzd3bn77rsZO3Ys77//vrW7ZzBaCz333HO4urri7e3N+++/X2PXzABlZWXs37+f+PhTuhIRzYRFWyguL6awvJCisiIKywurDBeVF1FYZj6XF1YZrpxnO5xflk92STbtvNrx8ICHuTbq2mZ5T9umTjppa+Iaqlvms3XLLbdw5ZVXMm7cuAbf9rJly9iyZQtPPvnkaZdtLa+3oxwvOM6qQ6vqnayLyousjzPh4eJR5eHp6omni6d12MPFg34h/bg8/HJcnZr37Q2bAumkrZlqqG6Zm6Ly8nJmzJjh6DBavbKKMm7/7+2k5qZap1kTs4unNSF7uXgR5B5kHbed5+niiYerOc1m2Dahuzu7S/v6JkISfzNw++23O2zfNd1AvqH87W9/s9u2Rf0t2bOE1NxUXrjwBYZ1HIa7i3uLus2gOFWzTvxa61Zx04TWrjlURzZX2cXZvPHHGwxuP5hLul4in6dWotl+rbu7u5OZmSlJoYXTWpOZmWltLioa1ht/vEFBWQEPJjwoSb8VabYl/k6dOnH48GHS09MdHYqwM3d3dzp16uToMFqc5Jxklu5ZythuY+nm383R4YhG1GwTv6urK+Hh4Y4OQ4hm64VNL+Dh4sHU2KmODkU0smZb1SOEOHtrj65l9eHV3NHnDgI9Ah0djmhkkviFaGXKLeU8t/E5Onp35KaeNzk6HOEAkviFaGW+2PcF+7P380DcA7RxbuPocIQDSOIXohXJK83jtUGIVugAACAASURBVMTX6B/Sn0u6XuLocISDNNuLu0KIM/ef7f8hqziL1y96XZpvtmJS4heilTicd5jFuxZzdeTVxATFODoc4UB2S/xKqXeVUmlKqR0202YppY4opRLNx2h77V8IUdW8zfNwcXLhnn73ODoU4WD2LPEvBC6rYfo8rXWs+fjOjvsXQpi2nNjCf1P/y+SYyYR6hZ5+BdGi2S3xa61XA1n22r4Qon4s2sKzG58lxDOESTGTHB2OaAIcUcc/TSm1zawK8nfA/oVoVZYnL2dn5k7u63+f3NREAI2f+N8AIoFY4BjwQm0LKqXuVEptUkptkv54hDg7hWWFvLTlJWICY7gioua7sYnWp1ETv9b6hNa6QmttAd4GBtSx7AKtdbzWOj44OLjxghSiBVm0cxFphWk8mPCg9LEvrBr1naCUam8zei2wo7ZlhRDn5kTBCd7b+R6XdL2EuNA4R4cjmhC7/YFLKfUxMBwIUkodBh4DhiulYgENpABT7LV/IVq7+VvnU24p5/64+x0dimhi7Jb4tdY31DD5HXvtTwjxl50ZO/k66Wsm95pMZ5/Ojg5HNDFS6SdEC6O15tmNzxLgHsCdve90dDiiCZLEL0QL81PqT2xJ28LU2Kl4t/F2dDiiCZLEL0QLUlJRwoubXyTKL4rrul3n6HBEEyW9cwrRgnz454ccyT/CW5e8hYuTfLxFzaTEL0QLkVmUyYJtC7ig0wUM6TDE0eGIJkwSvxAtxOuJr1NSXsKM+BmODkU0cadN/Eqpe5VSbZXhHaXUFqXUqMYITghRP/tO7uOzfZ8xPno8Eb4Rjg5HNHH1KfHfqrXOBUYB/sDNwBy7RiWEqDetNc9veh5vV2/+X9//5+hwRDNQn8RfeX+20cBirfVOm2lCCAf79civrD26lrv63oWfu5+jwxHNQH0S/2al1H8xEv+PSikfwGLfsIQQ9VFmKeP5Tc/TtW1Xro++3tHhiGaiPu29bsPoRjlZa12olAoEJts3LCFEfXy651MO5Bxg/oj5uDq7Ojoc0UycNvGbXShvsRnPBDLtGZQQ4vRySnJ4/Y/XGdBuAMM7D3d0OKIZkeacQjRTb217i9ySXB5MeBCl5LKbqD9J/EI0Q6m5qXy8+2Ou7XYtPQJ6ODoc0czU6z/dSilnINR2ea31QXsFJYSo2wubXqCNUxum95vu6FBEM3TaxK+Umo5xE5UT/NWaRwN97BiXEKIWG45tYOWhldzT7x6CPIIcHY5ohupT4r8XiDYv6gohHKjCUsGzG5+lvVd7bj7vZkeHI5qp+tTxHwJy7B2IEOL0vkr6ij0n93B/3P24u7g7OhzRTNWnxJ8MrFJKLQdKKidqrV+0W1RCiFMUlBUwf8t8+gb35bKwyxwdjmjG6pP4D5qPNuZDCOEA72x/h8ziTOaPnC/NN8U5qc8fuB5vjECEELU7mn+URTsXMTp8NH2CpV2FODe1Jn6l1Eta6/uUUt9gtOKpQmt9tV0jE0JYvbTlJZRS3Nf/PkeHIlqAukr8i83n5xsjECFEzf5I/4PvD3zPnX3upL13e0eHI1qAWhO/1nqz+fy/xgtHCGFLa82zG58l2COY23rd5uhwRAshXTYI0YR9f+B7tqVvY3q/6Xi6ejo6HNFCSOIXookqLi9m3pZ59AzoyZioMY4OR7Qg9U78SikpbgjRiN7f9T7HC47zYMKDOCkpo4mGU5+brQ9RSu0CdpvjfZVSr9s9MiFasfTCdP6z/T+M7DyShHYJjg5HtDD1KUbMAy7FvPmK1voP4AJ7BiVEa/fK1lcos5QxI36Go0MRLVC9fj9qrQ9Vm1Rhh1iEEMCfmX/y5f4vubHHjXRp28XR4YgWqD5dNhxSSg0BtFLKFaO3zj/tG5YQrZPWmuc2PYevmy9T+k5xdDiihapPif8uYCrQETiCceP1qfYMSojWasWhFWw8vpG7Y++mbZu2jg5HtFD16asnA5jYCLEI0aqVVZTx4qYXifCN4G/d/+bocEQLVp87cIUD04Ewqt56UfrqEaIBfbT7Iw7mHeT1i17Hxaled0UV4qzU5931JfAO8A1/3XpRCNGAThaf5K0/3mJoh6Gc3+l8R4cjWrj6JP5irfV8u0ciRCv2euLrFJYXMjN+pqNDEa1AfRL/y0qpx4D/UvUOXFvsFpUQrUhydjKf7v2Ucd3HEeUf5ehwRCtQn8TfG7gZGMlfVT3aHBdCnKPnNz2Pp4snd8fe7ehQRCtRn8T/NyBCa11q72CEaC3KLeXszNzJyoMr+fXIr8yIm0GAe4CjwxKtRH0S/w7AD0g7kw0rpd4FrgTStNa9zGkBwFKMFkIpwHit9ckz2a4QzZHWmpTcFNYdXcf6Y+vZeHwj+WX5KBRDOgzhxp43OjpE0YrUJ/H7AbuVUhupWsd/uuacC4FXgfdtpj0M/KK1nqOUetgcf+iMIhaimcgoymD9sfWsP7qe9cfWc6LwBAAdvTtyWfhlDGo/iAHtBuDv7u/gSEVrU5/E/9jZbFhrvVopFVZt8hhguDm8CFiFJH7RQhSWFbLpxCbWH1vPuqPr2J+9HwBfN18GthvIoA6DGNR+EJ19Ojs4UtHa1eefuw1568VQrfUxc/g4EFrbgkqpO4E7Abp0kY6qRNNTbilnR8YO1h1bx/qj69mWvo1yXU4bpzb0D+3PlRFXMrjDYHoE9JD+9EWTUmviV0r9prUeppTKw2jFY50FaK31OXUkorXWSildx/wFwAKA+Pj4WpcTorForTmQc8BI9GY9fUFZAQrFeYHnMSlmEoM6DCI2OBZ3F3dHhytEreq62fow89mnAfd3QinVXmt9TCnVnjO8YCxEY0srTOP3Y79b6+rTioy3bGefzowOH22tp/dz93NwpELUX3366lmstb75dNPq6WtgEjDHfP7qLLYhhN0UlBWw6bhRT7/+2HprPb2fmx+D2ht19APbD6STTycHRyrE2avPxd0Y2xGllAsQd7qVlFIfY1zIDVJKHca4SDwH+EQpdRuQCow/04CFaEhlljJ2ZOxg/dH1rDu2ju3p2ynX5bg5uxEXGsfVkVczqP0gogOipZ5etBh11fH/A3gE8FBK5VZOBkox697rorW+oZZZF51pkEI0tOTsZOZtmceGYxsoLC9EoYgJjOGWXrcwuP1g+ob0xc3ZzdFhCmEXddXxPwM8o5R6Rmv9j0aMSQi7WnNkDTP/NxMXJxeuiryKQe0HkdAuAV83X0eHJoRVdmEpyRkFRIV409bdtUG3XZ/mnJL0RYvx0Z8fMXfjXKL8onh15Ku0927v6JBEK1ZcVkFKZgHJ6QUcyKh8zudARgEnC8sAWDg5geHRIQ26X7nbg2gVyixlzN0wl6V7ljK803DmXDAHL1cvR4clWoEKi+bIySKSMvI5YCb4yseR7KIqy7Zr6054kBeX925PRJAXEcFe9O3U8C3GJPGLFi+3NJcZq2aw/th6JsdM5t7+9+Ls5OzosEQLorUmI7+U5PR8a1JPNp8PZhZSWvHXPax83F2ICPZmQHgA4WZyDw/yIizQCy+3xknJ9dqLUsoZ41+2trdePGivoIRoKAdzDzL1l6kczj/ME0Oe4Npu1zo6JNGM5RWXkZJRSHJGfpWS+4H0AvJKyq3LtXFxIizQk8hgLy7uGWotvYcHeRHg1QallAOPon7t+KdjNMU8QdX++PvYMS4hztnG4xu5f9X9ACy4ZAEJ7RIcHJFoDrTWHMwqZO+JfGt9e2UdfFqetZ9KlIKOfh6EB3lxXf+OhAd5ER7sTUSQFx38PHB2cmxyr0t9Svz3AtFa60x7ByNEQ/li3xc8ue5JOrftzGsjX6NzW+kYTdSuuKyC3w9ksXJ3Giv3pJGaWWidF+jVhvAgLy7sHkx4sBcRQV6EB3nTNdATd9fmWWVYn8R/CMixdyBCNIQKSwXzNs9j0a5FDOkwhOcufI62bc6pWynRQh3NLmLlnjRW7k5jzf5MisoqcHNxYkhkILcODadPJ18igrzx9WzYppRNQX0SfzKwSim1nKr98b9ot6iEOAsFZQU8tPoh/nf4f1wffT0PDXgIFydpvyAM5RUWthzMZsXuNFbtSWP38TzAqK4ZF9eJkT1CGBQRiEeb5lmKPxP1+VQcNB9tzIcQTc7R/KNMWzGN5OxkHhn4CDf0qO2P46I1ycwv4X9701mxO43Ve9PJLS7HxUkRH+bPI6N7MCI6hKgQb4dfbG1s9fkD1+ONEYgQZysxLZF7V95LWUUZr1/0OkM6DnF0SMJBLBbNzqO5rDDr6v84nI3WEOTtxqiYdozsEcKwbkEN/k/Y5qauvnpe0lrfp5T6hqr98QP1uvWiEHb3bfK3PLbmMUK9Qnn10leJ8ItwdEiikeUVl/HbvgyjCmdvOul5JSgFfTr5cd9F3RnRI5heHXxxasKtbBpbXSX+xebz840RiBBnwqItvJb4Ggu2LSAuNI6Xhr8kfeK3ElprktLzjVL97nQ2pmRRbtG0dXfhgu7BjIgO4cLoYIK8pZO92tTVSdtm87khb70oxDkrKi/in7/9k59Sf+LaqGt5dNCjuDq37p/uLV1xWQXrkjOtzS0PZRldHfRo58Pt50cwskcI/bv44eIsXWfXR33+wNUNeAY4D7DeT05rLb+pRaNLK0zjnhX3sCtzFzPiZjApZlKruzDXWhw+WWgm+nTWJmVQXGbBw9WZoVGB3HVhJMOjQ+jo5+HoMJul+rTqeQ/jn7vzgBHAZEC+VkWj25W5i+m/TCevLI+XR7zMiC4jHB2SaEDFZRVsOXiS/+0xWuHsS8sHoEuAJ9cndGFEjxAGhgc02z9NNSX1SfweWutflFJKa50KzFJKbQb+befYhLD6OfVn/vHrP/Bz92Px5YuJDoh2dEjiHJWWW9h2OJt1SZmsTcpk88GTlJZbcHVWDAgPYEJCZ0b0CCEiyEt+1TWw+iT+EqWUE7BPKTUNOAJ42zcsIQxaa/6z/T/M3zqfPsF9eHnEywR5BDk6LHEWKiyanUdzWGsm+k0pWRSWVqAU9GzXlr8P6srgyEAGRgTi3Ui9VLZW9e2rxxO4B3gSo7pnkj2DEgKgtKKUWWtn8U3yN1wefjlPDn1SbofYjFgsmj0n8liblMm6pEx+P5BJXrHRg2W3EG/GxXViSGQgA8MD8feS/4Y2pjoTv9kd8wSt9UwgH6N+Xwi7yyzK5L6V95GYnsjU2KlM6TNFfu43cUYzywLWJWeyLimD9clZZBWUAhAW6MmVfdozODKIQREBhPi4n2Zrwp7q+gOXi9a6XCk1rDEDEmLfyX1MXzGdjKIMnrvwOS4Lu8zRIYlaHMoqZG1ShrVUX9ltcQdfd0ZEhzA4MpDBkYHS+qaJqavEvwHoD2xVSn0NfAoUVM7UWn9h59hEK7T68Gr+b/X/4eniycLLFtIrqJejQxI2juUUsc5M8muTMq23DgzydmNwZCBDzEeXAE/5hdaE1aeO3x3IBEZidN2gzGdJ/KLBaK1ZvGsxL2x+gWj/aOaPnE87r3aODqvVy8gvMRJ9spHsD2QYZT8/T1cGhQcy5cIIBkcEtsqOzpqzuhJ/iFLqAWAHfyX8Sqf03SPE2SqzlDF7/Ww+3/c5F3W5iKeHPY2nq6ejw2qVcgrLWH8g01qq33PC6LrY282FgeEBTBzYhcGRgfRs11b6vmnG6kr8zhjNNmt6dSXxiwaRU5LDA6seYMPxDdze+3am95uOk5L/BzaWgpJyNqRkmVU3Gew8movW4O7qREJYAGP6dWBwRCC9O/pKdwgtSF2J/5jW+olGi0S0Oik5KUxbMY2j+UeZPWw2V0dKh6/2VlJewdaD2azdb1yQTTyUTblF08bZidguRm+WgyMD6dvZFzcX+YdsS1VX4pffccJu1h9bzwOrHsBFufCfUf+hf2h/R4fUIpVXWNhxNJe1SRmsS8pkY0oWxWUWnBT07uTHHRdEMDQyiLiu/q3izlPCUFfiv6jRohCthkVb+HTPpzyz4RnCfcN5ZeQrdPLp5OiwWgytNXtP5LPGLNHb/mkqOtSHGwZ0YUhkEAPCA/D1kB5NW6u6umXOasxARMuWU5LDl/u/ZOmepRzKO8SwjsN47oLn8G4jvX+cC601B7MKrd0grEvKICPf+NNUV5s/TQ2OCCTYR/71LAzSIYawq50ZO/l498f8kPIDJRUl9A/pz/R+0xnVdRTOTlK1cDZO5BazLinTWqqvbEsf4uPGsKgghkQFMSQykE7+0jJK1EwSv2hwJRUl/HDgB5buWcr2jO14uHgwJnIM46PHS6+aZyG7sJT1yUaJfs3+DJLSjbb0vh6uDI4w2tIPiQwiMlh6sRT1I4lfNJjDeYf5ZM8nLNu/jOySbMJ9w/nHgH9wVeRV+LTxcXR4zUZtTSw92ziTEGZ0VzwkMoie7dviLG3pxVmQxC/OSYWlgjVH17Bk9xJ+O/IbTsqJkV1GMiF6AgPaDZASaD1Ym1gmZbJ2f0aVJpb9zCaWQ6MC6dPJjzYu0pZenDtJ/OKsZBdns2z/MpbuWcqR/CMEeQQxpe8UxnYbK10tnEaFRbPraC6/7c9gbVJG1SaWHX2544IIhkQGEt81QJpYCruQxC/OyPb07SzZs4QfDvxAqaWUuNA47ou7j4s6XyQ3PK+F1poDGQWsScpkzb4M1iVnklNUBkD3UG+uT+hi9EsfEShNLEWjkMQvTqu4vJjvD3zP0j1L2Zm5E08XT67tdi0ToifQzb+bo8NrktJyi1mTlMGa/cYF2WM5xYDRXfGo80IZara8CWkr/dKLxieJX9TqUO4hPtlrXKzNKckh0jeSRwY+wlURV0n7+2pyi8tYn/RXy5vKG4X7eboyJDKQqZFBDI0KIixQuisWjieJX1RRYangtyO/sWTPEtYcWYOTcuKiLhdxfY/riQ+Nl6RlKi6rYEvqSWupftvhbCw2nZuNi+vE0KggzmsvvViKpkcSvwDgZPFJvtj3BZ/u/ZQj+UcI9gjmrr53Ma77OEI8QxwdnsNV3ij8t/0ZrN1v9HlTUm7B2UnRt5Mv00ZEMSQqiH5d/KRzM9HkOSTxK6VSgDygAijXWsc7Io7WTmvN9oztLNm9hB9TfqTUUkpCuwTuj7ufkV1G4urUei80aq1Jzihg7f4MfttvdHCWa9PnzY0DuzAsyujzxse99Z4n0Tw5ssQ/Qmud4cD9t1pF5UX8cOAHPt79MX9m/YmniyfXdbuOCdETiPKPcnR4DnMit5g1+/+6IHs817gg29HPg8t6tTMvyAZJnzei2ZOqnlbkUO4hluxZwpf7vyS3NJcovyj+OfCfXBV5FV6uXo4Or9HlFJUZXSGYpfrKrhD8PV0ZEhnEkKhAhkUFyf1jRYvjqMSvgf8qpTTwltZ6QfUFlFJ3AncCdOnSpZHDa1nKLGW8s/0d3tr2Fmi4qOtFXB99PXGhca0qoWmt2X08jxW701i5O40tB09i0eDh6syAcKMrhKFRQXJbQdHiOSrxD9NaH1FKhQA/KaV2a61X2y5gfhksAIiPj5dbPZ6l3Vm7eXTNo+zO2s3lYZczM2Fmq7pYW1hazpr9mazYncaqPWnW9vS9OrZl6ogohkUF0a+Lv3SFIFoVhyR+rfUR8zlNKbUMGACsrnstcSbKKsp4a9tbvLP9HXzdfHlpxEtc1KV13FsnNbOAlbvTWLEnnfXJmZSWW/Bq48z53YK5/+IQhkcHyx+nRKvW6IlfKeUFOGmt88zhUYDc27cB7czcyaNrHmXfyX1cGXElDw94GF83X0eHZTel5RY2pWSxYncaK/akkWzW1UcEe3HzoK6M7BFCQliAlOqFMDmixB8KLDPrll2Aj7TWPzggjhantKKUN/54g/d2vEegeyCvjnyVCztf6Oiw7CItr5hVu9NZuSeNX/dlkF9SThtnJwZGBHDzoK6MiA4hLKj1XbAWoj4aPfFrrZOBvo2935Zue/p2Hl3zKEk5SVwTdQ0PJjxI2zZtHR1Wg7FYNNuO5FgvzG4/kgNAu7buXNW3AyOigxkaFYSXmzRUE+J05FPSzBWXF/N64uss2rWIYI9g3rj4DYZ1HObosBpETlEZv+5LZ8XuNP63J53MglKcFPTr4s+Dl0YzIjqEnu19WlXLJCEagiT+ZiwxLZFH1zxKSm4KY7uNZUb8jGZ9pyutNfvS8q2l+k2pJ6mwaPw8XbmwezAje4RwQbdg/L3aODpUIZo1SfzNUFF5Ea9sfYUPdn1Ae6/2LLhkAYM7DHZ0WGeluKyCdUlGc8sVu9OsNw7v2b4td10YwYjoEPp18ZdbDArRgCTxNzObjm/isbWPcTDvIBOiJ3B/3P3N7l+3h7IKWbXHSPRrkzIpKbfg4erM0Kggpo6IYkSPYNr7ejg6TCFaLEn8zURhWSEvbXmJj3d/TCfvTrwz6h0GtB/g6LDqJauglLVm98VrkzJIzSwEoGugJzcM6MLIHiEMCA/A3VV6tRSiMUjibwZ+P/Y7j619jKP5R5nYcyL39LsHT1dPR4dVq4KScjYcyDI6PEvK5M9juQB4u7kwKCKASYPDuDA6mIggL7kwK4QDSOJvwgrKCnhx04t8svcTurbtysLLFtI/tL+jwzpFabmFrQdPsibJ6PAs8VA25RZNG2cn4rr6M3NUd4ZEBdGnoy8uzvInKiEcTRJ/E7X2yFpmrZvF8YLjTDpvElP7TcXDpWnUe1ssml3Hcq0l+o0Hsigqq8BJQe+OvtxxQQRDI4OID/OX6hshmiBJ/E1MXmkez296ni/2fUG4bzjvX/4+sSGxDo1Ja82BjAJriX5dcibZhWUARIV4Mz6+E0OighgUHoivp9yURIimThJ/E/Lr4V95fN3jpBelc2uvW7k79m7cnB1z0w/bm5KsTcqw9mrZwdedi3uGMjQqkCGRQYRKZ2dCNDuS+JuAnJIcnt34LF8nfU2UXxQvjXiJXkG9GjeGwjLWJWearW/+uimJn6crQyIDmRoZxNCoIMIC5aYkQjR3kvgdbOXBlTy5/kmyirO4s8+dTOkzhTbO9v9nalFpBZtSs6wl+h1Hck65KcmQyCDOay83JRGipZHE7yDZxdnM2TiH5cnL6e7fnVcvepXzAs+z2/5KyivYcSSHtfszWZOUwZbUbEorLLg4Kfp18WP6yG4MjQoitrOfdF8sRAsnid8Bfk79mafWP0VOSQ53972b23vfjqtzw14UzSkqY0vqSTamZLEp5SSJh7MpLbcAcF77tkwa0pUhUUEMCAuQHi2FaGXkE9+IsoqzePr3p/kx5Ud6BvTkrUveIjogukG2fSS7iE0pWdZEv+dEHlqDi5MipqMvfx/UlfgwfwaEBxIgnZwJ0apJ4m8EWmt+TP2Rp9c/TV5ZHtP7TWdyr8m4Op1dKb/CotlzPI9NqUaS35SSxVGz1Y23mwv9uvgxund74sP8ie3sh2cbeZmFEH+RjNAIZv8+m6V7ltIrsBdPDn2SKP+oM1q/uKyCxEPZZon+JFtST5JXUg5AaFs3EsICmBIWQHyYPz3atZWeLIUQdZLEb2crD65k6Z6l3NTzJmbEz8DF6fSnPKuglE0pWWwy6+h3HMmhrEID0D3Um6tiO5AQ5k981wA6+XtI80ohxBmRxG9HuaW5PLX+Kbr5d+OBuAdqTPpaa1IzC9mYksVmM9FXtqFv4+xEn06+3DYsgoQwf+K6+uPnKfXzQohzI4nfjl7c9CIZxRm8PPJla6ud8goLu47lstGsm9+YcpKM/BIAfD1cie/qz7i4ziSE+dOro6/0dSOEaHCS+O3k92O/8/m+z5kcM5nyok7M+2kvm1Kz2Howm8LSCgA6+XtwfjejM7OEsACigr3lz1JCCLuTxG8HJRUlPLZ2FoFtOrDy937MP7QGJwU92rXlb3GdiDcvxMpdpoQQjiCJv4FlFZTy+IoPOJJ/mMKDk+nqoXhiTAxjYjvi6yE9VwohHE8SfwOosGgSD53ks82H+WLLEZzaL8fDK5AFf7uREd1DpfpGCNGkSOKvp5MFpfyw8zjrkzPxdnMh0NsNf09Xdh7NZeXuNDILSnFzceLyWHdWFOzntr5TuKhHO0eHLYQQp5DEfxord6excG0Ka/ZnUG7RhLZ1o6xCc7KwFK2NljjDo4MZ2SOE4dEhfLJvIb9s1VwdebWjQxdCiBpJ4q9FWl4xj3+zi+XbjtHRz4Pbz4/gyj7tienQFqUU5RUWsovK8PNwtd5HVmvNV0lfER8aT2efzg4+AiGEqFmLTvyL16fy1v+S+O2hkTXOzyooZb1585EDGQWE+rjT0d8DNxcnFqxOprjMwoxLujPlwshTuip2cXYiyLvq3bES0xNJzU3l9t632+2YhBDiXLXoxP/olzsAI8H7erhSWFpOdmEZy7cfY/m2Y2w/kgOAVxtnokJ9SMnI4lhiERYNA8ICePq63kSFeNd7f1/t/woPFw9GdR1ll+MRQoiG0KITf6X+T/6EkwKL/mta306+zLikO0OigujTyRdXs7qmvMJCVmEpwd5uZ9QHTlF5ET+k/MCorqPwdPVs6EMQQogG0yoSPxhJPyrEm+v6d+TK3h3oElhzcnZxdiLE58xvIP5N0jcUlBUwJmrMuYYqhGgslgooKzIfBeZzofHs5AIubuDiYTy7elQdb8adI7aaxN+jnQ8/3HfBOW+nuLwYd5e/vhi01izauYh5W+bRJ6gPcaFx57wPIQRgsUB58alJubTQJkEX/pWoS22Gy6oN1zavvPjs43N2A1d3cLF5VB+v6Quj+nhN69mO+7SHNg1bi9AqEv97tySQEB5wzttZtm8Zj619jNiQWK6MuJIRnUfw4uYX+Tb5Wy7peglPDX0KJyX3qxUtlNZQXgLlRVBWXMdzsZlY61qmpufqw4VnHqNyhjZeRnJ19TQfHkbi9PA7dbqrpzHPdtzV00i8lgrjWMqL/zquyuMvLzG/OGzGqyxXDMXZNa93pl82Ez+Dbpec+bmo6zRprU+/lIPFx8frTZs2nfF6BSXlZOaX1lqtHrsv8AAADG1JREFUcya2pW/jlh9uoZt/N0rKS0jKSbLOmxo7lSl9pki/+MJxKsqrloCtpWKzpFxaULW0W1q9tFzwVwn4lOfCvxIYZ5kvnFyMhGotzXrU8exRSzKuK1Gbwy7NoNty2y/Qmr4wKr8oKr9Ywi+Atu3PaldKqc1a6/jq01t0id/LzeWMbySeXZzNP377B/1C+jEpZhJuzm5kFGVw/6r7CfEMYcElC2jbpi27snbxS+ov9Avpx/mdzrfTEYgWo6LMTK62ibawhmm2ybqW5FxlvjlcUXrmMVmTpplMXdyNYfe24BJaLSG7m1UUts+e9Uji5rNzi041Z0Yp47y4nvm1xIYir4aNcks5D65+kA3HN/Dbkd/4Yt8XzIifwQe7PiC3JJcPRn+Ar5svADGBMcQExjg4YtFgLBajBFaZTCuTrjUxF546zTYxV5lWULXEXVoIlrIzi6emKos2ZsnWw79aqbjafFevavM8bLZV+ezRrC9OinMjid/GvM3zWH9sPU8MeYL23u2Zu2EuD6x6AIBnL3iW6IBoB0coalVeAsU5UJRt1K0WZRvj1mGb58rlSnKMhF1aaCT9M6KqJuY2Xn8lXw8/m0Ts9dezNVnbJGbbhGybuJ1dJTELu5HEb/om6Rve3/U+N/a4kWu7XQvAp1d9yud7P0cpxeXhlzs4whZOa6PEXD0515nEbaadLnG7eoG7r5GU3f3ArzO4xRiJt3oyPiVp1zDNxV0Ss2i2Wm3izynJYe/JvRzMPUhqXiof/fkRCe0SmJkw07qMi5MLE3pMcGCUZ8FSUUddsVkXrC2gK4xka6kwhy3msDnPYrEZtpmuLea806xjnWe7TuVy5VCSd2qSP111iJsvePgaCdzdD4KijGfbhO7hf+o0d9/mcdFPiEbikMSvlLoMeBlwBv6jtZ7TGPu1aAsbjm/g872f88vBXygzE42Lkwu9Anvx/IXP4+pkx5ulaG0k3nNpdVFlfg0XAc/mIt9ZU+DkbNRHKydz2KnacC3z3Hz+Knm7+5lJ2tdmuNo0d19jPSHEOWv0xK+UcgZeAy4BDgMblVJfa6132WN/5ZZydmbuZPXh1Xx/4HsO5R2ibZu2jI8ezwUdz6erdyfauQfibCk3Emj+fiOBVpaIwWheVXQSCrOMkqpSRvM0a9JTRkIrLYTsVDiZYjyXFhp1zxUlRnOtyu2eCeV0av2vtV1yPS7y/f/2zj/YqqqK458v7we/HvFD0HlICBRK/CMSGUgkU4lkjv4RU1ATVFOMFpmkkzD+4Y+ZJi3GSYdM8Ec1lWgKY84bCs2YMc0ITUBEHpCa4iA/nMCwYQpY/bHX5Z33uPfhgwvncc/6zOx5+6y9ztnr7Lveuvvus8/e7R7s9Ya6xuML1KWyrDyGOoLgtCSPHv+FwDYzexVA0kPAlUDVA//tyz/Pr/dvOXL8sf8e5ur/HOCS/XvotfXHcPiH1a4yTV0bOAIGDIeeTentvvrGJO/KrItSeV1jBNggCKpKHoH/bODNzPF24OMdlSTNBeYCDB8+/LgqGt63GfZv4dZeH2JKw2AG1/tDubqGFFDrGlPPva4eejSkYNvYlAJvj1LTKAXu3oNSD7tnvyTOjl+XUl1PaDozAnUQBN2abvtw18yWAkshvbl7PNeYNX0xs6pqVRAEwelPHgvLvAVkt6ca5rIgCILgFJBH4F8LjJY0UlIjMBN4PAc7giAICskpH+oxs4OS5gGrSNM5HzCzl0+1HUEQBEUllzF+M1sJrMyj7iAIgqITi8cHQRAUjAj8QRAEBSMCfxAEQcGIwB8EQVAwToutFyXtBv55nKcPBvZU0ZzTnWiPNqIt2hPt0Z5aaI9zzGxIR+FpEfhPBEnPl9tzsqhEe7QRbdGeaI/21HJ7xFBPEARBwYjAHwRBUDCKEPiX5m1ANyPao41oi/ZEe7SnZtuj5sf4gyAIgvYUoccfBEEQZIjAHwRBUDBqOvBLmi6pVdI2SQvytudEkPRBSaslbZL0sqTvunyQpCclbfW/A10uSXf5vW+QND5zrTmuv1XSnIz8o5Je8nPuktJWYpXqyBtJdZJelNTixyMlrXH7H/Zlv5HU04+3efmIzDUWurxV0qUZeVnfqVRH3kgaIOlRSZslvSJpUsF9Y77/n2yUtExSryL7x1GYWU0m0pLP/wBGAY3AemBs3nadwP00A+M93w/YAowFfgQscPkC4HbPXwb8HhAwEVjj8kHAq/53oOcHetnfXFd+7mddXraOvBPwPeBBoMWPfwvM9Pw9wNWe/xZwj+dnAg97fqz7RU9gpPtLXWe+U6mOvBPwS+Abnm8EBhTVN0jbu74G9M58Zl8tsn8c1UZ5G3ASP/xJwKrM8UJgYd52VfH+fgdcArQCzS5rBlo9vwSYldFv9fJZwJKMfInLmoHNGfkRvUp15Hz/w4CngE8BLR6Q9gD1HT9/0t4Pkzxf73rq6BMlvUq+01kdObdFfw906iAvqm+U9vUe5J93C3BpUf2jXKrloZ5ym7qfnZMtVcV/il4ArAHOMrMdXvQ2cJbnK91/Z/LtZeR0Ukee/AT4PnDYj88A9prZQT/O2n/knr18n+t3tY06qyNPRgK7gZ/70Nd9kvpSUN8ws7eARcAbwA7S5/0CxfWPo6jlwF+TSGoClgPXmtm72TJL3YyTOj/3VNRxLCRdDuwysxfytKMbUQ+MB35mZhcA75GGXY5QFN8A8OcMV5K+EIcCfYHpuRrVzajlwF9zm7pLaiAF/d+Y2QoX75TU7OXNwC6XV7r/zuTDysg7qyMvJgNXSHodeIg03HMnMEBSaVe5rP1H7tnL+wPv0PU2eqeTOvJkO7DdzNb48aOkL4Ii+gbAZ4DXzGy3mf0PWEHymaL6x1HUcuCvqU3dfRbF/cArZnZHpuhxoDT7Yg5p7L8kn+0zOCYC+/wn+SpgmqSB3jOaRhqH3AG8K2mi1zW7w7XK1ZELZrbQzIaZ2QjS5/onM/sysBqY4Wod26Jk/wzXN5fP9FkdI4HRpIeYZX3Hz6lUR26Y2dvAm5LOc9GngU0U0DecN4CJkvq4vaX2KKR/lCXvhwwnM5FmL2whPYG/MW97TvBePkH6Gb0BWOfpMtK44lPAVuCPwCDXF/BTv/eXgAmZa30d2Obpaxn5BGCjn7OYtje7y9bRHRIwlbZZPaNI/5jbgEeAni7v5cfbvHxU5vwb/X5b8ZkqnflOpTryTsA44Hn3j8dIs3IK6xvALcBmt/lXpJk5hfWPjimWbAiCICgYtTzUEwRBEJQhAn8QBEHBiMAfBEFQMCLwB0EQFIwI/EEQBAUjAn9QM0g6JGmdr8q4XtJ1kjr1cUkjJH3pJNhyraQ+XdC/StLsatsRBOWI6ZxBzSBpv5k1ef5M0sqdz5rZTZ2cMxW43swur7Itr5Pmx++p5nWDoBpEjz+oScxsFzAXmOdvqI6Q9GdJf/d0kaveBkzxXwrzK+lJapb0tOttlDTF5dMkPee6j0hqknQNaY2Y1ZJWd7RN0m1K+ypskLTIZTdLul7SUK+jlA5JOkfSEEnLJa31NPlUtGNQm0SPP6gZsj3+jGwvcB7wb+CwmR2QNBpYZmYTOvb4fXimnN51QC8z+4GkOqAP6W3QFaQ3Ot+TdAPpTc1bK/X4JZ0B/AUYY2YmaYCZ7ZV0M7DfzBZldL8NXGxmX5D0IHC3mT0jaThpKYWPVLkJg4JQf2yVIKgJGoDFksYBh4Bzu6i3FnhAaaG8x8xsnaSLSZt1PJuWhKEReO4YduwDDgD3K+0c1lJOyXv03yQt1QFp4bGxXg/AByQ1mdn+Y9QXBEcRgT+oWSSNIgXvXcBNwE7gfNIQ54EKp80vp2dmT0v6JPA54BeS7gD+BTxpZrPer01mdlDShaSFw2YA80iri2btbiYtyHdFJrD3ACaaWSW7g+B9E2P8QU0iaQhp67vFlsYz+wM7zOww8BXS9nmQhoD6ZU4tqyfpHGCnmd0L3Eda9vivwGRJH3advpLOrXDdkl1NQH8zW0n6kjm/Q3kDaXGvG8xsS6boCeA7Gb1xXWuRIGgjAn9QS/QuTeckrRT5BGmVRoC7gTmS1gNjSJuVQFrN8pBP/5zfid5UYL2kF4EvAnea2W7SXq7LJG0gDfOMcf2lwB/KPNztB7S4/jOkfYOzXERaCfOWzAPeocA1wAR/ILwJuOo42ygI4uFuEARB0YgefxAEQcGIwB8EQVAwIvAHQRAUjAj8QRAEBSMCfxAEQcGIwB8EQVAwIvAHQRAUjP8Ds68KndNNqlwAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##4. (K-1) CMGF Binary Regressions"
+      ],
+      "metadata": {
+        "id": "2bmsihchf--d"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let us try to construct the multinomial logistic regression as a combination of $(K-1)$ binary logistic regressions."
+      ],
+      "metadata": {
+        "id": "DIe2QkTSgLvF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sigmoid_fn = lambda w, x: jax.nn.sigmoid(w @ x)\n",
+        "\n",
+        "class CMGFOneVsAllEstimator(BaseEstimator, ClassifierMixin):\n",
+        "    def __init__(self, params, weights=None):\n",
+        "        self.params = params\n",
+        "        self.weights = weights\n",
+        "\n",
+        "    def fit(self, X, y):\n",
+        "        X_bias = jnp.concatenate([jnp.ones((len(X), 1)), X], axis=1)\n",
+        "        input_dim = X_bias.shape[-1]\n",
+        "        num_classes = y.max() + 1\n",
+        "\n",
+        "        # Construct CMGFParams\n",
+        "        cmgf_params = self.params(\n",
+        "            initial_mean = jnp.zeros(input_dim),\n",
+        "            initial_covariance = jnp.eye(input_dim),\n",
+        "            dynamics_function = lambda w, x: w,\n",
+        "            dynamics_covariance = jnp.zeros((input_dim, input_dim)),\n",
+        "            emission_mean_function = sigmoid_fn,\n",
+        "            emission_var_function = lambda w, x: sigmoid_fn(w, x) * (1 - sigmoid_fn(w, x))\n",
+        "        )\n",
+        "\n",
+        "        # Construct (K-1) binary classifiers\n",
+        "        classifiers = []\n",
+        "        for k in range(num_classes):\n",
+        "            y_k = jnp.array((y == k).astype(float))\n",
+        "            post = conditional_moments_gaussian_filter(cmgf_params, y_k, inputs=X_bias)\n",
+        "            classifiers.append(post.filtered_means[-1])\n",
+        "\n",
+        "        self.weights = jnp.array(classifiers)\n",
+        "        return self\n",
+        "    \n",
+        "    def predict(self, X, y=None):\n",
+        "        X_bias = jnp.concatenate([jnp.ones((len(X), 1)), X], axis=1)\n",
+        "        return jnp.argmax(sigmoid_fn(X_bias, self.weights.T), axis=1)"
+      ],
+      "metadata": {
+        "id": "8hMGH1CtoByz"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's examine the speed-up."
+      ],
+      "metadata": {
+        "id": "WvNJoCREv3LZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "cmgf_est = CMGFOneVsAllEstimator(EKFParams)\n",
+        "sgd_op_est = LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1)\n",
+        "sgd_mp_est = LogisticRegression(multi_class='multinomial', solver='sag')\n",
+        "\n",
+        "# Plot timed results against different dataset sizes\n",
+        "# with fixed class size (K = 3)\n",
+        "import numpy as np\n",
+        "import time\n",
+        "\n",
+        "cmgf_times, sgd_op_times, sgd_mp_times = [], [], []\n",
+        "\n",
+        "it_times, vec_times = [], []\n",
+        "for data_size in data_size_grid:\n",
+        "    print(f'dataset of size {data_size}')\n",
+        "    simplefilter(\"ignore\", category=ConvergenceWarning)\n",
+        "    input, output = make_classification(n_samples=data_size, n_features=4, n_informative=4, \n",
+        "                                        n_redundant=0, n_classes=3, random_state=2)\n",
+        "    start = time.time()\n",
+        "    _ = cmgf_est.fit(input, output)\n",
+        "    cmgf_time = time.time() - start\n",
+        "    cmgf_times.append(cmgf_time)\n",
+        "    print(f'cmgf took {cmgf_time} seconds.')\n",
+        "\n",
+        "    start = time.time()\n",
+        "    _ = sgd_op_est.fit(input, output)\n",
+        "    sgd_op_time = time.time() - start\n",
+        "    sgd_op_times.append(sgd_op_time)\n",
+        "    print(f'one-pass sgd took {sgd_op_time} seconds.')\n",
+        "\n",
+        "    start = time.time()\n",
+        "    _ = sgd_mp_est.fit(input, output)\n",
+        "    sgd_mp_time = time.time() - start\n",
+        "    sgd_mp_times.append(sgd_mp_time)\n",
+        "    print(f'multi-pass sgd took {sgd_mp_time} seconds.')"
+      ],
+      "metadata": {
+        "id": "baAZZ7M4v7Ha",
+        "outputId": "c979c4a0-5e63-41c4-8986-f5dda2feea5b",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "dataset of size 20\n",
+            "cmgf took 2.247864246368408 seconds.\n",
+            "one-pass sgd took 0.0017330646514892578 seconds.\n",
+            "multi-pass sgd took 0.0015726089477539062 seconds.\n",
+            "dataset of size 40\n",
+            "cmgf took 2.141752004623413 seconds.\n",
+            "one-pass sgd took 0.0029501914978027344 seconds.\n",
+            "multi-pass sgd took 0.0028657913208007812 seconds.\n",
+            "dataset of size 60\n",
+            "cmgf took 2.113652229309082 seconds.\n",
+            "one-pass sgd took 0.003916263580322266 seconds.\n",
+            "multi-pass sgd took 0.0030303001403808594 seconds.\n",
+            "dataset of size 80\n",
+            "cmgf took 2.144176483154297 seconds.\n",
+            "one-pass sgd took 0.0017254352569580078 seconds.\n",
+            "multi-pass sgd took 0.0021047592163085938 seconds.\n",
+            "dataset of size 100\n",
+            "cmgf took 2.5510377883911133 seconds.\n",
+            "one-pass sgd took 0.0020895004272460938 seconds.\n",
+            "multi-pass sgd took 0.0025649070739746094 seconds.\n",
+            "dataset of size 200\n",
+            "cmgf took 2.141427516937256 seconds.\n",
+            "one-pass sgd took 0.0016314983367919922 seconds.\n",
+            "multi-pass sgd took 0.002859354019165039 seconds.\n",
+            "dataset of size 300\n",
+            "cmgf took 1.8176734447479248 seconds.\n",
+            "one-pass sgd took 0.0036988258361816406 seconds.\n",
+            "multi-pass sgd took 0.006010532379150391 seconds.\n",
+            "dataset of size 400\n",
+            "cmgf took 2.131483554840088 seconds.\n",
+            "one-pass sgd took 0.0019443035125732422 seconds.\n",
+            "multi-pass sgd took 0.0056073665618896484 seconds.\n",
+            "dataset of size 500\n",
+            "cmgf took 2.2097485065460205 seconds.\n",
+            "one-pass sgd took 0.0038950443267822266 seconds.\n",
+            "multi-pass sgd took 0.007578372955322266 seconds.\n",
+            "dataset of size 600\n",
+            "cmgf took 2.133527994155884 seconds.\n",
+            "one-pass sgd took 0.0022079944610595703 seconds.\n",
+            "multi-pass sgd took 0.007909297943115234 seconds.\n",
+            "dataset of size 700\n",
+            "cmgf took 2.025797128677368 seconds.\n",
+            "one-pass sgd took 0.004023313522338867 seconds.\n",
+            "multi-pass sgd took 0.011013269424438477 seconds.\n",
+            "dataset of size 800\n",
+            "cmgf took 2.6198127269744873 seconds.\n",
+            "one-pass sgd took 0.0039000511169433594 seconds.\n",
+            "multi-pass sgd took 0.011148452758789062 seconds.\n",
+            "dataset of size 900\n",
+            "cmgf took 2.1559877395629883 seconds.\n",
+            "one-pass sgd took 0.003929615020751953 seconds.\n",
+            "multi-pass sgd took 0.012558937072753906 seconds.\n",
+            "dataset of size 1000\n",
+            "cmgf took 2.049783229827881 seconds.\n",
+            "one-pass sgd took 0.0033288002014160156 seconds.\n",
+            "multi-pass sgd took 0.01012277603149414 seconds.\n",
+            "dataset of size 2000\n",
+            "cmgf took 2.0664381980895996 seconds.\n",
+            "one-pass sgd took 0.00454258918762207 seconds.\n",
+            "multi-pass sgd took 0.022353172302246094 seconds.\n",
+            "dataset of size 3000\n",
+            "cmgf took 2.1363601684570312 seconds.\n",
+            "one-pass sgd took 0.004629373550415039 seconds.\n",
+            "multi-pass sgd took 0.031493425369262695 seconds.\n",
+            "dataset of size 4000\n",
+            "cmgf took 1.895021677017212 seconds.\n",
+            "one-pass sgd took 0.004461050033569336 seconds.\n",
+            "multi-pass sgd took 0.034441232681274414 seconds.\n",
+            "dataset of size 5000\n",
+            "cmgf took 1.904376745223999 seconds.\n",
+            "one-pass sgd took 0.0064504146575927734 seconds.\n",
+            "multi-pass sgd took 0.051361799240112305 seconds.\n",
+            "dataset of size 6000\n",
+            "cmgf took 2.748452663421631 seconds.\n",
+            "one-pass sgd took 0.005502223968505859 seconds.\n",
+            "multi-pass sgd took 0.06683635711669922 seconds.\n",
+            "dataset of size 7000\n",
+            "cmgf took 2.287061929702759 seconds.\n",
+            "one-pass sgd took 0.008087158203125 seconds.\n",
+            "multi-pass sgd took 0.06329560279846191 seconds.\n",
+            "dataset of size 8000\n",
+            "cmgf took 2.2241897583007812 seconds.\n",
+            "one-pass sgd took 0.007070302963256836 seconds.\n",
+            "multi-pass sgd took 0.07593631744384766 seconds.\n",
+            "dataset of size 9000\n",
+            "cmgf took 2.251366376876831 seconds.\n",
+            "one-pass sgd took 0.007658481597900391 seconds.\n",
+            "multi-pass sgd took 0.09272050857543945 seconds.\n",
+            "dataset of size 10000\n",
+            "cmgf took 2.250208616256714 seconds.\n",
+            "one-pass sgd took 0.010555744171142578 seconds.\n",
+            "multi-pass sgd took 0.10252046585083008 seconds.\n",
+            "dataset of size 20000\n",
+            "cmgf took 2.3359451293945312 seconds.\n",
+            "one-pass sgd took 0.0217134952545166 seconds.\n",
+            "multi-pass sgd took 0.2470080852508545 seconds.\n",
+            "dataset of size 30000\n",
+            "cmgf took 2.475764036178589 seconds.\n",
+            "one-pass sgd took 0.022215604782104492 seconds.\n",
+            "multi-pass sgd took 0.25092577934265137 seconds.\n",
+            "dataset of size 40000\n",
+            "cmgf took 2.434718608856201 seconds.\n",
+            "one-pass sgd took 0.042949676513671875 seconds.\n",
+            "multi-pass sgd took 0.4916534423828125 seconds.\n",
+            "dataset of size 50000\n",
+            "cmgf took 3.076319694519043 seconds.\n",
+            "one-pass sgd took 0.050797224044799805 seconds.\n",
+            "multi-pass sgd took 0.9660537242889404 seconds.\n",
+            "dataset of size 60000\n",
+            "cmgf took 2.6345906257629395 seconds.\n",
+            "one-pass sgd took 0.061223745346069336 seconds.\n",
+            "multi-pass sgd took 1.0757758617401123 seconds.\n",
+            "dataset of size 70000\n",
+            "cmgf took 2.7093818187713623 seconds.\n",
+            "one-pass sgd took 0.10248351097106934 seconds.\n",
+            "multi-pass sgd took 1.5215744972229004 seconds.\n",
+            "dataset of size 80000\n",
+            "cmgf took 2.842820644378662 seconds.\n",
+            "one-pass sgd took 0.07693910598754883 seconds.\n",
+            "multi-pass sgd took 1.0894696712493896 seconds.\n",
+            "dataset of size 90000\n",
+            "cmgf took 3.032198667526245 seconds.\n",
+            "one-pass sgd took 0.10219120979309082 seconds.\n",
+            "multi-pass sgd took 1.5828421115875244 seconds.\n",
+            "dataset of size 100000\n",
+            "cmgf took 3.068697214126587 seconds.\n",
+            "one-pass sgd took 0.10702323913574219 seconds.\n",
+            "multi-pass sgd took 2.761890172958374 seconds.\n",
+            "dataset of size 200000\n",
+            "cmgf took 4.350834846496582 seconds.\n",
+            "one-pass sgd took 0.27786779403686523 seconds.\n",
+            "multi-pass sgd took 5.1138787269592285 seconds.\n",
+            "dataset of size 300000\n",
+            "cmgf took 6.191785573959351 seconds.\n",
+            "one-pass sgd took 0.39610838890075684 seconds.\n",
+            "multi-pass sgd took 6.630280256271362 seconds.\n",
+            "dataset of size 400000\n",
+            "cmgf took 6.729936361312866 seconds.\n",
+            "one-pass sgd took 0.5301399230957031 seconds.\n",
+            "multi-pass sgd took 8.880788803100586 seconds.\n",
+            "dataset of size 500000\n",
+            "cmgf took 7.156586647033691 seconds.\n",
+            "one-pass sgd took 0.5154798030853271 seconds.\n",
+            "multi-pass sgd took 9.878097772598267 seconds.\n",
+            "dataset of size 600000\n",
+            "cmgf took 8.344544649124146 seconds.\n",
+            "one-pass sgd took 0.6738855838775635 seconds.\n",
+            "multi-pass sgd took 12.782240390777588 seconds.\n",
+            "dataset of size 700000\n",
+            "cmgf took 9.24948263168335 seconds.\n",
+            "one-pass sgd took 0.9374144077301025 seconds.\n",
+            "multi-pass sgd took 18.83796525001526 seconds.\n",
+            "dataset of size 800000\n",
+            "cmgf took 10.545517921447754 seconds.\n",
+            "one-pass sgd took 1.1012070178985596 seconds.\n",
+            "multi-pass sgd took 18.36552929878235 seconds.\n",
+            "dataset of size 900000\n",
+            "cmgf took 11.651687860488892 seconds.\n",
+            "one-pass sgd took 1.2286105155944824 seconds.\n",
+            "multi-pass sgd took 15.630087852478027 seconds.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot the result\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(data_size_grid, cmgf_times, label='CMGF-EKF')\n",
+        "ax.plot(data_size_grid, sgd_op_times, label='SGD (single pass)')\n",
+        "ax.plot(data_size_grid, sgd_mp_times, label='SGD (multi pass)')\n",
+        "ax.set_xlabel('Dataset size')\n",
+        "ax.set_ylabel('Train time in s')\n",
+        "ax.set_title('Train speed vs dataset size (CMGF vs SGD)')\n",
+        "ax.legend();\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "xphGBYR0w9Zw",
+        "outputId": "f12db1df-e2a4-477b-c98c-377f621c9e77",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEWCAYAAAB8LwAVAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdeVwVVf/A8c9hkV1lE2UTFyRFERU1ywUtd9vUNLXSetIsNVus1OrRbDF9KkvtybTM0lx6MivXX26klWaK4r4iOwiisgjIdn5/zIUueMErcrks5/163Rf3zpyZ+c5w73xn5pw5I6SUKIqiKEppFuYOQFEURameVIJQFEVRDFIJQlEURTFIJQhFURTFIJUgFEVRFINUglAURVEMUgmihhFCbBVCjDV3HBUlhIgSQtxfxcuUQoiWVblMUxFC+AohMoUQlpU8XxshxEkhRJPKnG9dJ4RYL4QYaO44KkoliCqg+0EXvQqFENl6n8fczryklAOllN+YKta6TAjhp0smVtV1OVLKGCmlo5SyoJLDmgDskVImFg0QQnQRQmwRQlwTQlwRQhwQQjylGxeqW4cN+jMRQrTXDQ/TGyaEEJOFEEeFEFlCiCQhRJgQ4jG9MmFCiJxSv5VulbyO+nEGCiF+1a3XNSHEISHEIL3xTkKIj3UHNNeFEDFCiB+EEF31ykjduEwhRKoQYqcQYmSpRc0D3jXVepiaShBVQPeDdpRSOgIxwAN6w74rKmfqHZOilGMisLLog27nvAv4DWgJuALPAfpHwylANyGEq96wscDZUvNeCLwIvKKbjxfwJjCgVLnJ+r8VKeW+O16rsm0EtgONgUbAC0A6aGdTaOveDhgC1AdaA2spuf4A7XW/6wBgBbBYCDGraKSU8gBQXwgRYsJ1MR0ppXpV4QuIAu7XvQ8F4oDXgSS0H6gzsAntx3dV995bb/ow4Bnd+3HA78CHurIXgYHlLPt1IB7IAM4A9+mGzwZ+ANbpxoWjffGLpvME1utiugi8oDfOApgOXABSge8BF73xTwDRunFv6K9/qdi66raBpd6wR4CjuvddgINoP+JLwMflrOerQCKQADwNSKClbtxg4LBuPrHAbL3pYnRlM3WvbkALtJ1FKnAZ+A5oaMQ2LXO7GFqOgXUwuL6An25aK118mXqvHCDKmP9LqWX5AtmAld6w34HPytnGoWjf3SXAJN0wS922+DcQphvWCigAQm7xuwhD972+RbmtaIlEf1gEMBQQwAIgWbfdjgFtDczDTbcNG5axjGd03x+HW8RS/L3SGzZc939w1Ru2DJhlrn3OnbzMHkBde3FzgshHOw21AezQjrCGAfaAE/A/4Ce96Yt/SGgJIg8Yr/txPoe2UxQGlhuAtkP01H32A1ro3s/WzWc4YA1MQ0sE1rodzSHdj74e0ByIBPrrpp0K7Ae8devwBbBGN64N2o6rp27cx7r1vSlB6MpfAPrqff4fMF33fh/whO69I3B3GfMYgLZDbQs4AKspmSBC0Y4MLYAgXdmH9baJpOSOsiXQVxe/O7AH+MSIbVredrlpOQbWw+D6ljWt7n/1GzD3Vss3sKzBwAm9z/ZoO/Xe5cQXipYg7gH+0g0bBPwf2g42TDdsIrqkdYvfRRjGJYgngT/0PrcBrunWsT/ad7UhWrJoDTQxMA8BnEM7+HoY8Cg1fi2wwohYDCUIa7Tv+EC9YS8DP5pjf3OnL7MHUNde3JwgcgHbcsoHA1f1Phf/kNASxHm9cfa6L21jA/NpiXZkdT9gXWrcbGC/3mcLtCOoHmhH9jGlys8Avta9P4XuqFn3uQlasrFCSypr9cY56Na3rATxLrBc994JuA401X3eA7wNuN1i+y4HPtD73MrQD1lv/CfAAt17P269434YOGzENi1vuxizHIPrW9a0wOe6HZ7FrZZvYFljSv3/vXTLuKuc+EKBON37c2jJcq1uXvoJ4k39eeuGxaHt1HP0/r9hQJZu+DUgvIzllv5evKf3nemDdnnr7qLtUE783sBitIOSQt329teN21HqOxSsiykdOKM33OD3Cu1MeIze5/HArvLiqa4vVQdhfilSypyiD0IIeyHEF0KIaCFEOtoXt2E5rVaSit5IKbN0bx1LF5JSnke7DjwbSBZCrBVCeOoVidUrW4j2I/YEmgKeuoq8a0KIa8BMwENXvCmwQW/cKbSjTw/d9PrzvY52uaMsq4GhumvAQ9F2EtG6cf9C29mfFkL8LYQYUsY8SiwT7fJWMSFEVyHEbiFEihAiDe0I162sgIQQHrptFa/7f6wqKn+LbVredjGGseuLEOJZtB32aN3/7naXfxVtx6v/uRAtqRhjJTAZ6A1sKDUutfR8pJTeaNvQBu1ovsgLUsqGuldHQwuSUmYAm4GiCu5RaJf9kFLuQtvpf4b2/1gqhKhfxnzipJSTpZQt0LbVdeBbQzFLKY9IKRuifSdtytwKgBDCGu1M84reYCe0BFPjqARhfrLU51fQjsa6Sinro12egZI/pIotSMrVUsruaD8IiXZpq4hP0RshhAXaEVYC2s72ot4Pt6GU0klKWdTiIxbtdFp/vK2UMh7tLER/vvZol9DKiu8k2g59IDAaLWEUjTsnpRyFVqE4D/hBCOFgYDYllol2fV3fauAXwEdK2QDtGnrRti39vwB4Xze8ne7/8bhe+fK2aXnbxdBySjB2fYUQPYB3gIeklOl6o8pbfmlHgWZFjSR0Bxr70C51GmMl8DywRe8gpcguwLuSK2nXAKN0Fem2wO6iEVLKhVLKTmiXnlqh1UeVS0oZi5ZU2uoG7QT6lfH9upWH0C4xHdAb1hqtnqTGUQmi+nFCqzC8JoRwAWZVxkyFEAFCiD66o/Mc3TIK9Yp0EkIM1e0kXgRuoF3DPgBkCCFeF0LYCSEshRBthRCdddMtAd4TQjTVLcddCPGQbtwPwBAhRHchRD1gDrf+zq1Gu37eE60Ooij+x4UQ7roj5KKjsUID038PjBNCtNElpNLbzwm4IqXMEUJ0QUtERVJ082xeqnwmkCaE8EJvh3OLbVredjG0nBKMWV8hhI9ufZ+UUpZuOVTe8kuQUsYB59Eqxou8hrYdXy1qpaRrwrrWwPQXgV5ojRBKjzuDVv+xVgjRt+g7hFZ3UVFb0BLyHGBd0VmTEKKz7gzRGu2MIAcD3xEhhLMQ4m0hREshhIUQwg2tMcN+XZFv0Q40Nui+65ZCCFugzCQnhHARWpP1z4B5Ukr9M+VeaJXrNY+5r3HVtRcGWjGVGu+Jdj02E+166rPoXXPGQCumUtOXdV00CN3OHu30dxP/VK7OpmQrpsNAx1IxrUG7nHUV7YdUtA4WaJVwZ3TTXgDe15t2LFqrnXJbMemV90X7UW8uNXwV2vX+TOAEuorlMuYxXReroVZMw9HOUjJ022AxsEpv2jloO/BraNeyA9EqPjOBI2hneHFGbNNbbZcSyzGwDgbXl5KtmMbptpV+S6YTxizfwPImAZ+XGtYFbceWplu/v9CSERj47upNV1wHofss0JqRHkNLooloFeoj+KfOJAwjKqn15vmVbjt01ht2H9rZUCb/tDhzNDCtA/CN7ruYqfuurAG89Mo0QKufikZLNtFoLfm6lPqtXdfN4wramczoUsvqTBn1KTXhJXQrodRhQojZaDvQx80di2IeurOgw2gV24m3Kq8YRwixHvhKSrnF3LFUhLoxS1EUpJQ30K7bK5VISmlsPU61pOogFEVRFIPUJSZFURTFIHUGoSiKohhUq+og3NzcpJ+fn7nDUBRFqTEOHTp0WUrpbmhcrUoQfn5+HDx40NxhKIqi1BhCiOiyxqlLTIqiKIpBKkEoiqIoBqkEoSiKohhUq+ogDMnLyyMuLo6cnJxbF1ZqNFtbW7y9vbG2tjZ3KIpSK9T6BBEXF4eTkxN+fn4IcccdoirVlJSS1NRU4uLiaNasmbnDUZRaodZfYsrJycHV1VUlh1pOCIGrq6s6U1SUSlTrEwSgkkMdof7PilK5av0lJkVRapcbBTdYe3otDWwa4FffD9/6vjjbOKsDBBOoE2cQ5paUlMRjjz1GixYt6NSpE4MGDeLs2bMIIXjzzTeLy12+fBlra2smT55cPGzVqlUEBQURGBhI+/bteeaZZ7h2TXt+TGhoKAEBAQQHBxMcHMwPP/xw07JXrFiBu7t7cZng4GBOnjxJVFQUbdu2LS63bNkyOnXqxNWrVxk3bhzNmjUrLr9w4UITbh1FuT0rT67kw4Mf8tYfb/HE1ifota4X9669l1GbRjF973Q+P/I5WyK3cCL1BJm5meYOt0ZTZxAmJqXkkUceYezYsaxdqz2MKyIigkuXLtGsWTM2b97Mu+++C8D//vc/AgMDi6fdtm0bCxYsYOvWrXh5eVFQUMA333zDpUuXaNiwIQDfffcdISHlP81x5MiRLF68uMSwqKio4vcrV65k0aJF7Nq1C2dnZwD+85//MHz48Dtef0WpTGk30lh+bDk9vHrwepfXiU6PLvEKvxTOlsgtSL2nurrautK0flOa1m+Kb33f4rMOXydfbK1szbg21Z9KECa2e/durK2tmThxYvGw9u3bExUVhb29Pa1bt+bgwYOEhISwbt06RowYQUJCAgDvvfceH374IV5eXgBYWlry9NNPV2p833//PR988AE7d+7Ezc2tUuetKJXtq+NfkZmXydSOU4t3+qXl5OcQmxFLTHoMUelRxGTEEJUWxZ64PaTmpJYo28ShyT9Jw8kXvwbaXy8nL6wtVHPpOpUg3t54gpMJ6bcueBvaeNZn1gOBZY4/fvw4nTp1KnP8Y489xtq1a/Hw8MDS0hJPT8/iBHHixAk6duxY7vLHjBmDnZ0dADt37sTV1fWmMuvWreP3338v/rxv3z4AoqOjmTx5MocPH6Zx48Ylpnn11VeLz2xWrlxJu3btyo1DUUzt0vVLrD61msHNBxPgElBmOVsrW/yd/fF39r9pXGZuJtEZ0f8kj/QYotOj2XJxCxm5GcXlLIUlXo5exUlI/9XYoTEWom5cna9TCaI6GjBgAG+99RYeHh6MHDmyzHLHjh3jiSeeICMjg/fff7+4bEUvMQG4u7vj4uLC999/z0svvVRinLrEpFQ3n0d8ToEsYFLwpArPw7GeI4GugQS6ljyok1Jy7ca1my5ZRadHc/DSQbLzs4vL2lja4OPkQ9P6TWnj2oaxgWOxsbSpcEzVWZ1KEOUd6ZtKYGCgwcrjIvXq1aNTp0589NFHnDx5kl9++aXEtOHh4fTu3Zt27dpx5MgRJk+eTHZ2dpnz++yzz1i2bBkAW7aU/xhce3t7tmzZQo8ePWjUqBFjxoy5zbVTlKpxMe0iP53/iZEBI/F28q70+QshcLZ1xtnWmeBGwSXGSSlJzkrWLlXpzjqi0qO4mHaRnTE72Ru3l0/7fIqLrUulx2VudSpBmEOfPn2YOXMmS5cuZcKECQAcPXqUtLS04jKvvPIKvXr1wsWl5BdsxowZTJs2jZ9//hlvb+1HUV5yAJg0aRKTJhl/hNWoUSO2bdtGaGgobm5u9O/f3+hpFaWqLD68mHqW9RgfNL7Kly2EwMPBAw8HDzo37lxi3Laobbz5+5uM3jyaz+77jBYNW1R5fKZUNy6kmZEQgg0bNrBjxw5atGhBYGAgM2bMKHHNPzAwkLFjx9407aBBg3jhhRcYOHAgbdq04Z577sHS0vK2d+Lr1q0r0cz1zz//LDG+WbNm/PLLLzz99NMcOHCgYiuqKCZy4vIJfo3+lSfbPImbXfVqSDHAbwDL+y8nJz+Hx7c8zp8Jf956ohqkVj2TOiQkRJZ+YNCpU6do3bq1mSJSqpr6f9c+E36dwKkrp9g6dCuO9RzNHY5BCZkJTN41mchrkczsOpMRASPMHZLRhBCHpJQGKzLVGYSiKNXW/sT97Evcx/h246ttcgDwdPTk2wHf0s2zG+/sf4f5f8+noLDA3GHdMZUgFEWplqSUfHLoExo7NGbkXWW38KsuHOs5sqjPIkbfNZqVJ1fy4u4XycrLMndYd8RkCUIIsVwIkSyEOK43bJ0Q4ojuFSWEOFLGtFFCiGO6cuoh04pSB+2I2cGJ1BM83/75GtOM1MrCihldZzCjywz2xO/hya1PknQ9ydxhVZgpzyBWAAP0B0gpR0opg6WUwcB64Mdypu+tK1t+I39FUWqd/MJ8FoYvpEWDFjzY4kFzh3PbRrcezeI+i4nLjGP05tGcSD1h7pAqxGQJQkq5B7hiaJzQul0cAawx1fIVRam5frnwC1HpUUzpOAVLC0tzh1MhPbx7sHLgSqwsrBi3dRw7oneYO6TbZq46iB7AJSnluTLGS+BXIcQhIcSE8mYkhJgghDgohDiYkpJS6YEqilK1cvJz+OzIZwS5BdHHp4+5w7kj/s7+rB68mlbOrXgp7CWWH19OTWo5aq4EMYryzx66Syk7AgOBSUKInmUVlFIulVKGSClD3N3dKzvOSvHee+8RGBhIUFAQwcHB/PXXXwDk5+czc+ZM/P39i+9ReO+994qns7S0JDg4uLir748++ojCwkKDy0hMTGTIkCHlxnHPPfdUeB1WrFhRohtyc9q0aRP//ve/zR2GYiJrT68lOSuZFzu9WCue8eBm58ZX/b+iv19/FhxawKw/Z5FXkGfusIxS5QlCCGEFDAXWlVVGShmv+5sMbAC6VE10lW/fvn1s2rSJ8PBwjh49yo4dO/Dx8QHgzTffJCEhgWPHjnHkyBH27t1LXt4/Xxw7OzuOHDnCiRMn2L59O1u3buXtt982uJyPP/6Y8ePLv8u09A1yNdXgwYPZuHEjWVk1u4WIcrP03HSWHVvGvV733nTXck1ma2XL/J7zmRA0gQ3nNzBxx0TSbqTdekIzM8cZxP3AaSllnKGRQggHIYRT0XugH3DcUNmaIDExETc3N2xstFYYbm5ueHp6kpWVxbJly1i0aBG2tlqf9E5OTsyePdvgfBo1asTSpUtZvHixwVPU9evXM2CA1ibgxIkTdOnSheDgYIKCgjh3TruS5+iotSMPCwsjNDSU4cOHc9dddzFmzJjieW7ZsoW77rqLTp068cILLxg8K0lJSWHYsGF07tyZzp0788cff9xUZsWKFTz00EOEhobi7+9fIrE9/PDDdOrUicDAQJYuXQpAQUEB48aNo23btrRr144FCxYAsHDhQtq0aUNQUBCPPfYYoN2dHhoayqZNm26x9ZWaZsXxFaTnpjO1w1Rzh1LpLIQFUzpM4f3u73M4+TCPb3mc6PRoc4dVLpP1xSSEWAOEAm5CiDhglpTyK+AxSl1eEkJ4Al9KKQcBHsAG3amlFbBaSrmtUoLaOh2SjlXKrIo1bgcDPyhzdL9+/ZgzZw6tWrXi/vvvZ+TIkfTq1Yvz58/j6+uLk5OT0Ytq3rw5BQUFJCcn4+HhUTz84sWLODs7FyehJUuWMHXqVMaMGUNubi4FBTffsHP48GFOnDiBp6cn9957L3/88QchISE8++yz7Nmzh2bNmjFq1CiDcUydOpWXXnqJ7t27ExMTQ//+/Tl16tRN5Q4cOMDx48ext7enc+fODB48mJCQEJYvX46LiwvZ2dl07tyZYcOGERUVRXx8PMePa8cCRU/N++CDD7h48SI2NjbFwwBCQkLYu3cvI0bUnDtWlfKlZKWw6tQqBvoNpLVr7b0b/oEWD+Dp6MmLu19kzJYxfBL6CSGNq2djTVO2YholpWwipbSWUnrrkgNSynFSyiWlyibokgNSykgpZXvdK1BK+Z6h+dcUjo6OHDp0iKVLl+Lu7s7IkSNZsWLFTeW+/vprgoOD8fHxITY29raWkZiYiH79S7du3Xj//feZN28e0dHRxc+L0NelSxe8vb2xsLAgODiYqKgoTp8+TfPmzWnWrBlAmQlix44dTJ48meDgYB588EHS09PJzLz50Y59+/bF1dUVOzs7hg4dWvxMioULF9K+fXvuvvtuYmNjOXfuHM2bNycyMpIpU6awbds26tevD0BQUBBjxoxh1apVWFn9czzTqFGj4udmKLXDF0e/IK8gj8kdqkddlyl18ujEd4O+w9nGmfHbx/Pz+Z/NHZJBdas313KO9E3J0tKS0NBQQkNDadeuHd988w0jRowgJiaGjIwMnJyceOqpp3jqqado27atwSN+gMjISCwtLWnUqFGJ4XZ2duTk5BR/Hj16NF27dmXz5s0MGjSIL774gj59SrYGKTrbKIovPz/f6PUpLCxk//79xZfGylK6glEIQVhYGDt27GDfvn3Y29sTGhpKTk4Ozs7ORERE8H//938sWbKE77//nuXLl7N582b27NnDxo0bee+99zh27BhWVlbk5OQYTHxKzRSbHsv6s+sZ6j8U3/q+5g6nSvjW92XVoFW8EvYKb/7xJtHp0UzuMLlaPYyo+kRSS505c6a4DgDgyJEjNG3aFHt7e/71r38xefLk4p17QUEBubm5BueTkpLCxIkTmTx58k073latWpV4xnRkZCTNmzfnhRde4KGHHuLo0aNGxRoQEEBkZGTxvNatM9yOoF+/fixatKjEOhmyfft2rly5QnZ2Nj/99BP33nsvaWlpODs7Y29vz+nTp9m/fz8Aly9fprCwkGHDhvHuu+8SHh5OYWEhsbGx9O7dm3nz5pGWllZ8pnL27Fnatm1r1Hop1d/iI4uxsrBiYvuJty5cizSwacDnfT9nmP8wlh1bxrTfppV4OJG51a0zCDPIzMxkypQpXLt2DSsrK1q2bFlcMfvee+/x1ltv0bZtW5ycnLCzs2Ps2LF4enoC2rMfgoODycvLw8rKiieeeIKXX375pmU4ODjQokULzp8/T8uWLfn+++9ZuXIl1tbWNG7cmJkzZxoVq52dHf/9738ZMGAADg4OdO5suBXJwoULmTRpEkFBQeTn59OzZ0+WLFlyU7kuXbowbNgw4uLiePzxxwkJCaFdu3YsWbKE1q1bExAQwN133w1AfHw8Tz31VHEz3rlz51JQUMDjjz9OWloaUkpeeOEFGjZsCGjP+p47d65R66VUb6evnGbLxS080+4Z3O2rZ1N1U7K2sGZWt1n41ffj40Mfk5iZyKL7FlWPrs2llLXm1alTJ1nayZMnbxpWG/3444/yjTfeuOP5ZGRkSCmlLCwslM8995z8+OOPKzSfr7/+Wk6aNOmO4zEkKSlJ9unTx+C4uvL/rk0mbp8o71l9j0y7kWbuUMxuR/QO2XlVZ9n3f33l6dTTVbJM4KAsY5+qLjHVEo888gh+fn53PJ9ly5YV35yXlpbGs88+e+fBVbKYmBg++ugjc4ehVIK/k/7m9/jf+Ve7f1G/Xn1zh2N29/nex4oBKygoLODJrU+yJ26PWeNRDwxSahX1/645pJQ8sfUJEjMT2Tx0M7ZW5Td6qEsuXb/ElF1TOHP1DK91fo0xrU33vHj1wCBFUaqdsNgwIlIieC74OZUcSvFw8GDFgBX09O7JBwc+4L3975FfaHxLw8qiEoSiKFWuoLCAhYcX4lffj4dbPmzucKole2t7Pgn9hLFtxrL2zFom75pMZu7N9xuZkkoQiqJUuU2Rmzh/7TyTO0zGykI1piyLpYUl0zpP49/d/s3+hP08sfUJ4jPjq2z5KkEoilKlcgty+ezIZ7RxbUO/pv3MHU6N8GirR/n8/s+5dP0SozePJiIlokqWqxJEFagu3X0bKywsrHheYWFhJXqBXbJkCd9++22lLMdY06ZNY9euXVW6TMV0vj/zPYnXE3mxY+3ozruqdPPsxqpBq7C3sufpbU+z7WLldFFXHnVuZ2L63X3b2Nhw+fLl4rul33zzTZKSkjh27Bi2trZkZGSUaL5Z1N03QHJyMqNHjyY9Pd1gl9/GdPddEWFhYTg6OhY/S2LixKq/03XKlCmMHz/+pu5ClJrnet51lh5dStcmXenm2c3c4dQ4zRs2Z/Xg1UzdPZVX97xKVHoUzwY9a7pEW9YNEjXxVR1vlFu/fr0cMmTITcOvX78uXVxcZHp6epnTOjg4lPh84cIF6eLiIgsLC28q26xZM5mTkyOl1G5Se+ihh+T9998vmzZtKhctWiQ/+ugjGRwcLLt27SpTU1OllFL26tVL/v3331JKKVNSUmTTpk2llFLu3r1bDh48WF68eFF6eHhIT09P2b59e7lnzx45a9Ys+Z///Oem5Y8dO1Y+++yzslOnTtLf319u3LhRSinlxYsXZffu3WWHDh1khw4d5B9//CGllDIhIUH26NFDtm/fXgYGBso9e/bI/Px8OXbsWBkYGCjbtm1b4ia9jh07ysTExDK3VRFz/7+V8n12+DPZdkVbeSzlmLlDqdFu5N+Q0/dMl21XtJXT90yXN/JvVHhelHOjXJ06g5h3YB6nr5yu1Hne5XIXr3d5vczx5ujuG+D48eMcPnyYnJwcWrZsybx58zh8+DAvvfQS3377LS+++OItl+fn58fEiRNxdHRk2rRpAOzcubPM8lFRURw4cIALFy7Qu3dvzp8/T6NGjdi+fTu2tracO3eOUaNGcfDgQVavXk3//v154403KCgoICsriyNHjhjs8hugY8eO/PHHHwwbNszo7aVUL6nZqXxz4hv6Nu1LWzfVj9adqGdZj/e7v0/T+k357MhnJGQm8Pn9n2NvbV+py1F1ECZmju6+AXr37o2TkxPu7u40aNCABx54AIB27dqV6NivMo0YMQILCwv8/f1p3rw5p0+fJi8vj/Hjx9OuXTseffRRTp48CUDnzp35+uuvmT17NseOHcPJyanMLr9Bde9dG3x57EtuFNxgSocp5g6lVhBCMLH9ROb3nE+zBs2ws6r83o3r1BlEeUf6plTV3X1Dye68LSwsij9bWFgUd+1tZWVVXOldevqKMNS994IFC/Dw8CAiIoLCwsLiLsJ79uzJnj172Lx5M+PGjePll1/mySefNNjld1F8qnvvmis+M551Z9bxcMuHadagmbnDqVUGNhvIwGYDTTJvdQZhYubo7ttYfn5+HDp0CIAffvjBYBknJycyMjKMmt///vc/CgsLuXDhApGRkQQEBJCWlkaTJk2wsLBg5cqVxckvOjoaDw8Pxo8fzzPPPEN4eLjBLr+LqO69a7b/HvkvAlHnuvOu6Uz5yNHlwBAgWUrZVjdsNjAeSBFl0lYAACAASURBVNEVmyml3GJg2gHAp4Al2qNIzfOkn0pgju6+jTVt2jRGjBjB0qVLGTx4sMEyDzzwAMOHD+fnn38u8QwIQ3x9fenSpQvp6eksWbIEW1tbnn/+eYYNG8a3335b3I04aK2j/vOf/2BtbY2joyPffvutwS6/AfLy8jh//jwhIdXzsYxK+c5dPcfGCxsZGziWxg6NzR2OchtM1lmfEKInkAl8WypBZEopPyxnOkvgLNAXiAP+BkZJKU/eapl1ubO+DRs2cOjQId59912zLH/cuHEMGTKE4cOHV/q8N2zYQHh4OO+8884ty9aV/3dNMmXXFA4lHWLrsK00sGlg7nCUUszSWZ+Ucg9wpQKTdgHOS+3Z1LnAWuChSg2uFqqs7r6ro/z8fF555RVzh6FUwJHkI4TFhvFU26dUcqiBzFFJPVkI8SRwEHhFSnm11HgvQL8ZTxzQtaqCq8meeeYZsy3bUMusyvLoo4+abN6K6UgpWXBoAa62ribtrloxnaqupP4caAEEA4nAHT/1RQgxQQhxUAhxMCUlxWAZU11GU6oX9X+uXvbG7yU8OZyJ7SdWevt8pWpUaYKQUl6SUhZIKQuBZWiXk0qLB3z0PnvrhpU1z6VSyhApZUjpewEAbG1tSU1NVTuPWk5KSWpqanEzWsW8CmUhn4Z/io+TD8NaqZsba6oqvcQkhGgipUzUfXwEOG6g2N+AvxCiGVpieAwYXdFlent7ExcXR1lnF0rtYWtri7e3t7nDUICtF7dy9upZ5vWYh7WFtbnDUSrIlM1c1wChgJsQIg6YBYQKIYIBCUQBz+rKeqI1Zx0kpcwXQkwG/g+tmetyKeWJisZhbW1Ns2bqxhxFqSp5BXksPryYAOcABjQbYO5wlDtgsgQhpRxlYPBXZZRNAAbpfd4C3HR/hKIo1d8P534gLjOO/973XyyEuhe3JlP/PUVRKk1WXhZfRHxBiEcI3b26mzsc5Q6pBKEoSqVZdWoVqTmpTO04VT0MqBZQCUJRlEpxLecaXx//mt4+vQluFGzucJRKoBKEoiiV4qvjX5GVn8ULHV4wdyhKJVEJQlGUO5Z0PYnVp1bzQPMHaOlsfIeRSvWmEoSiKHfs84jPkUieD37e3KEolUglCEVR7khkWiQ/nf+JkQEj8XT0NHc4SiVSCUJRlDuy+PBibC1tGR803tyhKJVMJQhFUSrsWMoxtkdvZ1zgOFxsXcwdjlLJVIJQFKVCpJR8Ev4JLrYuPBn4pLnDUUxAJQhFUSpkX+I+DiQdYELQBBysHcwdjmICKkEoinLbirrz9nTw5NFW6oFOtZVKEIqi3Lbt0ds5mXqSSR0mUc+ynrnDUUxEJQhFUW5LXmEeiw4vomXDlgxuNtjc4SgmpBKEoii35afzPxGdHs3UjlOxtLA0dziKCakEoSiK0bLzs1lyZAnB7sH08u5l7nAUE1MJQlEUo605vYbk7GRe7PSi6s67DlAJQlEUo5xKPcWXR7+kp3dPOnl0Mnc4ShUwWYIQQiwXQiQLIY7rDfuPEOK0EOKoEGKDEKJhGdNGCSGOCSGOCCEOmipGRVGMsy9hH0/931M41nNkeufp5g5HqSKmPINYAZR+Yvl2oK2UMgg4C8woZ/reUspgKWWIieJTFMUIWy9u5fmdz9PEoQkrB67Ep76PuUNSqsgtE4QQYqoQor7QfCWECBdC9LvVdFLKPcCVUsN+lVLm6z7uB7wrFLWiKFVi5cmVvLbnNdq7t+ebgd/g4eBh7pCUKmTMGcTTUsp0oB/gDDwBfFAJy34a2FrGOAn8KoQ4JISYUN5MhBAThBAHhRAHU1JSKiEsRVGklHx86GPm/z2f+33v54u+X1C/Xn1zh6VUMSsjyhQ1VRgErJRSnhB32HxBCPEGkA98V0aR7lLKeCFEI2C7EOK07ozkJlLKpcBSgJCQEHkncSmKot0IN/vP2fxy4RdGtBrBzK4z1f0OdZQxCeKQEOJXoBkwQwjhBBRWdIFCiHHAEOA+KaXBHbqUMl73N1kIsQHoAhhMEIqiVJ6svCxe/u1l/oj/g0nBk3g26FnVnLUOMyZB/AsIBiKllFlCCFfgqYosTAgxAHgN6CWlzCqjjANgIaXM0L3vB8ypyPIURTHelZwrTNoxiZNXTjKr2yyGtxpu7pAUM7tlgpBSFgLhep9TgdRbTSeEWAOEAm5CiDhgFlqrJRu0y0YA+6WUE4UQnsCXUspBgAewQTfeClgtpdx2m+ulKMptiMuIY+KOiSRdT2JB6AL6+PYxd0hKNWDMGUSFSClHGRj8VRllE9DqOJBSRgLtTRWXoiglnblyhok7JpJbkMuyfsvo0KiDuUNSqgl1J7Wi1GEHEg8wbts4LIUl3wz4RiUHpQSjEoQQwlII4SmE8C16mTowRVFMa1vUNibumIiHvQerBq2ipXNLc4ekVEBBoSQ69bpJ5n3LS0xCiClo9QeX+Kf1kgSCTBKRoigm992p75h3YB4dGnVgYZ+FNLBpYO6QlNtQWCgJj7nKpqOJbDqaiJWF4M/pfbCwqNwWZ8bUQUwFAnSV04qi1GBSShYeXsiXx76kt09v5vecj62VrbnDUowgpeR4fDobjyawKSKBhLQc6llZ0CegEQ+096RQSiyo+gQRC6RV6lIVRalyeYV5vP3n2/x84WeGtxrOG13fwMrCZO1UlEpy9lIGGyMS2BiRQFRqFlYWgp6t3JnWP4C+bTxwsrU22bKN+XZEAmFCiM3AjaKBUsqPTRaVoiiVKisvi2m/TWNv/F6ea/8cz7V/Tt0AV41FXb7OpqMJbIxI5MylDCwEdGvhysReLegf2Bhnh6p5DrgxCSJG96qneymKUoNczbnK5J2TOZ56nLfufosRASPMHZJiQPy1bDbrksKxeO2iTUhTZ95+MJCB7RrTyKnqLwUac6Pc21URiKIolS8hM4Fntz9LQmYCH/f6mPua3mfukBQ9yRk5bD2WxMaIBA5GXwUgyLsBbwxqzeCgJng2tDNrfGUmCCHEJ1LKF4UQG9FaLZUgpXzQpJEpinJHzlw5w3M7niOnIIel/Zaqp8BVE9eyctl2PImNRxPYdyGVQgkBHk5M69eKIUGe+Lk5mDvEYuWdQazU/f2wKgJRFKXy/J30N1N3TcXO2o5vBnyDv7O/uUOq0zJy8th+8hIbIxLYe+4y+YUSP1d7JvduyZD2nrTycDJ3iAaVmSCklId0f3+runAURblTv0b9yvS90/F28uaL+7+giWMTc4dUJ2XnFrDrdDIbIxLYdSaZ3PxCPBvY8q/uzXigvSeBnvWrfUMB1cZNUWqRtafX8v5f7xPkHsTiPotpaGvwse+KidzIL2Dv2ctsPJrA9pOXyMotwM3RhtFdfHmgfRM6+DhX+s1spqQShKLUAlJKFh1exLJjywj1DmV+r/nYWZm3grOuyC8o5M8LqWyMSGDbiSQycvJpaG/NQ8FePNC+CV2buWJZg5KCPqMThBDCvqxnOCiKYj75hfm8s/8dfjz3I0P9h/LW3W+pG+BMTEpJRFwaPxyKZeuxJFKv5+JoY0W/QA8eaO9J95ZuWFvW/L5QjemL6R7gS8AR8BVCtAeelVI+b+rgFEUpX3Z+Nq/99hphcWFMCJrA5ODJ1f66dk2WeSOfnw7Hs/qvGE4mpmNrbcF9rT14IMiT0AB3bK1r16NZjTnMWAD0B34BkFJGCCF6mjQqRVFu6VrONSbvmszRlKO80fUNHrvrMXOHVGsdi0tj9YFofj6SQFZuAa2b1Oedh9vycLCnSbu6MDejzkOllLGljkoKTBOOoijGSMxMZOKOicRmxPJR6Ef0bdrX3CHVOtdv5PNLRAKr/4rhWHwattYWPBDkyeiuvgT7NKwTZ2pGddanu8wkhRDWaL27njJm5kKI5cAQIFlK2VY3zAVYB/gBUcAIKeVVA9OOBd7UfXxXSvmNMctUlNru3NVzTNwxkay8LL7o+wWdG3c2d0i1yomENFb/FcPPRxLIvJFPgIcTbz8YyMMdvGhgV3vPFgwxJkFMBD4FvIB44FdgkpHzXwEsBr7VGzYd2Cml/EAIMV33+XX9iXRJZBYQgnYX9yEhxC+GEomi1CWHLh1iyq4p2FrasmLACgJcAswdUq2QlZvPpohEvjsQQ0TsNWysLBgc1IQxXX3p6OtcJ84WDDGmL6bLwJiKzFxKuUcI4Vdq8ENAqO79N0AYpRIEWp3HdinlFQAhxHZgALCmInEoSm2wM3onr+15DU9HT77o+wWejp7mDqnGO5WYzpoDMWwIjyfjRj4tGzny7yFtGNbRmwb2detswRBjWjE1A6agXRIqLn8HfTF5SCkTde+TAA8DZbzQnkNRJE43zFB8E4AJAL6+6kmoSu2TkpXCT+d/YvGRxbR1bcvi+xbjbOts7rBqrOzcAjYdTWD1gRgOx1yjnpUFg9o2ZnTXpnT2q7tnC4YYc4npJ+ArYCP/PHK0UkgppRDipo4Ab3MeS4GlACEhIXc0L0WpDqSURKZFsjt2N7tidnHs8jEAenn3Yn7P+dhb25s5wprp7KUMVv8Vw4/hcaTn5NPc3YE3B7dmWEfvKnu+Qk1jTILIkVIurMRlXhJCNJFSJgohmgDJBsrE889lKABvtEtRilIrFRQWEJESwa6YXeyO3U1MRgwAga6BTA6eTB/fPrRs2FId3d6mnLwCthxLZPVfMRyMvko9SwsGtG3M6K6+dG3morbnLRiTID4VQsxCq5zWf6JceAWX+QswFvhA9/dnA2X+D3hfCFF0Ht0PmFHB5SlKtZSdn82+hH3sjt3Nnrg9XMm5gpWFFV0bd+XJNk8S6hOKh4OhK7DKrZxPzmT1XzGsD48jLTuPZm4OzBx0F8M6euPqaGPu8GoMYxJEO+AJoA//XGKSus/lEkKsQTsTcBNCxKG1TPoA+F4I8S8gGhihKxsCTJRSPiOlvCKEeAf4WzerOUUV1opSk13JucJvsb+xO3Y3+xL2kVOQg5O1E929u9PHpw/3et2LU73q2fVzdXcjv4Btx5P47q8YDly8grWloF9gY8Z08aVbC1d1tlABQsryL9sLIc4DbaSUuVUTUsWFhITIgwcPmjsMRSkhJj2muD7hSMoRCmUhHvYe9PbpTW/f3nT26Iy1pWoxU1GRKZmsORDDD4fiuJqVh6+LPaO6+PJoiDdu6mzhloQQh6SUIYbGGXMGcRxoiOG6AkVRSimUhZy4fIJdsbvYHbObC2kXAGjl3IoJQRPo7dOb1i6t1RHtHcjNL+T/TiSx+q8Y9kWmYmUh6NvGg9Fdfbm3hVuN6lK7OjMmQTQETgsh/qZkHYR65Kii6OQW5PJX4l/sjt1NWGwYKdkpWApLOnl0Ynir4YT6hOLt5G3uMGu0K9dz2Xsuhd/OphB2JoUr13Pxdrbj1f4BPBriTSMnW3OHWOsYkyBmmTwKRamB0m6ksTd+L7tjdvN7/O9k5WdhZ2VHd6/u9PbpTU/vnjSwaWDuMGus/IJCIuKu8dvZy/x2NoWjcdeQEhraW9PT352hHb3o6e+uzhZMyJg7qdUjRxVFJzEzUbt0FLubQ0mHyJf5uNq6Mqj5IHr79KZrk67YWKrr3hWVlJbDnrPaWcLecymk5+RjISDYpyEv3teKXgHutPNqUGMfwFPTlJkghBC/Sym7CyEy0FotFY9Cu8etvsmjUxQzk1Jy5uoZdsfsZlfsLk5fOQ1A8wbNGRs4lt6+vWnn1g4LUfMfDmMON/ILOBR1ld90SeF0UgYAHvVt6B/YmF4B7nRv6UZDe3UjmzmUmSCklN11f1WbO6VOikmPYebvM4lIiUAgCG4UzMudXqa3T2/8GviZO7waKzr1upYQzqSwLzKVrNwCrC0Fnf1cmDHwLnoFuBPg4aQq8asBY/piWimlfOJWwxSltpBSsv7ceub/PR8rCyve6PoGfZv2xdXO1dyh1UhZufnsj0zltzPaWUJUqvbkYh8XO4Z19KZXK3e6tXDFwUY9JrW6MeY/Eqj/QQhhBXQyTTiKYl6p2anM3jebsNgwujbuyrvd36WxQ2Nzh1WjSCk5eymT384m89vZFP6+eJXcgkJsrS24p4UbT93bjJ6t3PFztVdnCdVceXUQM4CZgJ0QIr1oMJCLrnM8RalNwmLDmPXnLDJzM3mt82uMaT1G1S0YKS07jz/OXy4+S0hKzwGglYcjY+9pSq9WjQjxc651z2yu7cqrg5gLzBVCzJVSqn6QlForKy+L+X/PZ/259QQ4B/Blvy/xd/Y3d1jVWmGh5HhCWnFCOBx7jYJCiZOtFT383ejp707PVu54NrQzd6jKHTCmmatKDkqtFZESwcy9M4nNiOXptk8zKXgS9SxVixlDrt/IZ/vJS+w+k8zec5e5cl3rfSfIuwHPh7agVyt3gn0aYmWpzrpqC1UrpNRJeYV5LD26lGVHl+Fh78Hy/ssJaWywO5o6rbBQsi8ylfXhcWw7nkRWbgGuDvXo1cqdXq3c6e7vpvo7qsVUglDqnItpF5m5dybHU4/zYIsHmd5luupBtZTzyZn8GB7HT4fjSUjLwcnGioeCPXmkgzchTZ3V3ct1hFEJQghhifZoUP1HjsaYKihFMQUpJd+f+Z4PD36IjZUNH/X6iH5+/cwdVrVx9XouG48msD48nojYa1gI6NnKnRmDWtO3jYeqYK6DjLkPYgpaf0yXKPk8iCATxqUolepy9mXe+uMtfo//nXs972XOvXNoZN/I3GGZXW5+IbvPJPNjeBy7TieTVyC5q7ETbw5uzYPBnqoDvDrOmDOIqUCAlDLV1MEoiinsjN7J7H2zyc7PZkaXGYy6a1Sdbn8vpeRoXBo/hsfxS0QCV7PycHO0YWw3P4Z29KaNp+pFR9EYkyBigTRTB6Iole163nU+OPABP53/iTaubZjbYy7NGzQ3d1hmk5iWzYbD8fwYHs/55EzqWVnQt40Hwzt608PfTbU+Um5iTIKIBMKEEJsp+TyIjyuyQCFEALBOb1Bz4N9Syk/0yoSiPav6om7Qj1LKORVZnlI3HU4+zIy9M0i8nsj4duN5rv1zdfKpbVm5+Ww7nsSP4fH8ceEyUkJIU2fmDm3HoHZNaGBX97aJYjxjEkSM7lVP97ojUsozQDAUV37HAxsMFN0rpRxyp8tT6pa8gjw+j/icr45/haeDJysGrKBDow7mDqtKFRZK9kemsj48nq3HE8nKLcDHxY4X+vgztKMXTV0dzB2iUkMYc6Pc2yZc/n3ABSlltAmXodQRkdcimb53OqeunOKRlo/wepfXcbCuOzvDCyla09QN4VrTVEcbKx4I8mRYJ9U0VamY8vpi+kRK+aIQYiMlnwcBVNojRx8D1pQxrpsQIgJIAKZJKU+UEecEYAKAr69vJYSk1DSFspA1p9ew4NAC7K3s+aT3J9zne5+5w6oS17Jy2RihNU09omua2sPfnemDWtO3tQd29VTTVKXihJQ37fu1EUJ0klIeEkL0MjT+Tp80J4Soh7bzD5RSXio1rj5QKKXMFEIMAj6VUt6yc5yQkBB58ODBOwlLqWGSs5J564+3+DPhT3p49WDOvXNws3Mzd1gmlZtfSNiZZH4Mj2fn6UvkFUgCPJwY1smLh4O9aFRfNU1VjCeEOCSlNNiNQHmd9R3S/TXVI0cHAuGlk4Numel677cIIf4rhHCTUl42USxKDfRr1K/M2T+H3IJc3rr7LR5t9Witbb4qpeR4fDrrdU1Tr1zPxc2xHk/c7cewTl60aVK/1q67Yj7G3CjnD8wF2gDFhyZSyjttLziKMi4vCSEaA5eklFII0QWwANR9GAoAGbkZzP1rLhsjN9LOrR3vd3+/VjzhTUrJleu5xFzJIuZKFrG6vzFXsoi6nEVSeg71LLWmqcM6edHD3x1r1TRVMSFjWjF9jXYn9QKgN/AU2g67woQQDkBf4Fm9YRMBpJRLgOHAc0KIfCAbeEyWdS1MqVMOJh1k5u8zSc5K5rn2zzE+aDzWFjWnqWZOXgFxV7NL7Pz1k0FWbkGJ8u5ONvi62HN3cxc6N3NhSDtPGtjXnPVVarYy6yCKC2jXpzoJIY5JKdvpD6uSCG+DqoOovXILcll8eDErTqzAx8mHuT3mEuRe/Xp7kVKSknGjxM6/KAHEXskufpBOEVtrC3xd7PF1scdH97fo5e1sryqZFZOrUB2EnhtCCAvgnBBiMtp9C46VGaCilOfc1XPM2DuDM1fP8GirR5kWMg17a3uzxZOVm0/slexSO3/d+6tZ5OQVFpcVAhrXt8XHxZ7u/m56ycAOHxd73B1tVN2BUm0Z2xeTPfAC8A7aZaaxpgxKUUBrvrrq5Co+Df8Ux3qOLO6zmF4+BhvVVbrs3AIupGRy9lIGUZev650NZHM580aJsg71LPF1daC5uwOhAe746J0NeDW0U72gKjVWuQlCd6fzSCnlNCATrf5BUUwuJj2GOfvm8FfSX4T6hDK722xc7VwrfTk5eQWcT87kXHIGZy9lcu5SBueSM4m5kkXR1VcLAZ4N7fBxtue+uxrh61rycpCzvbU6C1BqpfJulLOSUuYLIbpXZUBK3XYq9RTLjy/n1+hfsbG0YXa32Qz1H3rHO+CbE4H2Xj8RWFkImrs70NazAY908KKVhxP+jRxp6upAPSvVWkipe8o7gzgAdAQOCyF+Af4HXC8aKaX80cSxKXWElJKDlw7y1fGv+CP+DxytHXkq8Ckeb/P4bd/0VpQIzidrl4fOlpEImrn9kwj8GznRysMRPzcH1WxUUfQYUwdhi3YPQh+0LjeE7q9KEModKZSF/Bb7G18d/4qIlAhcbF2Y2nEqIwNG3vIRoDl5Wh3BuUtaIjiXrF0eirmSRWGpRBDoWZ+Hg7UzglYe6oxAUYxVXoJoJIR4GTjOP4mhiLonQamwvMI8tl3cxvLjyzl/7Txejl682fVNHmr5ELZWJbuJKEoEJc4IDCQCPzcH2njW5yFdIvD3cMRPJQJFuSPlJQhLtOashi7+qgSh3Lbs/Gw2nNvANye+IeF6Av7O/nzQ4wP6+/XHyuKfr2JOXgHL9kTy4+F4olOvG0wEDwZ70crDkVYeTioRKIqJlJcgEtVDepTKkHYjjXVn1vHdqe+4knOFDo068Mbdb9DDq0eJymcpJRuPJvLBllMkpOXQw9+NB9p70srDEf9GTjRzU4lAUapSeQlCtdtT7khKVgorT67k+7Pfcz3vOj29e/Kvtv+io0fHm8pGxF5jzqaTHIq+SqBnfRaMDKZr88pv1qooivHKSxB1o0N9pdLFpMfw9Ymv+fn8zxTIAgb4DeDptk8T4BJwU9mktBzm/99pfgyPx83RhvnDghjWyRtL9XAbRTG78rr7vlKVgSg1n/49DFbCiqH+QxkbOBYfJ5+bymbnFrBsbySfh12goFDyXGgLJvVuiaONMQ3rFEWpCurXqNyR272HQUrJLxEJzNt6moS0HAa1a8yMga3xcTFf30qKohimEoRSIRW5h+FI7DXmbDxBeMw1Vc+gKDWAShDKbbmdexiKJKXlMH/baX48rOoZFKUmUQlCMYqx9zCUmEbVMyhKjaZ+qUq50m6ksfb0Wr479R1Xb1wt8x4GfaqeQVFqB7MlCCFEFJABFAD5pZ9oJLS9z6fAICALGCelDK/qOOuq5Kxk7R6GM9+TlZ9V7j0M+lQ9g6LUHuY+g+gtpbxcxriBgL/u1RX4XPdXMaHL2Zf57MhnRt3DoE+/nsHdyYb5w4MY1lHVMyhKTWbuBFGeh4BvpfbQ7P1CiIZCiCZSykRzB1Zb/ZnwJzP3ziQ9N73cexj0ZecWsHRPJEt+u0CBlDwf2oLnVT2DotQK5vwVS+BXIYQEvpBSLi013guI1fscpxtWIkEIISYAEwB8fX1NF20tlleYx6LDi/j6+Ne0aNCCZf2W4e/sX+40qp5BUWo/cyaI7lLKeCFEI2C7EOK0lHLP7c5El1iWAoSEhKheZm9TbEYsr+95nWOXjzG81XBe6/wadlZ25U6j6hkUpW4wW4KQUsbr/iYLITYAXQD9BBEP6F/f8NYNUyrJ1otbmbNvDgLBh70+pL9f/3LLq3oGRalbzJIghBAOgIWUMkP3vh9QumvxX4DJQoi1aJXTaar+oXJk5WXxwYEP2HB+A8HuwczrOQ9PR88yy6t6BkWpm8z1C/cANuja0VsBq6WU24QQEwGklEuALWhNXM+jNXN9ykyx1iqnr5zm1d9eJTo9mvHtxvN88PNl3uim6hkUpW4zS4KQUkYC7Q0MX6L3XgKTqjKu2kxKyerTq/no4Ec0tGnIsn7L6Nqk7FbDh2OuMmfTSQ7HXKOtl6pnUJS6SF0jqAOu5VzjrT/fIiw2jJ7ePXnn3ndwsXUxWPbspQw+D7vABr16huEdvbFQ9QyKUueoBFHL/Z30N9P3TudqzlVe7/w6Y1qPuamLjOzcAjYfS2TNgRgORV+lnpWFqmdQFEUliNoqvzCfL45+wdKjS/Fx8mHRoEW0cW1TosypxHTWHojhx8PxZOTk09zNgTcGtWZoRy9cHW3MFLmiKNWFShC1UGJmItP3Tic8OZwHWzzIG13fwN5aq1jOys1nU0Qiqw/EcCT2GvWsLBjUtjGjuvjSpZlLmR3wKYpS96gEUcvsjN7Jv//8N/mF+cztMZchzYcAcCIhjTUHYvjpcAKZN/Jp2ciRt4a0YWgHL5wd6pk5akVRqiOVIGqJnPwcPjz4IevOrCPQNZD5PefjYuPJmgMxrDkQw9G4NGysLBjcrgmjuvoS0tRZnS0oilIulSBqgQvXLvDqnlc5d/Uc4wLH0afRWD7fkcgvR05yPbeAAA8nZj/Qhkc6eNPA3trc4SqKUkOoBFGDSSlZf2498w7Mw87KnhHeb7N7nzuL4v/C1tqCIUGejOriS0ffhupsQVGU26YSRA2VnpvO23++za/Rv+Jm0ZZLZx7hqyM23NVY8s5DgTwY7EUDO3W2oChKxakEUQP9GXeQV397nfS8y9xIHkhSRigPeeayWgAAFBdJREFUtvdmVFdf2ns3UGcLiqJUCpUgaggpJQejU5n75385m7semdeQJrmv8FSvXjzY3hMnW3W2oChK5VIJoppLy8pjw+E4Vv19jPh6y7FyuICXdTfmhM6iq5+XucNTFKUWUwmiGpJScij6KqsPxLD5aCL5Nidx9P4BO8s8Xu08i8fuGqYuIymKYnIqQVSSvIJCrC0t7mge17Jy+TE8njUHYjiXnImjDbQO/I0LuVvxdw5gfq/5NG/QvJIiVhRFKZ9KEJUgKS2HwQv38mQ3P6beX/6znItIKdlyLIlNRxNIuJZNQloOlzNvICUE+zTk9SEu7LyygDNXTzH6rtG8HPIyNpaqfyRFUaqOShCV4POw86Rez+WTnWfp3MyZe1q4lVv+dFI6s385wf7IK3g1tKO5uwN3Na6Pl7Md97f24Hx2GO/uf5d6lvVY2HshvX17V9GaKIqi/EMliDuUlJbDmgOxPBTsybH4NF5ad4StU3viYqB/o3OXMvj6zyjWHoihvp017z7cllFdfIuf6Xw97zrv7n+XTZGbCPEIYW6PuTR2aFzVq6QoigKoBFHCyn1RtPdpSJB3Q6On+W/YeQqlZFq/ANJz8njksz959X8RfDk2BCEE6Tl57Dmbwqr90eyPvEI9SwvGdG3KK/1a0dD+nyRyPe86j216jJiMGCYFT2J8u/FYWliaYC0VRVGMU+UJQgjhA3yL9lxqCSyVUn5aqkwo8DNwUTfoRynlHFPFlJp5g7yC/2/v3KOzqq4E/tt5vyA8ohgNLxUFRkaFqIBaGLUi1lU7VguOFGZ0xqmtU3XEV1stdjlrgaVWW+qD0apoq06VZRmWoxXFB4aXL5CHaFRAIAJBCeT92vPHOUluPu8XEpJ8X8y3f2vddc/r3nPuycne391n33OU2/+6EYCtc7/TrutKyqp4es3nXFY4uHmf5p9dOJI5/7uJKx9bS0lZNVt2H0QVCvpncssFI/lBYUHoXgtFu4rYemAr906+l3OHntt1D2cYhnGYxOMNoh64UVXfFZE+wDsi8rKqbooo96aqXhSLBo27a9lhXXf/8k9QlJ/8w3HNabMmDmPN1i9546NSTh3Sj6kn5XPa8P6cMXxgsykpjKJdReSk5jBp8KTDaothGEZXE3MFoaolQIkPHxSRzcAxQKSC6DGoKqs/+5InVm1jf2UtBf2yyO+XwTNr3dtDQf+s5rIiwv1XjENV2/2tgqpStLOIM/LPICXJrH6GYfQM4iqNRGQYcCqwOiR7goisA3YBs1V1Y5R7XA1cDTBkyJAubV9peQ3LNu3m8ZXb2FxygP5ZqQwdmM0rH+6htLyGzNRkfjz5uNBrO/Ih2/aD29lVsYsrT7qyq5puGIbRaeKmIEQkB3gOuF5VD0RkvwsMVdVyEbkQeB4I/cBAVRcCCwEKCwu1K9p219JNrCgu5cMvDgJw4qA+zL1kDN879RgyUt3EcVVtA7UNjV2yYmrRriIAJh49sdP3MgzD6CrioiBEJBWnHP6kqosj84MKQ1VfEJH7RSRPVUtj0b6HV3zGxOMGctOUEznr+Dz+PmSF1My0ZDLpGi+jol1FFOQUMLjv4C65n2EYRlcQDy8mAR4BNqvqPVHKHAXsVlUVkdOBJGBfLNp31VnDmX3+iWSmxcbFtK6xjjUla5r3jjYMw+gpxOMN4kzgh8AHIvK+T/sZMARAVR8ELgWuEZF6oAqYrqpdYj46FGePyIuZcgBYv3c9lfWVZl4yDKPHEQ8vphVAmzO4qroAWBCbFrWmaY4hVhTtKiJZkjkt/7SY1msYhnEoOrf8aC9jyt8NYlR+35jWuXLXSsbkjaFvWmzrNQzDOBTmdA88cMVY8vtlcsrg9i+x0RWU1ZSxoXQD15x8TUzrNQzDaA+mIICpY/LjUu+qklUoyoSjJ8SlfsMwjLYwE1M38+n+T5n9+mx2le9qld7Q2MCijYsYkDGAk/JOilPrDMMwomNvEN1IdX01N75+I8X7iympKOGxCx4jNcl9WPfk5idZX7qeeWfPs+U1DMPokdgbRDfym7d/Q/H+Yi4feTnr967n9+/+HoDtB7az4L0FTC6YzNThU+PcSsMwjHDsp2s3sXz7cp7e8jQzR8/kptNuoqGxgUc3Psq4QeN4fNPjpCSl8Ivxv+jQmk2GYfQyGuqhrhLqqgLnYLiijbxKqPXhtCz4/sNd3jxTEN3A7ord3FF0B6MGjOK6sdcBcPPpN7Nu7zquf+166hvrmTNhDoOyB8W5pYZhtIkq1NdAbTnUHPTn8kA8UoBHCvLK6MK9rgoaajvepuQ0SM3yR6Y79+keWWIKoouob6xnTckaXtz6Isu2L6O+sZ5535pHWrLbNS49OZ35k+Yzbek0CgcVcsmIS+LcYsPopTTUOwH+NWEeJV5zEGoPBvIiyjTWt7/ulMwWoZ0WEODpfSBnkI9nQmp2S15qZkQ44trgOSUTkmMntk1BdAGlVaXMeGEGO8t3kp2azTmDz2H6yOkMzx3eqtyw3GEs/cel5KZ/ffE/wzACNDZA5ZdQWQoVpYHzPneu+tIJ8Jryrwv3+qr21SHJkJ4DaX38OccJ8j5HRaRFlgnGs1uEfUoGJPWuaV1TEJ1EVblz5Z3srdzL/EnzmTx4MunJX99StIkjso6IYesMo4dQXxsh7Pe1FvqRaVVf4XYkDiGjH2QNdMI8vQ/0LWinMI+Ip2SA/VBrE1MQnWTJJ0t47fPXmF04mynDpsS7OYYRG2orIoT9vrYVQE3kli8eSYLMAZCdB1l5cOQod26KZw9sHc8aAMmd34PFaB+mIDrBFxVfMHfNXMYeOZYZo2bEuzmGEZ3GRu/1Uu6Ee9MEa3CyNTSvvMWeX1vh4pX7optxklJbC/d+Q6ML++w89zbQy8wyvQlTEIeJqnL7W7fToA3cdeZdJCfFdhVYowtQdV4krTxRmlwHfVptJTTWAeLNEcFzUouJImpexHWSFJFGG3kR96qvbhHStQcD4YqIeHCyNSD4o5lsIknJcOaYtGxnwknLdoK87zEuntm/tZBv+mWfnQfpfc1s04swBXEY1DXU8eu3f82qklXcPv522wmuu2hyMQy6CtZWRAjyToa1Id5P2XnScgIC3dvYc46CgT4tOKGaFrTFB8PZLfcwE47hMQXRQXYc3MFNr9/Ehn0bmDFqBpedcFm8mxRbmoR2fVXAt7vK/bptDkemV0KdP9dXR4R9XvM1wbyqjgvwpFTvIpgVcBfMcsKv2c0wy3ufRIb9OS0rEM6GpBRA3bM3nwnEGyPy/FkbQ65T90M+al6Ue6GQnB74Vd/kQZNlJhqj2zAF0QZlNWUs/3w5FXUVNGojFXUVLNq4CIDfTv4t5w09L84tPASNjc5U0uQO2OzvHRYPppVHCPsIod1eU0UkqVnOfJGaBakZAZ/xDMjIDfiDe3/v1IyAAI8Q+NHC9uvXMLqMuCgIEbkAuA9IBh5W1bkR+enAImAcbi/qaaq6NVbt23FwB09ufpLFHy+mKmIybkzeGO7+1t0U9CnonspVW08eBo/ItDbj3g7dHmGelNriMhj8dZqdFyGsMwNCPTOKsA/mBYR9SrrZpg3jG0bMFYSIJAN/AL4N7ADWisgSVd0UKHYV8JWqHi8i04F5wLTubFdpVSnLti3jzZ1vsmLnCpJIYuqwKVwx4vvkZw0iOSmZZJLIJgmpLoP9a53rXkOtO+proaHG/cqur3Huffu3wVfboHwPZPR1vttZA135po+Aqg+4LzW1wa/LUuHND4cgKcXbj/t6wZ7jJg9zB7cW9k0CPzTe1/uDR/9uwzCMxCUebxCnA8Wq+imAiDwNXAwEFcTFwBwffhZYICKiqodp24hOY0MdMxedwbqkOgAGNCpXVdQwrayMQZ8+AK8+cHg3TkqB3ALn5jd0gvtVX7kPStY5gZw10Pl8p/d1ZpGkFC/0AzbmJgHeSrD3tY98DMOICfFQEMcAnwfiO4AzopVR1XoRKQMGAqWRNxORq4GrAYYMGdLhxlRV7ePI2mq+l5zO9H4nMTo1Fzkqp8VMkpIOQRfWlAz3Sz0j1wntlHS3eFZSqje1+GvSclpfZxiG8Q3jGz9JraoLgYUAhYWFHX7DyM45inv+fdOhCxqGYSQY8fCP2wkEPxwo8GmhZUQkBcjFTVYbhmEYMSIeCmItMEJEhotIGjAdWBJRZgkwy4cvBV7tjvkHwzAMIzoxNzH5OYVrgZdwbq5/VNWNIvIr4G1VXQI8AjwhIsXAlzglYhiGYcSQuMxBqOoLwAsRaXcEwtVAgn2ibBiG0bOwb/QNwzCMUExBGIZhGKGYgjAMwzBCMQVhGIZhhCK9yXtURPYC2w7z8jxCvtROUKwvWmP90RrrjxZ6Q18MVdUjwjJ6lYLoDCLytqoWxrsdPQHri9ZYf7TG+qOF3t4XZmIyDMMwQjEFYRiGYYRiCqKFhfFuQA/C+qI11h+tsf5ooVf3hc1BGIZhGKHYG4RhGIYRiikIwzAMI5SEVxAicoGIbBGRYhG5Nd7t6QwiMlhElovIJhHZKCLX+fQBIvKyiHzsz/19uojI7/yzrxeRsYF7zfLlPxaRWYH0cSLygb/mdyJu39NodfQERCRZRN4TkaU+PlxEVvtneMYvO4+IpPt4sc8fFrjHbT59i4hMCaSHjp9odcQbEeknIs+KyIcisllEJiTq+BCRG/z/yQYReUpEMhJ5bISiqgl74JYb/wQ4FkgD1gGj492uTjxPPjDWh/sAHwGjgbuBW336rcA8H74Q+D9AgPHAap8+APjUn/v7cH+ft8aXFX/tVJ8eWkdPOID/BP4MLPXx/wGm+/CDwDU+/GPgQR+eDjzjw6P92EgHhvsxk9zW+IlWR7wP4HHgX304DeiXiOMDt63xZ0Bm4O/1z4k8NkL7Kd4NiPMgmQC8FIjfBtwW73Z14fP9Ffg2sAXI92n5wBYffgi4PFB+i8+/HHgokP6QT8sHPgykN5eLVke8D9yOha8A5wBLveAqBVIixwBuj5IJPpziy0nkuGgqF238tFVHnPsi1wtFiUhPuPFBy773A/zfeikwJVHHRrQj0U1MTYOkiR0+7RuPfwU+FVgNDFLVEp/1BTDIh6M9f1vpO0LSaaOOeHMvcDPQ6OMDgf2qWu/jwWdofm6fX+bLd7Sf2qojngwH9gKPepPbwyKSTQKOD1XdCcwHtgMluL/1OyTu2Agl0RVEr0REcoDngOtV9UAwT93Plm71bY5FHe1BRC4C9qjqO/FuSw8hBRgLPKCqpwIVOHNPM4kyPvwcyMU4pXk0kA1cEM829UQSXUHsBAYH4gU+7RuLiKTilMOfVHWxT94tIvk+Px/Y49OjPX9b6QUh6W3VEU/OBL4rIluBp3FmpvuAfiLStJti8Bman9vn5wL76Hg/7WujjniyA9ihqqt9/FmcwkjE8XEe8Jmq7lXVOmAxbrwk6tgIJdEVxFpghPcqSMNNPi2Jc5sOG+8x8giwWVXvCWQtAZo8TWbh5iaa0md6b5XxQJk3A7wEnC8i/f0vrfNxdtIS4ICIjPd1zYy4V1gdcUNVb1PVAlUdhvvbvqqqVwDLgUt9scj+aHqGS3159enTvSfLcGAEbjI2dPz4a6LVETdU9QvgcxE50SedC2wiMcfHdmC8iGT5tjb1RUKOjajEexIk3gfOU+MjnMfBz+Pdnk4+y1m4V/f1wPv+uBBn93wF+BhYBgzw5QX4g3/2D4DCwL2uBIr98S+B9EJgg79mAS1f44fW0VMOYDItXkzH4v6Ji4G/AOk+PcPHi33+sYHrf+6feQveM6et8ROtjngfwCnA236MPI/zQkrI8QHcCXzo2/sEzhMpYcdG2GFLbRiGYRihJLqJyTAMw4iCKQjDMAwjFFMQhmEYRiimIAzDMIxQTEEYhmEYoZiCMBIKEWkQkff9Kp7rRORGEWnz/0BEhonIP3VDW64XkawOlP+RiMzs6nYYRjTMzdVIKESkXFVzfPhI3Cqvb6nqL9u4ZjIwW1Uv6uK2bMV9W1Dalfc1jK7C3iCMhEVV9wBXA9f6r4WHicibIvKuPyb6onOBs/2bxw3RyolIvoi84cttEJGzffr5IrLSl/2LiOSIyE9xawAtF5HlkW0Tkbni9vVYLyLzfdocEZktIkf7OpqOBhEZKiJHiMhzIrLWH2fGoh+N3ou9QRgJRfANIpC2HzgROAg0qmq1iIwAnlLVwsg3CG8WCit3I5Chqv8lIslAFu7r3MW4L2wrROQW3Jezv4r2BiEiA4EiYKSqqoj0U9X9IjIHKFfV+YGyPwEmqeoPROTPwP2qukJEhuCWvxjVxV1oJBAphy5iGAlDKrBARE4BGoATOlhuLfBHcQsmPq+q74vIJNymMm+5JX9IA1Yeoh1lQDXwiLhd8JaGFfJvCP+GW2IF3AJ0o309AH1FJEdVyw9Rn2GEYgrCSGhE5FickN8D/BLYDZyMM79WR7nshrByqvqGiHwL+A7wmIjcA3wFvKyql7e3TapaLyKn4xaQuxS4FrcSbbDd+biFGb8bUABJwHhVjdZuw+gQNgdhJCwicgRuy8cF6mytuUCJqjYCP8RtGwnO9NQncGloOREZCuxW1f8GHsYtpb0KOFNEjvdlskXkhCj3bWpXDpCrqi/glNHJEfmpuEXeblHVjwJZfwP+I1DulI71iGG0xhSEkWhkNrm54lYV/RtuVU+A+4FZIrIOGInbUAfcyqcN3i32hjbKTQbWich7wDTgPlXdi9vr+CkRWY8zL4305RcCL4ZMUvcBlvryK3B7ageZiFs19c7ARPXRwE+BQj+xvQn40WH2kWEANkltGIZhRMHeIAzDMIxQTEEYhmEYoZiCMAzDMEIxBWEYhmGEYgrCMAzDCMUUhGEYhhGKKQjDMAwjlP8HfP3OIg+ArGQAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_cv_accuracies(num_points, num_classes):\n",
+        "    input, output = make_classification(n_samples=num_points, n_features=num_classes+1, \n",
+        "                                        n_informative=num_classes+1, n_redundant=0, n_classes=num_classes, random_state=2)\n",
+        "    scaler = preprocessing.StandardScaler().fit(input)\n",
+        "    input, output = jnp.array(scaler.transform(input)), jnp.array(output)\n",
+        "\n",
+        "    cv = RepeatedStratifiedKFold(n_splits=10, n_repeats=1, random_state=1)\n",
+        "\n",
+        "    cmgf_est = CMGFOneVsAllEstimator(EKFParams)\n",
+        "\n",
+        "    cmgf_score = cross_val_score(cmgf_est, input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "    sag_op_score = cross_val_score(LogisticRegression(multi_class='multinomial', solver='sag', max_iter=1), input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "    sag_mp_score = cross_val_score(LogisticRegression(multi_class='multinomial', solver='sag'), input, output, scoring='accuracy', cv=cv, n_jobs=-1, error_score='raise').mean()\n",
+        "\n",
+        "    return cmgf_score, sag_op_score, sag_mp_score"
+      ],
+      "metadata": {
+        "id": "zE7jM6lsvhnl"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_points = 1000\n",
+        "class_range = range(2, 19)\n",
+        "\n",
+        "cmgf_accuracies, sgd_onepass_accuracies, sgd_multipass_accuracies = [], [], []\n",
+        "for num_classes in class_range:\n",
+        "    print(f'{num_points} data points, {num_classes} classes.')\n",
+        "    cmgf_ac, sgd_op_ac, sgd_mp_ac = compute_cv_accuracies(num_points, num_classes)\n",
+        "    cmgf_accuracies.append(cmgf_ac)\n",
+        "    print(f'EKF-CMGF estimate average accuracy = {cmgf_ac}')\n",
+        "    sgd_onepass_accuracies.append(sgd_op_ac)\n",
+        "    print(f'One-pass sag estimate average accuracy = {sgd_op_ac}')\n",
+        "    sgd_multipass_accuracies.append(sgd_mp_ac)\n",
+        "    print(f'Multi-pass sag estimate average accuracy = {sgd_mp_ac}')"
+      ],
+      "metadata": {
+        "id": "Tb6zzkxttk2S",
+        "outputId": "f9ffb4a8-97ca-4023-e256-4b18fa06f549",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "1000 data points, 2 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.9010000000000001\n",
+            "One-pass sag estimate average accuracy = 0.9\n",
+            "Multi-pass sag estimate average accuracy = 0.905\n",
+            "1000 data points, 3 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.625\n",
+            "One-pass sag estimate average accuracy = 0.585\n",
+            "Multi-pass sag estimate average accuracy = 0.628\n",
+            "1000 data points, 4 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.5359999999999999\n",
+            "One-pass sag estimate average accuracy = 0.46299999999999997\n",
+            "Multi-pass sag estimate average accuracy = 0.5489999999999998\n",
+            "1000 data points, 5 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.491\n",
+            "One-pass sag estimate average accuracy = 0.449\n",
+            "Multi-pass sag estimate average accuracy = 0.483\n",
+            "1000 data points, 6 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.5680000000000001\n",
+            "One-pass sag estimate average accuracy = 0.537\n",
+            "Multi-pass sag estimate average accuracy = 0.5670000000000001\n",
+            "1000 data points, 7 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.45199999999999996\n",
+            "One-pass sag estimate average accuracy = 0.394\n",
+            "Multi-pass sag estimate average accuracy = 0.445\n",
+            "1000 data points, 8 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.376\n",
+            "One-pass sag estimate average accuracy = 0.33599999999999997\n",
+            "Multi-pass sag estimate average accuracy = 0.384\n",
+            "1000 data points, 9 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.45499999999999996\n",
+            "One-pass sag estimate average accuracy = 0.41900000000000004\n",
+            "Multi-pass sag estimate average accuracy = 0.4629999999999999\n",
+            "1000 data points, 10 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.399\n",
+            "One-pass sag estimate average accuracy = 0.36499999999999994\n",
+            "Multi-pass sag estimate average accuracy = 0.41\n",
+            "1000 data points, 11 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.38699999999999996\n",
+            "One-pass sag estimate average accuracy = 0.36900000000000005\n",
+            "Multi-pass sag estimate average accuracy = 0.393\n",
+            "1000 data points, 12 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.357\n",
+            "One-pass sag estimate average accuracy = 0.331\n",
+            "Multi-pass sag estimate average accuracy = 0.365\n",
+            "1000 data points, 13 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.336\n",
+            "One-pass sag estimate average accuracy = 0.30500000000000005\n",
+            "Multi-pass sag estimate average accuracy = 0.33999999999999997\n",
+            "1000 data points, 14 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.341\n",
+            "One-pass sag estimate average accuracy = 0.29799999999999993\n",
+            "Multi-pass sag estimate average accuracy = 0.31900000000000006\n",
+            "1000 data points, 15 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.258\n",
+            "One-pass sag estimate average accuracy = 0.229\n",
+            "Multi-pass sag estimate average accuracy = 0.261\n",
+            "1000 data points, 16 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.266\n",
+            "One-pass sag estimate average accuracy = 0.24699999999999997\n",
+            "Multi-pass sag estimate average accuracy = 0.272\n",
+            "1000 data points, 17 classes.\n",
+            "EKF-CMGF estimate average accuracy = 0.279\n",
+            "One-pass sag estimate average accuracy = 0.256\n",
+            "Multi-pass sag estimate average accuracy = 0.291\n",
+            "1000 data points, 18 classes.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/joblib/externals/loky/process_executor.py:705: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+            "  \"timeout or by a memory leak.\", UserWarning\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "EKF-CMGF estimate average accuracy = 0.26799999999999996\n",
+            "One-pass sag estimate average accuracy = 0.229\n",
+            "Multi-pass sag estimate average accuracy = 0.25600000000000006\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot result\n",
+        "fig, ax = plt.subplots()\n",
+        "ax.plot(class_range, cmgf_accuracies, 'r', label='CMGF-EKF')\n",
+        "ax.plot(class_range, sgd_onepass_accuracies, 'y', label='SGD (single pass)')\n",
+        "ax.plot(class_range, sgd_multipass_accuracies, 'b--', label='SGD (multi pass)')\n",
+        "ax.set_xticks(class_range)\n",
+        "ax.set_xlabel('Number of output classes')\n",
+        "ax.set_ylabel('10-fold cv average accuracy')\n",
+        "ax.set_title('10-fold cv accuracy (CMGF vs SGD )')\n",
+        "ax.legend();"
+      ],
+      "metadata": {
+        "id": "Q989sIJZxHJJ",
+        "outputId": "dd6aa795-97a6-4247-aec3-a70da7121c2e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd3gU1frA8e+bTsiGGkA6kUiHQBKwi+IVFJWLIFUFr6goWFD8qdgQRcV+ERVBpYlS5KKoKEVBiqAECL2HFmpCSwKElH1/f8wmbMImWSCbej7PMw+ZmTMz727CnJk5Z94jqophGIZRdnkVdQCGYRhG0TIVgWEYRhlnKgLDMIwyzlQEhmEYZZypCAzDMMo4UxEYhmGUcaYiKGNE5E0RSRCRw26U3SMit+ayrr2IxBV8hGWTiISIyFYRKVfUsZRWIuLv+I5DijqW4sZUBMWciAwWkWgROSciE12s7+D44z4jIotEpF4e+6oLPAs0VdUaHgzbuHgvABNV9WzmAhHpKCJLRCRJROJF5E8Ruduxrr+IqIh85LwTEeniWD7RaZmfiLwqIttE5LSIHBCRX0XkNqcye0TkrIgkO001PfVhReR6EflLRE6JyHERWS4iUU7rrxCR8SJy0BFLrIhMFJHGjvX1HZ8zM9YjIvKziPwrt2Oq6jnga6zv2nBiKoLi7yDwJtYfcDYiUhX4H/AKUBmIBqbnsa+6wDFVPeqBOEsdEfEppOP4A/2Ab5yWdQdmApOB2kB14FXgLqdNdwE9csTZD9ie4xDfA12AB4BKQAPgv0DnHOXuUtUgp+ng5X42V0QkGPgZ+ATr77YW8DpwzrG+CvAXEAjcANiANsCfQM4TfUVVDQJaAQuA2SLSP4/Dfwv0c3znRiZVNVMJmLAqg4k5lj0C/OU0Xx44CzR2sf2tjnV2IDlzX8DdwCbgJLAYaOK0zR7gVsfP5YCJwAlgM/AcEJdHvM2w/mMeB44Aw4CajhgqO5VrDSQAvi720RZY4YjtEDAG8MvrGI7l3o7j7QKSgNVAHaA+oICP0z4WAwMcP/cHlgMfAccc3/mVwB+O+QRgKtbJJ3P7OliVcbyjzBjAzxFTC6dy1YAzQIiLz3kjsNNpXoB9wHN5fL/9gWXAb0Bnx7LKwGHgPaffb+bvvXY+f19Zv+t8ym0B7nSa93F89jZAAFZldszxO1sFVHexj0jgZD5/6+sArzzKXPC7dCwf6vhbyGvbHcBNRf1/ujhN5o6gZGuG9R8GAFU9jXXya5azoKouBG4HDqp1tddfRK4CvgOeBkKAucBPIuLn4livYZ0UrwQ6Yl15uiQiNmAh1kmqJtAQ+F2tK8wVQDen4n2A71U1zcWuMoAhQFXgGqAD8Hhex3Bs9wzQG7gDCAb+g3USdkc7IBbrCnwk1kn5bccxmmCd+Ic7YvDGurLdi3ViqgVMU9VUYBpwn9N+ezu+g3gXx2wBbHOab+Q4zvduxDsZ60ofoBfwI44ra4dbgb9VtaDac77D+iyZOgIJqroG62+iAlbsVYCBWJVQTtuBDBGZJCK3i0ilHOtvBWarqv0S4vsfVqXbKI8yW7DuIAwHUxGUbEHAqRzLTmHdSrujJ/CLqi5wnIjfx7ryv9ZF2R7ASFU9rqr7gdF57PdO4LCqfqCqKaqapKp/O9Z9i+NEIiKCdfL61tVOVHW1qq5U1XRV3QN8AdzkxjEGAC+r6ja1rFPVY+59JRxU1U8cxzyrqjsd3885x0n8Q6cY2mJVEM+p6mlHHMsc6yYBvR2fEeB+YEoux6yIdeeSqYrj30NuxDsbaC8iFbAqhMk51lfFuksAQEQqi8hJx7P5lBxlf3CsOykiP+RyvG+Bu0Uk0DHfB6tyAEhzxN5QVTMcv7/EnDtwLLse64p+PBAvInNEpHouMd/tiClJRObn+W1Yj1LBujvKTRLWd244mIqgZEvGuuJ1FgwkicgNTg1pm3LZvibW1SwAjiuw/VhXtq7K7nea3+uiTKY6WHcmrswCrhGRK7AeidiBpa4KishVjgbAwyKSCLyFdZLI7xh5rcuP82dERKqLyDRHA2si1qMP5xj2qmp6zp04KqUzWCfpxlh3LHNyOeYJslfemZXWFfkFq1bj8i/Ay0AVVV2eo8gx5/04KvKKQASQ8zn5v1W1omP6dy7H24l1RX2XozK4m/MV+RRgHjDN0cj7roj45rKfLaraX1VrA82x/r4+ziXmOY6Yh2A9dstL5t/u8TzK2LAeXRkOpiIo2TbhdIsrIuWxHt1sUtWler7R74JHRQ4HgXpO2wvWye2Ai7KHHOsy1c0jrv1AqKsVqnoCmI91N9IH61FKbilwPwe2AmGqGoz13D/zCjvXYzjWXeli+WnHv4FOy3L2nsoZy1uOZS0cMdyXI4a6eTQqT3KUvx/r8VfOK/BM64GrnOa3OfbdzXXxC0zG6g32jYt1vwNRIlLbzX25I/PxUBdgs6NyQFXTVPV1VW2KdVd5J+cfW+VKVbditT81d4r53yJyKeenrsBRsj9qy6kJTo9UDVMRFHsi4iMiAVgNoN4iEuB04pkNNBeRbo4yrwLrHf+x3DED6OzoguqLdTI5h9Vjw1XZF0WkkuOk8kQe+/0ZuEJEnhar77ZNRNo5rf8W6wTRnVweCznYgEQg2XFV/Zibx/gSeENEwsTSUkSqOB7tHADuExFvEfkPriuMnDEkA6dEpBZWI3mmf7AqyHdEpLzjd3Od0/pvsE5M93HhIxtn/wAVHfvHUTE+A7wiIg+KSLCIeDm6XI5zsX1mb5pPcq5Q1fnAIqzHPu3E6krqC1ydz+fOyzTgNqzfR9bvT0RuFpEWjraTRKxHRRc85xeRxiLybGblJCJ1sCqWlY4iH2L1bpoiIlc6foc2IDy3gBx3boOx2rJezK19wfEdV3Y6lgGm11Bxn7AaJjXHNNxp/a1YV81nsXrA1M9jX+3J0dMH60S1Gatt4U+gmdO6PZzvNRSIdTI7iXu9hppjXdmdwHre+4LTunJYz2k35fPZb3R8tmSsx0cjgGX5HQOr0nwZ2O04ziocvWawGsx3Oz7HB47P7NxraFmOGJph9TpKBmKwKss4p/V1gR8436todI7tFzq+R8nns74HPJ9jWSfH507G6pmzmPM9hC6I1Wm7bD3MsB6nDMfqLXMGiAN+BW5z9bt28+/ydyAdqOG0rDfWlfhprJ47o8nRq8dRrhbWhcUBR9kDWO0/wU5lagJfYVW0yViP+ibh6NXG+V5DyY59HMXq7NApn7ifAz4s6v/XxW0Sx5djGIYHiMjXWA3QL+dTLgTrpN9anV4qMwqO492BdcCNat6lycZUBIbhISJSH+suorWq7i7aaAwjd6aNwDA8QETeADYC75lKwCjuzB2BYRhGGWfuCAzDMMq4QkmqVZCqVq2q9evXL+owDMMwSpTVq1cnqKrLFNwlriKoX78+0dHRRR2GYRhGiSIiuWYDMI+GDMMwyjhTERiGYZRxpiIwDMMo40pcG4FhGBcnLS2NuLg4UlJyy3lnlCYBAQHUrl0bX1+XiV9dMhWBYZRycXFx2Gw26tevz/nhEYzSSFU5duwYcXFxNGjQwO3tzKMhwyjlUlJSqFKliqkEygARoUqVKhd992cqAsMoA0wlUHZcyu/aoxWBiHQSkW0islNEXnCxvp6I/C4i60VkcQEPnmEYhmG4wWMVgWNwik+x8r83xRq/tWmOYu8Dk1W1JVau+bc9Fc+f3x0gvH48e/Z46giGYeTl8OHD9OrViyuvvJKIiAjuuOMOtm/fjojw8svns3QnJCTg6+vL4MGDs5Z98803tGzZkmbNmtGqVSsGDBjAyZPWaJPt27enUaNGhIeHEx4ezvfff3/BsSdOnEhISEhWmfDwcDZv3syePXto3rx5Vrnx48cTERHBiRMn6N+/Pw0aNMgqP3p0XsN0l2yebCxuC+xU1VgAEZmGY2g7pzJNsUZiAscoSp4K5kzsm6zb+zlLfk6g/uCq+W9gGEaBUVW6du1Kv379mDZtGgDr1q3jyJEjNGjQgF9++YU333wTgJkzZ9Ks2fnRVX/77Tc++ugjfv31V2rVqkVGRgaTJk3iyJEjVKxojUE/depUIiMj84yhZ8+ejBkzJtuyPU5XhlOmTOGTTz7hjz/+oFKlSgC89957dO/e/bI/f3HnyUdDtcg+EHgcFw6Kvg64x/FzV8AmIlVy7khEHhGRaBGJjo+Pv6RgWl9fn/LlT7H4532XtL1hGJdu0aJF+Pr6MnDgwKxlrVq1ok6dOgQGBtKkSZOs1DHTp0+nR48eWeVGjhzJ+++/T61a1unD29ub//znPzRq1KjA4psxYwbvvPMO8+fPp2rVsnehWNTdR4cCY0SkP7AEa8i6jJyFVHUcMA4gMjLykvJmV2p9L82a/cXy9Y0vPVrDKOmefhpiYgp2n+Hh8PHHeRbZuHEjERERua7v1asX06ZNo3r16nh7e1OzZk0OHjwIwKZNm2jTpk2e++/bty/lypUD4Pfff6dKlQuuJ5k+fTrLli3Lml+xYgUAe/fuZfDgwaxdu5YaNWpk2+a5557LulOZMmUKLVq0yDOOksqTdwQHgDpO87Udy7Ko6kFVvUdVWwMvOZad9EQw/sGhhIetYPuhBhw/7okjGIZxqTp16sSCBQuYNm0aPXv2zLXchg0bCA8P58orr2T69OlZy6dOnUpMTAwxMTEuKwGwHg1llomJicmqOEJCQqhbty4zZsy4YJv33nsvq3xprQTAs3cEq4AwEWmAVQH0Avo4FxCRqsBxVbUDLwJfezAebmy6mdi200k8dCeVK5f35KEMo3jK58rdU5o1a+ayETeTn58fERERfPDBB2zevJk5c+Zk23bNmjXcfPPNtGjRgpiYGAYPHszZs7kP7fzpp58yfvx4AObOnZtnbIGBgcydO5cbbriBatWq0bdv34v8dCWfx+4IVDUdGAzMA7YAM1R1k4iMEJG7HcXaA9tEZDtQHRjpqXgArosK5KW3e1H78O+ePIxhGDnccsstnDt3jnHjxmUtW79+Pfv3n29GfPbZZxk1ahSVK1fOtu2LL77I0KFDiYuLy1qWVyUAMGjQoKwr+Zo1a+YbX7Vq1fjtt98YNmwY8+bNc/djlRoebSNQ1bnA3BzLXnX6+Xsg98uEAmZr3AV2TWH38gWEdbg7/w0MwygQIsLs2bN5+umnGTVqFAEBAdSvX5+Pne5QmjVrlq23UKY77riD+Ph4br/9djIyMqhYsSLNmzenY8eOFxVDzjaCzz77LFsl0aBBA+bMmcMdd9zB7NmzL+FTllwlbsziyMhIvdSBaVJTExg48L9MnfwKp5L9CAgo4OAMoxjasmULTZo0KeowjELk6ncuIqtV1WUf2zKVYsLPryqNa+0kNcOP6JXpRR2OYRhGsVCmKgKAa5ufAGDZ94eLOBLDMIziocxVBHWbRVGv3maWLD5T1KEYhmEUC2WuIgiufSvNmy/jr501sNuLOhrDMIyiV9RvFhe6oKA23HH789yaspKM9K/w8jPpeQ3DKNvK3B2Bj4+NyIb76HDLBHz37CjqcAzDMIpcmasIAGwV2rI+qDHzv9hV1KEYRpkwcuRImjVrRsuWLQkPD+fvv/8GID09nWHDhhEWFpaV7nnkyPPvlXp7exMeHp6VfvqDDz7Anssz3UOHDnHnnXfmGce11157yZ9h4sSJ2VJjF6Wff/6ZV199Nf+CbiqbFUHtDnw5ezgDxuWdttYwjMu3YsUKfv75Z9asWcP69etZuHAhdepYachefvllDh48yIYNG4iJiWHp0qWkpaVlbVuuXDliYmLYtGkTCxYs4Ndff+X11193eZwPP/yQhx9+OM9Y/vrrr4L7YEWoc+fO/PTTT5w5UzCdXspkRRAc3JYWLZaxPzmEfSYrtWF41KFDh6hatSr+/v4AVK1alZo1a3LmzBnGjx/PJ598QoDj7U6bzcbw4cNd7qdatWqMGzeOMWPG4OpF2FmzZtGpUyfAyljatm1bwsPDadmyJTt2WI+Bg4KCAFi8eDHt27ene/fuNG7cmL59+2btc+7cuTRu3JiIiAiefPJJl3cZ8fHxdOvWjaioKKKioli+fPkFZSZOnEiXLl1o3749YWFh2Sqwf//730RERNCsWbOstBsZGRn079+f5s2b06JFCz766CMARo8eTdOmTWnZsiW9evUCrDe127dvz88//5zPt++eMtdYDFC+fCtaNnscgOW/nKTuYxWLOCLDKBw7djxNcnLBpqEOCgonLCz3ZHa33XYbI0aM4KqrruLWW2+lZ8+e3HTTTezcuZO6detis9ncPlZoaCgZGRkcPXqU6tWrZy3fvXs3lSpVyqpsxo4dy1NPPUXfvn1JTU0lI+OC7PasXbuWTZs2UbNmTa677jqWL19OZGQkjz76KEuWLKFBgwb07t3bZRxPPfUUQ4YM4frrr2ffvn107NiRLVu2XFDun3/+YePGjQQGBhIVFUXnzp2JjIzk66+/pnLlypw9e5aoqCi6devGnj17OHDgABs3bgTIGoHtnXfeYffu3fj7+2ctA4iMjGTp0qXZxm64VGXyjsDbO4DmDVMo75/Ish+PFXU4hlGqBQUFsXr1asaNG0dISAg9e/Zk4sSJF5SbMGEC4eHh1KlTJ1syOnccOnSIkJCQrPlrrrmGt956i1GjRrF3796slNPO2rZtS+3atfHy8iI8PJw9e/awdetWQkNDadCgAUCuFcHChQsZPHgw4eHh3H333SQmJpKcnHxBuX/9619UqVKFcuXKcc8992TlOho9ejStWrXi6quvZv/+/ezYsYPQ0FBiY2N54okn+O233wgODgagZcuW9O3bl2+++QYfn/PX7tWqVcsas+Fylck7AoBKNa+ladMVLFvdPP/ChlFK5HXl7kne3t60b9+e9u3b06JFCyZNmkSPHj3Yt28fSUlJ2Gw2HnzwQR588EGaN2/u8goeIDY2Fm9vb6pVq5Ztebly5UhJScma79OnD+3ateOXX37hjjvu4IsvvuCWW27Jtk3m3UNmfOnp7qedsdvtrFy5MuuRVm5E5IL5xYsXs3DhQlasWEFgYCDt27cnJSWFSpUqsW7dOubNm8fYsWOZMWMGX3/9Nb/88gtLlizhp59+YuTIkWzYsAEfHx9SUlJcVnCXokzeEQAEV7yap559nF9blv7xSA2jKG3bti3rGT1ATEwM9erVIzAwkIceeojBgwdnncQzMjJITU11uZ/4+HgGDhzI4MGDLzjBXnXVVdnGH46NjSU0NJQnn3ySLl26sH79erdibdSoEbGxsVn7ch78xtltt93GJ598ku0zubJgwQKOHz/O2bNn+eGHH7juuus4deoUlSpVIjAwkK1bt7Jy5UoAEhISsNvtdOvWjTfffJM1a9Zgt9vZv38/N998M6NGjeLUqVNZdx7bt2+nefOCuZAts3cENlsktWrF4u21G5KS4CKeUxqG4b7k5GSeeOIJTp48iY+PDw0bNsxqIB05ciSvvPIKzZs3x2azUa5cOfr165eVHvrs2bOEh4eTlpaGj48P999/P88888wFxyhfvjxXXnklO3fupGHDhsyYMYMpU6bg6+tLjRo1GDZsmFuxlitXjs8++4xOnTpRvnx5oqKiXJYbPXo0gwYNomXLlqSnp3PjjTcyduzYC8q1bduWbt26ERcXx3333UdkZCQtWrRg7NixNGnShEaNGnH11VcDcODAAR588MGs7rFvv/02GRkZ3HfffZw6dQpV5cknn6RiRatNc9GiRbz99ttufa78lKk01M7s9nSW/RnET8Oeovn199PvPfOIyCidykoa6tmzZ7N69eqsMYYvVXJyMkFBQagqgwYNIiwsjCFDhlz0fiZOnEh0dDRjxoy5rHhcOXLkCH369OH3310PsmXSULvJy8uHoKBwfjvUla9mBBV1OIZhXKauXbtSv379y97P+PHjs15iO3XqFI8++ujlB1fA9u3bxwcffFBg+yuzdwRgdaV75cU6/DD7CU6d8cOp7cgwSo2yckdgnGfuCC5CcHAUzcOXcs5uBqoxDKPsKtMVgc0WRfPm1huBy2YeKuJoDMMwioZHKwIR6SQi20Rkp4i84GJ9XRFZJCJrRWS9iNzhyXhyKleuIVUqp9IkZC0nt5iKwDCMssljFYGIeAOfArcDTYHeItI0R7GXgRmq2hroBXzmqXhcx+iFLTiKSaOu4e3ggumGZRiGUdLkWxGIyBMiUukS9t0W2KmqsaqaCkwDuuQoo0Cw4+cKQMG8L30RbLZIztRNw75yKZSwhnPDKCmKSxpqdy1evDhrX4sXL86WtXTs2LFMnjy5QI7jrqFDh/LHH394bP/uvFBWHVglImuAr4F56l5Xo1qAc8KQOKBdjjLDgfki8gRQHrjV1Y5E5BHgEYC6deu6cWj3BQdHkXgmmKiTc3l85GEeevmKAt2/YZR1zmmo/f39SUhIyHp7+OWXX+bw4cNs2LCBgIAAkpKSsnWLzExDDXD06FH69OlDYmKiy1TU7qShvhSLFy8mKCgoayyDgQMHFvgx8vPEE0/w8MMPX5Amo8Coar4TIEBHrKv6ncBbwJX5bNMd+NJp/n5gTI4yzwDPOn6+BtgMeOW134iICC1IZ8/u1T/+QEP8D+l9V28v0H0bRnGwefPmIj3+rFmz9M4777xg+enTp7Vy5cqamJiY67bly5fPNr9r1y6tXLmy2u32C8o2aNBAU1JSVFV1woQJ2qVLF7311lu1Xr16+sknn+gHH3yg4eHh2q5dOz127Jiqqt500026atUqVVWNj4/XevXqqarqokWLtHPnzrp7926tXr261qxZU1u1aqVLlizR1157Td97770Ljt+vXz999NFHNSIiQsPCwvSnn35SVdXdu3fr9ddfr61bt9bWrVvr8uXLVVX14MGDesMNN2irVq20WbNmumTJEk1PT9d+/fpps2bNtHnz5vrhhx9m7b9NmzZ66NChXL8rZ65+50C05nJedSvFhKqqiBwGDgPpQCXgexFZoKr/l8tmB4A6TvO1HcucPQR0chxjhYgEAFWBo+7EVRD8/evg51eN1qF/sWzjDYV1WMMoMu3bX7isRw94/HE4cwbucNFlo39/a0pIgO450nMtXpz38YoiDTXAxo0bWbt2LSkpKTRs2JBRo0axdu1ahgwZwuTJk3n66afzPV79+vUZOHAgQUFBDB06FCDXt3kB9uzZwz///MOuXbu4+eab2blzJ9WqVWPBggUEBASwY8cOevfuTXR0NN9++y0dO3bkpZdeIiMjgzNnzhATE+MyFTVAmzZtWL58Od26dXP7+3KXO20ET4nIauBdYDnQQlUfAyKAvCJaBYSJSAMR8cNqDJ6To8w+oIPjOE2AACD+oj/FZRARbLYoml39N3uSQ4iLK8yjG0bpVxRpqAFuvvlmbDYbISEhVKhQgbvuuguAFi1aZEtQV5B69OiBl5cXYWFhhIaGsnXrVtLS0nj44Ydp0aIF9957L5s3bwYgKiqKCRMmMHz4cDZs2IDNZss1FTUUbNrpnNy5I6gM3KOqe50XqqpdRHJtmVHVdBEZDMwDvIGvVXWTiIzAukWZAzwLjBeRIVgNx/0dtzCFKjg4ikbtfoIJsPyn4/R8rHJhh2AYhSavK/jAwLzXV62a/x2AK4Wdhhqyp5n28vLKmvfy8spKOe3j45PV+Jxz+0vhKu30Rx99RPXq1Vm3bh12uz0rdfWNN97IkiVL+OWXX+jfvz/PPPMMDzzwgMtU1JnxFVTa6Zzc6T76K3A8c0ZEgkWkHYCqXjgkjxNVnauqV6nqlao60rHsVUclgKpuVtXrVLWVqoar6vxL/yiXzmaLomHDGLpWmE7IYffS1RqG4Z6iSEPtrvr167N69WoAvv/+e5dlbDYbSUlJbu1v5syZ2O12du3aRWxsLI0aNeLUqVNcccUVeHl5MWXKlKxKbu/evVSvXp2HH36YAQMGsGbNGpepqDMVZNrpnNy5I/gcaOM0n+xiWYlms0Xi7Z3Bf++8nzonBgLtizokwyg1iiINtbuGDh1Kjx49GDduHJ07d3ZZ5q677qJ79+78+OOP2cYgcKVu3bq0bduWxMRExo4dS0BAAI8//jjdunVj8uTJWemtweqN9N577+Hr60tQUBCTJ092mYoaIC0tjZ07dxIZ6TJV0GXLN+mciMSoaniOZetVtaVHIspHQSadc7ZiRT2C16RQdWwLKqxaSD4DDxlGiVFWks4VVBrqS9W/f3/uvPNOuudsTS8As2fPZs2aNbzxxhtulfdE0rlYEXlSRHwd01NArFvRlCA2WxTLzrahxsaFLJ57uqjDMQzjIhVUGuriKD09nWeffdZj+3enIhgIXIvV9TPzpbBHPBZREQkOjqJusyV4k86ymYeLOhzDMC7BgAEDiuzYEydO9MjdAMC9996bNTKZJ+TbRqCqR7G6fpZqNlsU5cqdoWX5NSz7KyT/DQyjBFHVCxpYjdLpUjpe5lsROF7yeghohtXPP/Ng/7nooxVjNlsEAG2axDB1TT9SU8HPr4iDMowCEBAQwLFjx6hSpYqpDEo5VeXYsWNZXVTd5U6voSnAVqwUEyOAvkCe3UZLIh+fCpQr14hm168lJfoR1vydxtU3+BZ1WIZx2WrXrk1cXBzx8YX6rqZRRAICAqhdu/ZFbeNORdBQVe8VkS6qOklEvgWWXlKExVxwcBSNb1zA1x8/SMPTgwDPdNUyjMLk6+tLgwYNijoMoxhzp7E4zfHvSRFpjpUuuloe5Ussmy2ScpV20afKRKpuXFzU4RiGYRQKdyqCcY7xCF7GyhW0GRjl0aiKiM0WBcDWdhF8PdWPXNKeG4ZhlCp5VgQi4gUkquoJVV2iqqGqWk1Vvyik+ApVUFA44M1vFTrzUMyTbNtiagLDMEq/PCsCVbUDuaWZLnW8vQMpX745TW5eBcCyWUeKOCLDMAzPc+fR0EIRGSoidUSkcubk8ciKSHBwFJXCVlCNIyz91b1EU4ZhGCWZO72Gejr+HeS0TIHQgg+n6NlsURw69CXXBP/Dso05R9Y0DMMoffK9I1DVBi6mUlkJwPkG4zaRO9mdXI0j5umQYRilnDtvFj/garmqTi74cIpe+fLNEfGnc98/eOyPtwhJjwFqFXVYhq6IyBIAACAASURBVGEYHuNOG0GU03QDMBy424MxFSkvL1+CgsLxaniAEBJg2bKiDskwDMOj3Ek694TzvIhUBKZ5LKJiIDg4ikOnJzA94D5WvF2Nj3vmv41hGEZJ5c4dQU6ngVL9vrrNFoXdfpqYK9vzybobSUws6ogMwzA8x502gp+wegmBVXE0BWZ4Mqiiltlg3KrDPuybvFn5+2lu61q+iKMyDMPwDHe6j77v9HM6sFdV49zZuYh0Av4LeANfquo7OdZ/BNzsmA0Eqqmq50ZfcFNgYCO8vW1c9a9teI3OYNnMQ9zW1f1xUA3DMEoSdyqCfcAhVU0BEJFyIlJfVffktZGIeAOfAv/CGtlslYjMUdXNmWVUdYhT+SeA1hf/EQqeiBc2WwQZAbtozVqW/VWpqEMyDMPwGHfaCGYCzkl3MhzL8tMW2KmqsaqaitXA3CWP8r2B79zYb6Gw2aJIPrOeW67YhPepE1zCoD+GYRglgjsVgY/jRA6A42d3xu6qBex3mo8jlw75IlIPqwH6j1zWPyIi0SISXViDa9hsUaim8sqj81mQcgOSeq5QjmsYhlHY3KkI4kUk670BEekCJBRwHL2A71U1w9VKVR2nqpGqGhkSUjjjCdts1qA0iZE2SElBo1cXynENwzAKmzttBAOBqSIyxjEfB7h82ziHA0Adp/najmWu9CJ7LqMiFxBQHx+fKiTVSqQv32AfVInvYoo6KsMwjILnzgtlu4CrRSTIMZ/s5r5XAWEi0gCrAugF9MlZSEQaA5WAFe4GXRhEhODgKJLObcQvuBu/bLkCVTBjfxuGUdrk+2hIRN4SkYqqmqyqySJSSUTezG87VU0HBgPzsAa7n6Gqm0RkhPOjJqwKYppq8WuOtdmiOH16E9eGnyQ+tSLbt5qBagzDKH3caSO4XVVPZs6o6gngDnd2rqpzVfUqVb1SVUc6lr2qqnOcygxX1RcuNvDCYL1YZif8LuvV4mUzDxVtQIZhGB7gTkXgLSL+mTMiUg7wz6N8qZH5hnH1WxKoQgLLfnP3qZhhGEbJ4U5j8VTgdxGZ4Jh/EJjkuZCKD3//Gvj71yY5YA9Dgr6kur0q0KiowzIMwyhQ7jQWjxKR9UAHx6I3VHWeZ8MqPmy2SJKSVvFSp1RYtQoYUNQhGYZhFCi3so+q6q+qOtQxlZlKAKzHQ2fP7iDtxjYc25vEoejcesAahmGUTO70GrpaRFaJSLKIpIpIhoiUmcTMme0EJyIqUZd9jHrFtBMYhlG6uHNHMAYrD9AOoBzWs5FPPRlUcZL5hvHZK47R1ns1y1YHFHFEhmEYBcvdR0M7AW9VzVDVCUAnz4ZVfPj6VqJcuYYknV7NDXX3sTa+NklJRR2VYRhGwXGnIjgjIn5AjIi8KyJD3Nyu1LDZokhKiub6GwQ73qxcaB4PGYZRerhzQr/fUW4w1jCVdYBungyquLHZojh3bj9t7g3CiwzzYplhGKWKO91H9zp+TAFe92w4xVNmgzGt05nm1ZeIChHAc0Uak2EYRkEpU494LpXN1hrwIil1PfdG7SF045x8tzEMwygpTEXgBm/v8pQv35SkpFUkRnVg0oqr2LXZDFRjGEbp4HZFICKBngykuLMajFeRGH49/TO+Ys7n5sUywzBKB3deKLtWRDYDWx3zrUTkM49HVszYbFGkpSVQpVM1GhDLskVpRR2SYRhGgXDnjuAjoCNwDEBV1wE3ejKo4iizwTjJN5brgzewdEd17GZ4AsMwSgF3Xyjbn2ORy7GFS7OgoJaI+JGUFM2dkYeJT63IiNfK3NdgGEYp5E5FsF9ErgVURHxFZCjWiGNlipeXH0FBrUhKWsW9z9alPxPYNmujuSswDKPEc6ciGIg1sHwtrLGHwylmA80XFqvBeDXc3pFx//mbb7e0xmvR70UdlmEYxmXJtyJQ1QRV7auq1VW1mqrep6rHCiO44sZmiyQjI5EzZ7bj+8mHSJPGxPYaxu0dznHkSFFHZxiGcWnyfbNYREa7WHwKiFbVHws+pOIrq8E4aRXlazSG6dM5GfEwfy5W7rlH+eMPwb9MDOJpGEZp4s6joQCsx0E7HFNLoDbwkIh8nNeGItJJRLaJyE4RcTlAvYj0EJHNIrJJRL69yPgLVfnyTfDyKk9S0iprQYsWtPn4ASbaH+Cvv4THHgPVoo3RMAzjYrkzZnFL4DpVzQAQkc+BpcD1wIbcNhIRb6xxC/4FxAGrRGSOqm52KhMGvOjY/wkRqXbJn6QQiHhjs7U5XxEAPPYYPRYuZOOPI3ljwku0bAlPP110MRqGYVwsd+4IKgFBTvPlgcqOiiGvPAttgZ2qGquqqcA0oEuOMg8Dn6rqCQBVPep25EXEZosiOTkGu93xQpkIfPklw2uOo2v5eXw7JYP09KKN0TAM42K4UxG8izUWwQQRmQisBd4TkfLAwjy2qwU4v38Q51jm7CrgKhFZLiIrRcTlgDci8oiIRItIdHx8vBshe47NFoXdnsLp05vOL6xcGa9vv2HKme4sDnsYH2/zfMgwjJLDnV5DXwHXAj8As4HrVfVLVT2tqpebi9kHCAPaYw2HOV5EKrqIYZyqRqpqZEhIyGUe8vIEB59vMM7mhhsoP/w5AqdPIOmLb3niCThxoggCNAzDuEjuJp1LAQ4BJ4CGIuJOiokDWIPYZKrtWOYsDpijqmmquhvYjlUxFFsBAaH4+FS6sCIAeOkluOkmNg8ZzxdfKL16YR4TGYZR7LmTdG4AsASYhzUwzTxguBv7XgWEiUgDx1CXvYCcifx/wLobQESqYj0qinUz9iIhIthska4rAm9vmDqVduU38vkVI5g/H54z49cYhlHMuXNH8BQQBexV1ZuB1sDJ/DZS1XSs4S3nYaWkmKGqm0RkhIjc7Sg2DzjmyG66CHiuJLysZjUYbyAtzcWzn1q1YMIEHto3nKfC/+Tjj+Hrrws/RsMwDHeJ5tPxXURWqWqUiMQA7VT1nIhsUtVmhRNidpGRkRodHV0Uh86SnLye6Ohw6tZ9ntDQt10Xeuop0kd/yh3hh9h6LITt2yEgoHDjNAzDyCQiq1U10tU6d+4I4hwNuD8AC0TkR2BvPtuUakFBLalWrQ9xcf/l3LmDrgu9+y4+4S2Yvvdqls86bCoBwzCKLXd6DXVV1ZOqOhx4BfgK+LenAyvuGjQYgWo6e/aMcF3A3x+mTaNS6hHqPNcLe1oGn3wCp08XbpyGYRj5ybMiEBFvEdmaOa+qf6rqHMcLYmVauXKh1Kz5KIcOfcmZM9tdF2rUCMaMgT//ZPUTE3j6aejXD5O62jCMYiXPisDx9vA2EalbSPGUKPXqvYyXVwC7d7+Se6F+/aBvX6LGP8q7j+1m1iwYkctNRHGy46OfeTHkS85uzzkmkWEYpY27KSY2icjvIjInc/J0YCWBn1916tR5hvj4GdY4Ba6IwOefQ4MGPPPjTfTvfY7XX4eZMws31ouRtGAl1z3TlncSBjDpvgVFHY5hGB7mTkXwCnAnMAL4wGkygDp1huLjU4XY2BdzL2SzwbRpyJHDjD19P9dcozzyCCQmFl6c7tJdsTx05xGOU5nnW89nwKpH4J9/ijoswzA8yJ3G4j+BPYCv4+dVwBoPx1Vi+PgEU6/eS5w4sYATJ/IYrSwyEt5+G/85M/nf3ZOYOxeCgwsvTrecOsXH185gZmoX3v6/E7zz5zX4VKtCxpChJr+2YZRi7rxZ/DDwPfCFY1EtrK6khkPNmo/h71+X2NgXyPO9jCFDoFMnagwfyDVBVgbvefPgXF45XAtLejr06EHNhPXc/6/DDH0nBGw25vWawJV/TebQV3OLOkLDMDzEnUdDg4DrgEQAVd0BFOtxAwqbt3cA9eu/TlJSNPHxs3Iv6OUFkyZBpUrQsyebVp2hUyeKxYA2+tTTMH8+Pcd1YPL8GohYyxs+fhsHqMWIZ04WkxrLMIyC5k5FcM65u6iI+ADmOUEONWrcT2BgU3bvfgm7PY9Mc9WqwZQpsHUrzcY9xSuvwIQJVk6ioqoM0j8eQ6fP7uLrTtPhoYeyrbuykQ+P3nWI8Uk92TF8atEEaBiGR7lTEfwpIsOAciLyL2Am8JNnwyp5RLwJDX2Ls2e3c/jwhLwL33orvPACfPklrzedzuDB8MEH8OKLRVAZ/Porw4acZT4d8evd3WWRl8fVxd87nZc/qAjHin0qKMMwLpaq5jlhVRYPY1UA3zt+lvy289QUERGhxZXdbtfVq6/R5ctranr6mbwLp6aqXn21anCw2nfF6mOPqYLq0qWFE6uqqm7YoLMC+iioPjYgNc+iLz96VEF16/1vFlJwhmEUJCBaczvP57YiqwDcA/jnV66wpuJcEaiqnjjxpy5ahO7dOyr/wrt3q1aooNq2rWbEH9MFCzwe3nmHD+u2mu3VJonaNvycpqRkX33s2Dxdu7a9njt3VFVVT55UXdj5Q1UfH9Vt2woxUMMwCkJeFYE7j4buAraLyBQRudPRRmDkomLFG6lc+Q727XvbdZpqZ/XrWw0Ea9bg1aoFt2bMA2DFCnj3XQ8GmZIC//43C+LD8a8QwMwf/fD3d14dx+bNvTl5cjEHDnwKQIUK0OGrPlCuHPbnnvdgcIZhFDZ33iN4EGiI9WioN7BLRL70dGAlWWjoW6Snn2L/fjfO5l27wt9/Q8WK0KkTDBrENxPSeP55eOstDwSnCv/5D6xcyaBpN7Btly91nRKI2O3pbNnSB7v9HMHBV3PgwBgyMs5YK6tXZ9S1P9J+zhD0j0UeCM4wjKLg1lCVqpoG/ApMA1Zjso/mKSioVf5pqp21aQOrV1vvGXz2GaMXtaBvxwReeglGjSrg4EaMYNJ3vix7dArccw+VK2dfvXfvCE6dWspVV40lNPRd0tOPcfjwpKz11bpex1Ju5H8DfjHZ8wyjtMjtmVHmBNwOTMR6u3gicAfgk992npqKextBpjNndunixb66deujF7fhH3+o1qmjaV5+2qvZOgXV998voKC+/VZX0lZ9vdL07rvtF6w+fnyhLlokumVLf1W1Gr+jo9vpihVXqt2erqqqaWmqTWqd1EZs0bSvJhVQYIZheBqX2UbwANabxI1Utb+qzlVrGEojD9nTVO9wf8Obb4YNG/C5rxdTNrXh3koLWDE/8fIvvleuJL7/c3T3+4ladbyZMEGyrU5NPcKWLfcRGNiIsLAxgDU+c506Q0lJ2UVCwo8A+PjAW58Es43GTHxmvRlgwTBKAXfaCHqr6g+qal4rvUjn01S/fHEbVqgAkybh8/10psr9fPdnLbzGjObc2UusDfbsIePurvTxnka8hPD9LMn2SEjVzpYtD5CWdoKmTafj7V0+a11ISFcCAkLZv//9rGVd/i1c3SyRN08NJuO9Dy8tJsMwig13cg1dLSKrRCRZRFJFJENEimHezOLHrTTVeenWDd9NMfh2uJH4p94gImQvY986fnH7SEyEu+5ianIXFp69njFjhIiI7EX273+PEyfmExb2X4KCWmZbJ+JNnTrPkJi4glOnljuWwdipwczr+BHe770DB91oBzEMo9hy59HQGKzeQjuAcsAA4FNPBlWauJWmOi81asDPP1Ph07cJTdnMYy9VZvyAle69gpyeDr16wZYt3PdDd+bMgQEDshc5deovYmNfIiTkXq644pFcQuiPj0/lbHcFrVpBo0+fhPR07C+/emmfzTCMYsHdXkM7AW9VzVDVCUAnd7YTkU4isk1EdorICy7W9xeReBGJcUwDXO2nJHM7TXVeRPB7fAAz1zfmjop/8chXV/N127H5p3t49ln2/LqZfW9Owuu2W7nrruyr09KOs3lzbwIC6tKo0XhExOVuvL3LU6vWIBISfsw2LGd6vSvpXm8Vr0wIhZiYS/tshmEUOXcqgjMi4gfEiMi7IjLEne1ExBvrzuF2oCnQW0Sauig6XVXDHVOpfD/BSlNdh9jYFzN7Yl0S/6ZXMiuuHR3DYhkQ/SjfN3wBfvvNdeHPPiNl9BfcU20ZHb7qS3qO5n1VZdu2h0hNPUjTptPw8amQ57Fr1RqEiB/7959vE/DxAb+WjfmIpzk0eGTRp1A1DOOSuFMR3O8oNxg4DdQBurmxXVtgp6rGqpW9dBrQ5VIDLcmsNNUjSEpaRULC/y5rXwHlvZm9LpSB9x7n+mrb4fbb4fHHs/femT8fnnySwXV+ZO3R2nz4oXXSdnbgwKckJPxAaOgogoPb5ntcP7/q1KjRj8OHJ5KaejRr+Ruj/Ejz8mfE8lvgl18u67MZhlFEcutXerkT0B340mn+fmBMjjL9gUPAeqyEdnVy2dcjQDQQXbdu3YLsWlto7PZ0/fvvprpyZSPNyEgrmJ2ePatpQ57TJdygGhamumKF6qZNqsHB+mXt1xRUhw27cLPExDW6eLGfrlvXWe32C98nyM3p01t10SLR2NhXsy1/fGC6epOm2xvcZiXTMwyj2OEy3yPwpJ+A+qraElgATHJVSFXHqWqkqkaGhIQUaoAF5Xya6m0cPjyxYHYaEMDbld6lvdefzDh+K1x3HbRvzzqfCAbFv0aHDjBiRPZN0tOT2Ly5B76+ITRuPDHXdgFXAgMbUaXK3Rw48On5tBPAK6954+8PI3f3hnHjCuazGYZRaDxZERzAeoyUqbZjWRZVPabn30/4EsjRsbF0qVLlboKDr2HPnuFkZJwtkH0OGQLXXiv0Ofkps278L6SmEjpzFA89JHz3HXh7ny+rqmzf/hhnz8bStOm3+PlVvejj1akz1JF2YmLWsho1YNZsbz64/gd47TU4ebIAPplhGIXFnUbfNpe471VAmIg0cDQ29wLm5Nj3FU6zdwNbLvFYJYKIEBr6DqmpBzhwYEyB7DMoCObOhbZthZ5LBzPts+PYboni008h583T4cMTOXp0KvXrD6dixRsv6XgVKlxHcPDV7N//IaoZWcs73S5UGf0aeuy4h7LlGYbhKe7cEXwgIltE5A0Rae7ujtVKQzEYmId1gp+hqptEZISI3O0o9qSIbBKRdcCTWG0GpZqVpvp2R5rqgrlyttmszkMtWsDAx71cXpCfPr2ZHTsGU7HiLdSrN+ySj5U97cQP2dbtrtiaqCqx/PHROti9+5KPYRhG4RJ1o8ufiNQAegA9gWCsLp9vejg2lyIjIzU6OrooDl1gkpPXER0dTt26LxIaWnBXz0lJVkbrDh3A+dF/RsZZ1qxpS2rqESIj1+Hvf0XuO3GDagZ//90IX9+qtGmzIqudISUFwkIzqHlkDSu7vY/MmH5ZxzEMo+CIyGpVjXS1zt0Xyg6r6mhgIBADmFdJL8P5NNUfu5em2k02mzUccs723507n+b06Y00aTLlsisBOJ92Iinp76y0EwABAfD6m978Y49i9sw0+Ouvyz6WYRie504bQRMRGS4iG4BPgL+wGn6Ny9CgwRuoprF37xsePc7RozM4dGgcdeo8T+XKHQtsv1baiSrZ0k4APPAANGlk5yWfUaQPec68ZGYYJYA7dwRfAyeAjqraXlU/V9Wj+W1k5K1cuVCuuOJRDh4cf3Fpqi/C2bO72LbtYYKDr6FBg4KtcLy9A6lVaxDHjs3hzJltWct9fOCtd7zYmh7GtH8awHTzeMgwijt3KoJ/Yb0IdhBARLxEJNCzYZUN9eu/gpdXALGxL5CRUbB5/e32VDZv7oWIF02bfoeXl2+B7h+stBNeXv7Z0k4AdOkCU6fY6dFyG7zwgtV4UAypwpYt5qbFMNypCBZiZR3NFOhYZlwmK031UBIS/sfSpRVYtSqcbdse5dChrzl9ehOqlz4aTWzsCyQlRdOo0dcEBNQrwKjP8/OrRvXq/Th8eBKpqUeylotAn/u88PtoFLp3L/z3vx45/uUaNgxeeaWoozCMoudORRCgqsmZM46fzR1BAalf/1VatJhLvXrD8POrTnz8DLZte4hVq5qzbFlFYmI6EBs7jISEHzl37rBb+0xI+Jm4uI+oVWswISFdPRp/nTrPoJrKgQMXZiafl3YL4cGxnHxzDBwtXk8Tp06Fd96BKlWs+T17zLAKRtmVb/dREVkOPKGqaxzzEViPiq4phPguUBq6j+ZF1c7ZsztITPw7azp9eh2Zo4P6+9cjOLhd1hQU1AZv7/M3bCkpcURHtyIgoC6tW6/A2zvA4zFv3NiVkyeXcM01+7KNbhYTA61bwzB5m5ED98Nnn3k8Fnf88w/ceCNc3fgECzI64PPe21w3oiN79sDs2dCuXVFHaBgFL6/uo+5UBFFYmUMPAgLUAHqq6iUMuXX5SntF4EpGxlmSk9dkqxzOndsLgIgP5cu3zKoYDh36kqSktURGriEw8KpCie/UqeWsXXs9YWFjqFVrULZ1ffrADzNT2ZXRgCsWf2edgYvQgQMQFQUB3mn8k9SEqomx4OXF+mHT6DKlO4cOWemSHnigSMM0jAJ3WRWBYwe+QCPH7DZVTSvA+C5KWawIXElNPZKtYkhK+oeMjCQAmjT5hurV+xZqPGvWXEtq6hHatduONRSFZdcuaNxYGRA0nc+9BsHKlRAWVqixOVu9Gnrem8EPdKV50gr44w94/nn49VcSBr1Gj82vsWiR8MwzMGrUhem7DaOkuuyKoDgxFYFrqnbOnNlKWlrCJecRuhzx8f9j06ZuNG06k2rVumdbN2gQjB+v7LM1p0blVKsyyHw4X9gyMkjv3AWf3+fBwoVw003WkJ5PPgmff05a1x48W2MqS1f4sHw5BJrWMKOUyKsiMNc7pYSIF+XLuxoArnBUrdqFcuUasn//e4SEdMuW3nrECLjuOqFG/fFwyy3QtSssWAD+/oUW3zvvQHIyjEh5EZ95v8AXX1iVAFiX/Z9+Cg0b4jt0KKPb7uX0/+YQGFiNpCTrcVLjxoUWqmEUuqIej8AoJUS8qV37GZKS/uHUqWXZ1lWpYrUVcO21LHpuLhOXhsKAAYXWgX/OHKur6K6Fu5EP3rNuUR55JOcHgGeegVmzYP16yt/SDrZs4ZlnoG1b+PnnQgnVMIpErhWBiLTJayrMII2SoUaNfvj6Vr0g7YSzMZtv4UEm8t9vKsMbnk2vAbBxI/TtCxGNk/l6TThyyy3w0Ue5b9C1K/z5J5w9C9dcw6sdlnPVVXD33VZ27RL2JNUw3JLXHcEHjulT4G9gHDDe8fOFncaNMs/bO5CaNa20E6dPb3VZ5ttv4Z57lKf5L6+/loF+M9Vj8SQkWCdwW2AGP8RfT7m6ITBzJvjm85Z1VJTVjlGrFnXub8/SR6bQuze89BL06pV9eGjDKA1yrQhU9WZVvRlrTOE2jqEiI4DW5BhpzDAyWWknAoiL+9Dlen9/mD5d6P9ABsN5nWf6HcP+51KPxPL333DsmPJDpQepdS7WekZUubJ7G9evD8uXQ/v2lHv0Ab5p8Aqj3lGWLIHjxz0SrmEUGXfaCBqp6obMGVXdCDTxXEhGSebnF0KNGv05fHhytrQTznx84KsJ3jz1aArHyteFe+6BnTsLPJbOdyh7Ogyg7fZv4LvvoOlFNqZXrGgN//bQQ8jIN/m/dX3Zti6FOnXAbof16ws8ZMMoEu5UBOtF5EsRae+YxgPmv4CRq9q1M9NO5D4cp5cXfPR5ABOiW+AlysGOD3LuUMFcao8fDzNmACNHUmn211aXoc6dLyhnt5/j2LG52O3pue/M19fa4VtvwXffEdztX5CQwOjREBEBY8cWSMiGUbRUNc8JCACGALMd0xCs/EP5buuJKSIiQo3ib8OGrrp0aWVNT0/Ot+zZhcs0jO16W6W/Nfn4ucs67h9/qHp7q94ZeVDtoHr//ap2+wXl7Ha7btnyoC5ahMbE3Kqpqcfz3/m0aar+/qoNG+qJ6J16++2qoDpwoOq5ywvbMDwOiNbczvO5rSiuk6kISoaTJ5frokXo/v2fuFX+60dWqBfpem3Idj1x/MITtzt27lStXFm1SehZPRVYQ7VdO9WzZ12WPXDgC120CF2//k5dvNhPV64M09Ont+Z/kOXLVatWVa1cWdMXLdHnn7f+F91wg+qRI5cUtmEUirwqgry6j24QkfW5TYVws2KUYBUqXEtw8LXExX2Y96MXhwe/uJoZPWexKr4eNzc9ctHJShMTrR5CarczJ6UjwZW8rQxyARcm3UtM/IcdO56gcuVONG/+A+Hhf5CefpLVq9tx/Pj8vA907bVWj6KqVfHueCvvtPyWqVNh3TrY4RhfKC6u2A7BYBiu5VZDAPXymnLbLsc+OgHbgJ3AC3mU6wYoEJnfPs0dQclx9Oj/dNEi9MiRGe5tYLfrbx3e1XKc1l7X7LmoY331laq3t11/b/GUakCA6qpVLsudO3dU//qrtq5YUV9TU49lLT97do/+809LXbTIW/fvH612F4+Tsjl2TPXGG63bgREjst3F3H67FUKHDqojR6quXKmalnZRH8cwChyX+2gIqA7c6ZiqubmNN7ALCAX8gHVAUxflbMASYKWpCEoXuz1dV65sqNHRUfmfWDOlpOjK8Ec13vcK1WXLLuZguuXeV6w/6e++c1kkIyNN1669Rf/8M0ATE9dcsD4tLUnXr++iixahW7c+ohkZqfnGqvffbx2zX7+shoL581WHDFFt2dJaBaq33XZ+s9hYl80WhuFRl1URAD2AvcAkYDKwG+juxnbXAPOc5l8EXnRR7mOgM7DYVASlT1zc57poEXrixJ/ub5SQoBoWpueqXKH3/ztR167NveisWapr1qjq6NHWn/OwYbmW3bnz/3TRIvTQoYm5lrHbM3TXrhd10SJ07dr2mpqakHesdrvq8OHnGwomTlRduzarUjhyRHX6dNU5c6ziycmqvr6q1aur9u6t+uWXqrt3530IwygIl1sRrHO+CwBCgHVubNcd+NJp/n6sAW2cy7QBZjl+zrUiAB4BooHounXrevjrMgpSevoZXbasqq5ff9fFbbh9u+6t0ELr+BzQCsEZunz5hUX+/tvqxHN7VLzVVahLF9WMDJe7O3r03qB5fAAAIABJREFUe120CN22baBbhz98+BtdvNhfV6wI1eTkTflvMHmyqs12/hbAx0e1RQvrjuH991UXLFA9elSTk62Tf58+VmWQWfzTT63dnD6tevSoWyEaxkW53IpgQ455r5zLctkuz4rAsZ/FQH3NpyJwnswdQcmze/dwx5X4pIvbcMkS3et7pYaV26eBgXadP//8qrg41SuuUK1fO1Xjg0NVmzdXTUx0uZvk5C26ZEmQRke304yMFLcPf/LkCl22rLouWWLThIRf/r+98w6vqsoW+G+lh5BAQk3oBFB6FWXEEQFpzoBi76IzOA4WwIbiWOc9C/YZHfvoKBZGUHwWwBIFURFCCaH3koQQCGmShCR3vT/2CdyEm3YLLfv3fee7p+y9zjonJ3vtulbNGUpLVdetM9NM77tPdcwY1YSEI6U9mOPRo1WnTVPX+x9o6tzN+sJzZbphgxExe7ZJ1ru36gsvqObm1lpdi6VaqjMEtYlQNgPoBXzgnLocSFHVe2vINwh4WFVHOsf3Aajq485xI8wYQnk85JZANjBWVasMOGDjEZx8lJYWkJp6ITk539Khw+O0bXtvBTfV1fLee2ReeycjY5eytqAN//2vMGKECXS2fr3yU9Nx9Cz42cSf7NDBw73zWb58ICUl++nffzkREa3rpHtR0S5SU8dRULCKxMQZtG49pfa6l7Nvn5lWtGqVid+5ahWsXWviIABERkKPHtC7N1sSzmHWnt/zaXIbfk0OJjoaJkyAxx+3sREsvlFdPILqavThbvvjgWed7aKq8lTKHwJsBTpwZLC4ezXpv8e2CE5ZysqKdc2aq5zumUnqcpXWPvNDD2k2jXVMl026YoXqE0+oirj0036PmC6Y77/3mM3lcmlq6iWalBSk2dnfea17aWmBrl59sSYloevWTahTq6JKiotVV640YwpTpqgOHarapMmRlkNwsC4Z8YBeM2a/9ulzZHB5w4Yqe78slmrBm64hYLnz+25VaWragDHARkzNf7pz7lFMrd8agnqGy1WmmzffrUlJ6OrVF2lp6cHaZlS95hrzuX74oZaUqC645FVz/MorVWbbsWOGJiWhO3bM8IvuW7c+qElJ6PLlg7W4OACrx1wu0+f1+eeqU6ceHnMoGTZS9euvNT/PpTExqqefbsYU8vP9r4Ll1MVbQ5AKXOUU4uMrb1XlC/RmDcHJz65dz2tSkmhy8tkV5vJXS1GRmZUTHq56553m0500qcrk2dnfaVJSkKamXlL7qau1IDPzQ/3hhwj96ad2mp+f4je5HsnJUX3ySTMYAlrc+wx9968/6YD+LgXVRo1MY2LXrsCqYTk1qM4QVDlGICKDgasx00c/O7pHSW+svkcqMNgxglODvXtnsW7dtURGJtKr1zwiItrWnGn/fjjrLOOpdOhQmDfPY2yBoqLdJCf3IzS0Kf36LSEkJNqvuuflLSM1dRxlZXl07TqTpk3H+lX+URQXw8yZMGMGrF+PtmvPLxfP4MWdF/LxpyH88otxgFdQAFFRJtiaxVIZr8YIyjfgpprSHMvNtghOHQ4c+F4XLmykixcnaH7+qtpl2rRJ9Y47zFoDD5SVFemyZWfqwoUNtaBgnR+1rUhR0W5dtmyAJiWJbt/+uF9bHVVSVqY6d67q735nWkRNmmjmXU+pZmWpquoNN6h276766qtmGqrF4g6+zBqqZFFeU9WJNacMHLZFcGpRUJBKSsooysry6dHjE2Jjh/okb+PGW0hPf4Xu3T+mWbOL/aSlZ8rKCtmw4Ub27v2QFi2upUuX1wgOPtq3karichVRWprjtuVWOC4rq3isWkarVrfSpMkfPc9SWrwYnnrKBNuJjISbbuL9xL/x9H+as2IFxMaasNCTJkG7dgF9DZaThOpaBHU1BMtV9bjGK7aG4NSjqGgXKSmjKSzcyOmn/4cWLa7wSk5Gxtts2DCBNm3uITHxST9r6RlVZceOv7N9+4NERfWmQYPOHgt61ZJq5YiEEhLS+PBWUrKPoqJtxMaOoFOn54mKqiIW1Lp18PTT8O67UFaGXnoZP414mBfmncacOcYQvPCCCaSjCsHBAXgJlpMCfxqCeao6ym+aeYE1BKcmJSUHSE29kNzchSQmPkObNlPrlD8/fwUrVhiPp716zScoKCRAmnomK2s2W7dORySYkJBGFQp19+Pg4EYezwcFRVSo+btcJaSnv8y2bQ/hcv1Gq1a30b79Q4SENPKsQHq6KfFfecW4Yh0+nF03/I2Q884hPkH49lu44QazTZgAHTsek9diOYHwmyE4EbCG4NSlrKyI9euvIyvrv7RuPYXExKcRqTmIXknJfpKTB6BaSv/+yYSFNT8G2h4bDh3KYtu26WRkvEFoaDM6dnycli1vqPq95ObCa6/Bc89BRgb06QN3382SVuN55MkI5s83rYPzzoMbb4TLL/c43m45BfHKEDgrf+8DLgSaY9xE7wXmAk+oak5g1K0eawhObVRdbN48hbS0F2nW7DK6dv0PQUHh1aQvIyXlAnJykujbdxExMQOPobbHjvz8ZDZtup28vJ+Ijh5Ap04v0qjRoKozFBfD+++bcYT16810ojFj2D3kGt7ZM5K3ZoZz8CDs2mViSO/ZAy1a2BlHpzLVGYLqqluzgAPAEFWNU9UmwHnOuVn+V9NiAZEgOnV6no4dnyIraxYpKaMoKam6zrF9+yMcODCfzp3/ccoaAYDo6P707fsjXbu+R3FxOitW/I51666juDjdc4bwcNMHtGYNfP01XHstLFxI60njmP5UIzZ1G8fPd35MSF42ZWUwYAD07g3PP288YljqF9W1CDao6ml1vRZobIug/pCZOZP16yfQoMHp9Or1FeHhrSpc37fv/0hNHUvLlhM47bQ36+4D6CSltLSAnTv/l127niEoKIx27R6gdevJ1bacACgrg59/htmzYc4c2LkTQkI4dO75vN1yGm+uPYtfV4QRGgrjxsG0aWZ9guXUwNuuoQXAN8A7qprpnGsB3ACcr6rDA6Nu9VhDUL/Izv6GNWvGExLSmF69viIqqjsABw9uJjl5AJGRifTt+yPBwZHHWdNjT2HhFjZvnsr+/Z8RGdmJxMTnaNLkgtoZRFVITjZGYfZsE2dThNS+1/JW9B28u7o3784MZtQoM9Rw8CAkJgb+mSyBw1tDEAtMA8ZhxggAMjGrjJ9U1ewA6Foj1hDUP/LzV7J69WhcriJ69PiM6Oh+LF8+iOLiNPr3TyYysv3xVvG4kp09n02b7qCwcANxcaPp1Ok5GjSoQ4Nd1XQhlbcUUlI4RCjB/fsSfMlF3Lt1Ik+9Hse555oB5gsvhJiYWsr97TfT17R/v/l13y8thTvuMIMTloBjZw1ZTnoKC7eTkjKKoqLtxMScQW7uYnr1mkdc3IjjrdoJgct1iLS0f7J9+yO4XAdp1eoO2rd/kJCQ2pTYldi0yRiEOXPg119JI4F3mt/DWyXXsuVAHGGhLsb/LpMP/vxd1YV8+X5xsed7lLdazj4bvvvOTl06BvjdEIjIBFX9t8+aeYE1BPWXkpL9rF49lry8n+jQ4e+0azf9eKt0wnHoUCZbt97Pnj3/JjS0uTPd9PpaTcP1yK5dh42CLlzETwxiNhejCM9h1nrczKv0idrERS1/pmVLoEkTaNrUbFXtN24Ms2bBVVeZVsHzz/vvJVg8EghDsFNVa+ElzP9YQ1C/KSsrJDd3MbGxQ70v3OoBeXlL2bz5dvLyfiE6+gzatLmHpk3HEhQU5r3QzEz4/nvj0sIp2HPDmjFwVCwbNwoipoI/fjxcdhm0alWjRJg82SyEe/99uPJK73Wz1Ii3YwQpVckDuqhqDVMUAoM1BBZL7VB1kZk5k23bHqC4eCehoc2Jj7+R+Pg/ERnpv5Hf8iGGOXPMMENKCrz9Nlx//ZGeotOqGrIoKYFhw8zA9S+/QM+eftPLUhFvDUEmMBKzbqDCJeAnVU3wq5a1xBoCi6VuqJaRnT2f9PTX2L//c6CM2NjhxMff7HsrwQObN5vx3+hoU9mfPBm6d4eLLzZbz56VFq7t2QP9+plFb0uXmm4ji9/x1hC8CfxbVX/0cO19Vb3Kv2rWDmsILBbvKS5OIyPjLTIy3jjcSmjZcgLx8X+iQYNOfr9fWtqRyUiLFhn3Fl26mLDNEe6OWhcvhiFDYPRo+PRTCLLdfv7GzhqyWCwVMK2EBaSnv1qplTCRpk3H+b2VALB3L8ydCxs3mhg7APPnw/DhjlfUf/wDbr8dHnsMHnjA7/ev71hDYLFYquRYtxLKWboUBg403UXvvQcR4WpcYbz/Pnz1FYwcGbB710esIbBYLDVS3krIyHiNffv+DyijceNhJCTcHLBWwnPPwdSpcM45prUQG/YbDBpk+pSSk6F9e7/fs77irdM5f9x4lIhsEJHNIjLNw/W/iMhqEVkpIj+KSLdA6mOxWKpGJJgmTUbTo8cnDBq0g/btH6OwcBNr117Gzz+3ZsuWezl4cCP+rDxOmQIffghLlsDgwbBzf5QZUCgrM/NQCwv9di9L1QSsRSAiwcBG4HxgN7AUuFJV17qliVHVPGd/LPDXmgLf2BaBxXLs8NRKCAqKJDy8FeHhrQkLM7/lx0fOt8AUAbXj+++N64oXX4TrrgM+/xz++EcTSeett6x/bD9QXYsgkGGcBgKbVXWro8SHGL9Fhw1BuRFwiMLEPLBYLCcI5a2EJk1GU1ycTlbWHIqKtlNcvJtDh9LIy1tMcXGah1CcwYSHx9dgLBIOx3geMsR4tmjWzOTOPecPNPrb38zA8Vlnwc03H9Pnrm8E0hC0Ana5He8GzqycSEQmAVOBMMBj5HIRmQhMBGjb9rgsaLZY6j3h4Qm0bn3rUedVXZSU7KO4eDfFxWnO75H9gwfXcODAfMrKCirkEwmjS5dXiY+/AThiBJYuhREj4JWXH+byUUvhtttMpLUzjyo+LH7i2AZ29YCqvgS8JCJXAQ8A13tI8xrwGpiuoWOrocViqQ6RIMLCmhMW1pzo6H5VpistzatgJDIz/8OGDTcRHNyQ5s0vOZyuUyez6OyKq4JI//vHTFnfAy65xAweNz91wpCeSARysDgNaON23No5VxUfYsJiWiyWU5CQkBiioroRFzeC+PgJ9Oz5OTExg1i37ir27593OF1sLCxYYKaVTn0gijsHL8GVtR+uuMK4rj7Byc8/sj9qFEycaCZBncgE0hAsBTqLSAcRCQOuwMQyOIyIdHY7vADYFEB9LBbLCURwcBQ9e35OVFR31qwZT07OosPXIiLgo4/g1lvh2fea8841X0NSEkw/8TzOulymO+vhh+GMM4yzvXLv26NHG79LnTvDffdBznGJ9F4LVDVgGzAGM3NoCzDdOfcoMNbZfwFYA6wEkoDuNcns37+/WiyWU4fi4r26ZMnpunBhtObmLq1wzeVS/fhj1dJSVb3lFlUwJ04QZs9WbdHCqCWiOmiQ6mOPqebmHkmzZYvq1VebNLGxqvPmHR9dgWVaRblqF5RZLJbjTlHRblasGExZWQF9+y4kKuroJUVpW4u5uf9SXj10I62WzYWuXY+Zfqqwbh18+SV88QXcfz+cfz4sWwbPPgtjxphuoKZNnQx5ebBiBaSmQsuW0KMHK/MTefDREF56Cdq0gawsiItz3GscA+zKYovFcsJz8OBmVq48BxD69v2RyMiOFa4vWgRjRruILUxnXru/0G3VB8bFaQDJzzddOl98Adu3m3M9e8Lf/w5jxzqJ8vJg+XIzmF2+bdx4tLCwMDj9dOjRA+3WneEf/ZnMokY88XQIF/wxKOBLJawhsFgsJwUFBamsXHkuISGN6Nt3EeHhFaPbrFgBo4cd4tCBAj4791kGJz3mt8VmBw6YuAorV5rImTffbPr/ExNN4X/BBTB6cD5ts5KrLvRbt4b+/c02YIDJuGePEbxmjWkhrFmD7tzJbC7mfv6XTXThnIbLefKczxk0JML47O7RA9q29etCOmsILBbLSUNe3lJWrRpGeHhr+vT5gbCwZhWub9sGo87MZkdWA76a+CnnvXpFHeWbCJzdu5vjSZPgk08gI+NImiFDIGmuqem7liYTtKKaQn/AgCOFf22nt+bnw9q1lKxcwxuzYnjkx6FkHorjA67gCj4yaRo2hG7djhiG7t3NPQ73P9UNawgsFstJRU7OD6SkjKJBg2706fMdISGNKlzfl6XcM/B7nt1xMY2/+RiGelyLCsC338K8eUcq5Tt3mimq+/eDFBXy0F2/sX1DMd1jdtEjZD3dC5fRdsPXyCY/Ffq1oKAAXnoJJl11gIY717Lsi0zi96yg1Y6fjNKZmSbhP/9pLJcXWENgsVhOOvbv/5LU1HHExJxFr17zCQ5uUDFBfj6ceSaFWQW8efsqGneIPdz7snatCZkZ5cpn2uQinn83jtObH6BHzE66B6+ne1Eyf8idSVBWZkWZISFmJLdXr4AV+jWhCr17G5cbkyfDvfdC49J9xiAkJhqj5AXWEFgslpOSvXtnsXbtlcTGnk/PnnMJCqoUKn39el7v8xITi/8BQGhQKV2i0ukevJ4XuIOWOespIIoIigihDMLDoV27I1v79hV/ExKO3TSeati2DR58EGbONJE777/frKmoENWtjlhDYLFYTloyMt5iw4abaNr0Yrp1+5CgoIqecXT2HH69dAbRmkvnBumEtm/luZBv397U7AMUBrOsrJCioq0UFm6hsHAzhYVbKC7eTWzsUFq0uJ7Q0LrHYl650sxamjfPGIWrfAgQbA2BxWI5qdm163m2bJlCy5Y3cNppbyJSqTDfs8d06zRpElCX1SUlORQVbalQ2Jf/HjpU0Y9EcHAjQkObUlS0haCgBrRocRUJCZOIju5T5/suXmycsPrSWDlebqgtFovFL7RpM5mysjy2b3+I4OBoOnV6AXEv8Fu29Nu9Dh3KorBwo8fCvrR0f4W0YWEtiYhIJDZ2OJGRic7WicjIREJC4hAR8vOXk5b2MpmZM8nIeIOYmEEkJPyV5s0vPbqrqwrOPttvj+cR2yKwWCwnBarKli13sXv3s7Rr9wAdOjzmF7llZUXk5i4iO3s+Bw7M57ffUt2uBhER0ZaIiCMFfHlhHxHRkZCQhrW+T0nJAfbseYf09JcpLNxEaGhT4uP/RHz8zURGtvfLs1SH7RqyWCynBKrKxo0Tych4g44dn6Jt27u9knHw4PrDBX9Ozg+4XIWIhNGo0WBiY8+nYcNeTmHf3u+xmlVdHDjwLenpL7Nv32eA0qTJBSQkTCIubsTR3V5+wnYNWSyWUwIRoUuXVygtzWfr1nsICYkhIaHm6GUlJQc4cOAbp/BfQHGxiZkVGdmF+Pg/ERc3ksaNhxAcHBXoR0AkiLi484mLO5+iol2kp79KRsbr7N//ORERHUlIuIX4+AmEhjYJuC6HdbItAovFcrLhcpWQmnoR2dlf0rXrTFq0uLLS9VLy85cervXn5f0KuAgObkRs7DDi4kYSGzvimHTJ1AaX6xBZWXNIT3+Z3NxFBAVF0Lz5FSQk/JWYmDP8cg/bNWSxWE45ysoKWb16DDk5i+jRYw4NG/YhO3s+2dnzycn5ltLSHECIjh5IXNxI4uJGEB195lHTT080CgpWk57+Mnv2vIvL9RvR0QNISJhE8+aXExwc6bVcawgsFsspSWlpPqtWDSc/fylgyrKwsFZOwT+S2NjhhIbGHV8lvaS0NI/MzHdJS3uJgwfXERISS+fOLx3V+qktdozAYrGckoSERNOr11ds2zadyMjOxMWNpEGDbhWnlp6khITE0KrVJBIS/kpOzg+kp79MRET7wNwrIFItFovlGBEaGkeXLv863moEDBEhNnYIsbFDAnaPQMYstlgsFstJgDUEFovFUs+xhsBisVjqOQE1BCIySkQ2iMhmEZnm4fpUEVkrIiki8q2ItAukPhaLxWI5moAZAhEJBl4CRgPdgCtFpFulZCuAAaraC/gYeCpQ+lgsFovFM4FsEQwENqvqVlU9BHwIjHNPoKpJqnrQOfwF8C70jsVisVi8JpCGoBWwy+14t3OuKm4CvvJ0QUQmisgyEVmWlZXlRxUtFovFckIMFovINcAAYIan66r6mqoOUNUBzZo1O7bKWSwWyylOIBeUpQFt3I5bO+cqICLDgenAuapaXJPQ5OTkfSKyw0udmgL7vMxrZVlZJ6ssf8uzsk5OWVVPxlHVgGwYI7MV6ACEAauA7pXS9AW2AJ0DpUel+y2zsqys+ibrRNbNyjq+30X5FrCuIVUtBW4F5gPrgFmqukZEHhWRsU6yGUBD4L8islJEPguUPhaLxWLxTEB9Danql8CXlc496LY/PJD3t1gsFkvNnBCDxceQ16wsK6seyvK3PCvr1JB1mJMuHoHFYrFY/Et9axFYLBaLpRLWEFgsFks9p14YAhFpIyJJjoO7NSJyhw+yIkTkVxFZ5ch6xA/6BYvIChH53Ec520VktTMDy6d4niLSWEQ+FpH1IrJORAZ5Kec0R5/yLU9EJvug1xTnvaeKyAciEuGDrDscOWvqqpOIvCUie0Uk1e1cnIh8LSKbnN9YH2Rd6ujlEhGP4QXrIGuG83dMEZFPRKSxD7Iec+SsFJEFIpLgrSy3a3eKiIpIUx/0elhE0ty+szG+6CUitznvbI2I1MoHWhV6feSm03YRWemDrD4i8kv5/7eIDKyNrFoRiDmpJ9oGxAP9nP1oYCPQzUtZAjR09kOBJcBZPuo3FXgf+NxHOduBpn56Z+8Af3L2w4DGfpAZDOwB2nmZvxWwDYh0jmcBN3gpqweQCjTAzJ77BuhUh/y/B/oBqW7nngKmOfvTgCd9kNUVOA34HuOY0Re9RgAhzv6TPuoV47Z/O/CKt7Kc820wU8x31PbbrUKvh4G7vPgOPMk6z/kewp3j5r48o9v1Z4AHfdBrATDa2R8DfO/Nt+9pqxctAlXNUNXlzn4+Zl1DdX6PqpOlqlrgHIY6m9cj7iLSGrgAeMNbGf5GRBphPsQ3AVT1kKrm+EH0MGCLqnq7MhxMoR0pIiGYQjzdSzldgSWqelDNmpcfgPG1zayqC4HsSqfHYQwozu+F3spS1XWquqG2+tQga4HzjFAH545VyMpzO4yilt9+Fe8L4DngntrKqUFWnalC1i3AE+p4OlDVvb7qJSICXAZ84IMsBWKc/UZ4/+0fRb0wBO6ISHvMiuYlPsgIdpp4e4GvVdVrWcDzmH8Elw8yylFggYgki8hEH+R0ALKAfztdVm+ISJQf9LuCWv4jeEJV04CngZ1ABpCrqgu8FJcKnCMiTUSkAaaG1aaGPDXRQlUznP09QAsf5QWCG6nCuWNtEZH/EZFdwNXAgzWlr0bOOCBNVVf5oo8btzrdVm/VtluuCrpgvo0lIvKDiJzhB93OATJVdZMPMiYDM5x3/zRwnx/0AuqZIRCRhsBsYHKlmk2dUNUyVe2DqVkNFJEeXurzB2CvqiZ7q0slBqtqP0wMiEki8nsv5YRgmqX/UtW+wG+Yrg6vEZEwYCzwXx9kxGJq3R2ABCBKjMPCOqOq6zDdJAuAecBKoMxb3TzIV3xoKQYCEZkOlAIzfZGjqtNVtY0j51YvdWkA3I8PhqQS/wISgT6YSsIzPsgKAeKAs4C7gVlOjd4XrsSHSpDDLcAU591PwWmx+4N6YwhEJBRjBGaq6hx/yHS6S5KAUV6KOBsYKyLbMfEahorIez7ok+b87gU+wcSE8IbdwG63ls7HGMPgC6OB5aqa6YOM4cA2Vc1S1RJgDvA7b4Wp6puq2l9Vfw8cwIwd+UKmiMQDOL+16lI4FojIDcAfgKsdI+UPZgIXe5k3EWPQVznff2tguYi09EaYqmY6FTQX8Dref/tgvv85Tjfwr5jWeq0Gsj3hdGOOBz7yQSeA6zHfPJgKld8Gi+uFIXCs+ZvAOlV91kdZzcpnXYhIJHA+sN4bWap6n6q2VtX2mG6T71TVqxquiESJSHT5PmaA8KgZGrXUaw+wS0ROc04NA9Z6I8sNf9SIdgJniUgD5286DDPe4xUi0tz5bYv5R33fR/0+w/yz4vzO9VGeXxCRUZjux7F6JBCUt7I6ux2Ow/tvf7WqNlfV9s73vxszoWOPl3rFux1ehJffvsOnmAFjRKQLZrKEL95DhwPrVXW3DzLAjAmc6+wPBXzpZqqIv0adT+QNGIxppqdgugBWAmO8lNULE2IzBfOx1WoWQC3kDsGHWUNAR4yH11XAGmC6j/r0AZY5z/kpEOuDrChgP9DID+/pEUzhkwq8izOzw0tZizAGbhUwrI55P8B0QZRgCrGbgCbAt84/6DdAnA+yLnL2i4FMYL4PsjZjgkSVf/u1nenjSdZs592nAP8HtPJWVqXr26n9rCFPer0LrHb0+gyI90FWGPCe85zLgaG+PCPwNvAXP3xfg4Fk53tdAvT39f+pfLMuJiwWi6WeUy+6hiwWi8VSNdYQWCwWSz3HGgKLxWKp51hDYLFYLPUcawgsFoulnmMNgcWvOF4kn3E7vktEHvaT7LdF5BJ/yKrhPpeK8bia5AdZk51VtN7m71NbT5pueb6XOngstVisIbD4m2JgfG1dCh8rnNWdteUm4M+qep4fbj0Z4xzPW/pg/CBZLAHDGgKLvynFxFWdUvlC5Rq9iBQ4v0Mc515zRWSriDwhIleLifuwWkQS3cQMd3yxb3R8NZU7AZwhIksdp2M3u8ldJCKf4WFltIhc6chPFZEnnXMPYhbuvCkiMyqlF+c+qU6+y93u87lbun+KyA0icjvGJ1JSeetCRApE5Dkxfu6/FZFmzvnDtXgRaSrGd30Y8ChwuRgf9JdX0idYRJ529EkRkds8POO/nPdVIXaG847XOvmeds5d6shaJSILa3i38SKy0NErVUTOqXxvy8lDXWpJFktteQlIkVoG9HDojXENnQ1sBd5Q1YFiggjdhqlZA7TH+FhJxBSwnYDrMJ5IzxCRcGCxiJR7Je0H9FBJWWYnAAADWElEQVTVbe43ExNQ5UmgP8bP0AIRuVBVHxWRoRjf9pWD+4zH1NB7Y3zPLC0vMD2hqi+KyFTgPFUtd1EQBSxT1SmO0XmIKhy3qeohJ80AVfWUZqLzPvqoaqmIxHlIM11Vs0UkGPhWRHoBaZiVy6erqsqRQDUPAiNVNc3t3E14frfjMaud/8eR7Uurx3KcsS0Ci99R49n1P5jAJbVlqZq4EcXAFoxXUDBuA9q7pZulqi417ny3Aqdj/CpdJ8Y1+BKMq4dynzi/VjYCDmdgAntkqfHVPxMTg6E6BgMfqHFulomJYVBXF8Uujjgfe8+R6S3DgVcd/VFVT77wLxOR5Ri3KN2BbkAuUIRp9YwHyv0PLQbeFpE/Y4IIQdXvdikwwRn/6akmzoflJMUaAkugeB5Tm3SPY1CK882JSBDGp0s5xW77LrdjFxVbrpV9oigmatxtqtrH2TrokTgFv/n0FLXj8HM51CV8ZvnzuMvwOvymOyLSAbgL40epF/AFEOEYjoEYr7J/wLjhRlX/AjyAicuQLCJNqOLdqgmc8ntM6+JtEbnOHzpbjg/WEFgCglM7nYUxBuVsx3TFgIlNEOqF6EtFJMgZN+gIbMCEOrxFjKtxRKSL1BxI51fgXKc/PhjjHfWHGvIswvTXBzt9+7935OwAuolIuNOlMswtTz4mPGo5QUD5OMlVwI/O/naOvBv3mVGV87vzNXBz+UC4h66hGIwhzBWRFhhX4OVxORqp6peYsZzezvlEVV2iqg9iAhOVh5E86t2KSDtMoJXXMdH1fHVTbjmO2DECSyB5hor9368Dc0VkFaYW6k1tfSem8I3BeHQsEpE3MN1Hy0VEMIVYtWEiVTVDRKZh4kkI8IWq1uQ2+hNgEMb7owL3qOM2WURmYbxVbsN0w5TzGjBPRNKdWUi/YYIZPYCJV1A+APw0JgDKREzNvZwkYJrTNfO4qrr7tH8DE00rRURKMO/3n27PuEpEVmC8te7CdP2AMSxzRSTCefapzvkZYtxMC8aL6iqMN8/2HP1uhwB3O/ctwIzTWE5SrPdRi+UYIiIFqtrweOthsbhju4YsFoulnmNbBBaLxVLPsS0Ci8ViqedYQ2CxWCz1HGsILBaLpZ5jDYHFYrHUc6whsFgslnrO/wP/U6KIX7D6fQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description
- Compared 10-fold cv average accuracy of CMGF-EKF against one-pass and many-pass SGD
- Compared training speed vs dataset size of CMGF-EKF against one-pass and many-pass SGD
- Implemented multinomial logistic regression as $(K-1)$ binary CMGF-EKF regressions and performed the equivalent comparisons.
- Overall, CMGF-EKF performs comparably to many-pass SGD in terms of accuracy, and trains faster than many-pass SGD (though slower than one-pass SGD) given a large enough dataset.
- Switching multinomial logistic regression to $(K-1)$ binary logistic regressions does not seem to help with speed.


## Figures
![multilogreg_accuracy](https://user-images.githubusercontent.com/16075389/189803335-9b31cb7d-4bab-4077-8955-5151dc525270.jpg)
![multilogreg_speed](https://user-images.githubusercontent.com/16075389/189803342-903eb5de-f64e-42ad-9a3b-10fc3a1022d6.jpg)

![one_vs_all_accuracy](https://user-images.githubusercontent.com/16075389/189803353-b28a8559-ccba-4831-9ce7-bebb558ba950.jpg)

![one_vs_all_speed](https://user-images.githubusercontent.com/16075389/189803362-3c899347-6c8c-4fc4-883f-c87dcca63ffd.jpg)

## Issue 
#208 
