### PR TITLE
Fix tests failing because of NormalInverseGamma bug

### DIFF
--- a/ssm_jax/distributions.py
+++ b/ssm_jax/distributions.py
@@ -344,6 +344,11 @@ def iw_posterior_update(iw_prior, sufficient_stats):
 
 class NormalInverseGamma(tfd.JointDistributionSequential):
 
+    def __new__(cls, *args, **kwargs):
+        # Patch for tfp 0.18.0. 
+        # See https://github.com/tensorflow/probability/issues/1617
+        return tfd.Distribution.__new__(cls)
+
     def __init__(self, loc, mean_concentration, concentration, scale):
         """
         A normal inverse gamma (NIG) distribution.


### PR DESCRIPTION
Add the tfp bug fix to the `NormalInverseGamma` class to match other distributions which inherit from `tfd.JointDistributionSequential`.

This resolves 3 tests which were failing under tfp version 0.18:
 > ssm_jax/distributions_test.py::test_normal_inverse_gamma_vs_normal_inv_wishart
 > ssm_jax/distributions_test.py::test_normal_inverse_gamma_log_prob
 > ssm_jax/hmm/models/test_models.py::test_sample_and_fit[GaussianMixtureDiagHMM-kwargs5-covariates5]
