### PR TITLE
Add relative tolerance to the monotonically increasing check

### DIFF
--- a/ssm_jax/distributions.py
+++ b/ssm_jax/distributions.py
@@ -344,6 +344,11 @@ def iw_posterior_update(iw_prior, sufficient_stats):
 
 class NormalInverseGamma(tfd.JointDistributionSequential):
 
+    def __new__(cls, *args, **kwargs):
+        # Patch for tfp 0.18.0. 
+        # See https://github.com/tensorflow/probability/issues/1617
+        return tfd.Distribution.__new__(cls)
+
     def __init__(self, loc, mean_concentration, concentration, scale):
         """
         A normal inverse gamma (NIG) distribution.

--- a/ssm_jax/hmm/models/test_models.py
+++ b/ssm_jax/hmm/models/test_models.py
@@ -32,7 +32,7 @@ def test_sample_and_fit(cls, kwargs, covariates):
     params, param_props = hmm.random_initialization(key1)
     states, emissions = hmm.sample(params, key2, num_timesteps=NUM_TIMESTEPS, **covariates)
     fitted_params, lps = hmm.fit_em(params, param_props, add_batch_dim(emissions), **add_batch_dim(covariates), num_iters=10)
-    assert monotonically_increasing(lps, atol=1e-3)
+    assert monotonically_increasing(lps, atol=1e-3, rtol=1e-3)
     fitted_params, lps = hmm.fit_sgd(params, param_props, add_batch_dim(emissions), **add_batch_dim(covariates), num_epochs=10)
 
 

--- a/ssm_jax/utils.py
+++ b/ssm_jax/utils.py
@@ -40,8 +40,9 @@ def pad_sequences(observations, valid_lens, pad_val=0):
     return dataset
 
 
-def monotonically_increasing(x, atol=0):
-    return jnp.all(jnp.diff(x) >= -atol)
+def monotonically_increasing(x, atol=0, rtol=0):
+    thresh = atol + rtol*jnp.abs(x[:-1])
+    return jnp.all(jnp.diff(x) >= -thresh)
 
 
 def add_batch_dim(pytree):


### PR DESCRIPTION
As described in #221 this adds an `rtol` argument to `monotonically_increasing` which makes the check slight more permissive:
```python
def monotonically_increasing(x, atol=0, rtol=0):
    thresh = atol + rtol*jnp.abs(x[:-1])
    return jnp.all(jnp.diff(x) >= -thresh)
```

This resolves the previous failing test on `MultivariateNormalDiagHMM`.