### PR TITLE
Add parallel inference algorithms for lgssms.

### DIFF
--- a/ssm_jax/containers.py
+++ b/ssm_jax/containers.py
@@ -12,7 +12,7 @@ class GSSMPosterior:
                 Cov[x_t | y_{1:t}, u_{1:t}].
             smoothed_means: (T,D_hid) array,
                 E[x_t | y_{1:T}, u_{1:T}].
-            smoothed_covs: (T,D_hid,D_hid) array of smoothed marginal covariances,
+            smoothed_covariances: (T,D_hid,D_hid) array of smoothed marginal covariances,
                 Cov[x_t | y_{1:T}, u_{1:T}].
             smoothed_cross: (T-1, D_hid, D_hid) array of smoothed cross products,
                 E[x_t x_{t+1}^T | y_{1:T}, u_{1:T}].

--- a/ssm_jax/linear_gaussian_ssm/demos/lgssm_parallel_inference.ipynb
+++ b/ssm_jax/linear_gaussian_ssm/demos/lgssm_parallel_inference.ipynb
@@ -1,0 +1,773 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "VmddSCQsVn37",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "VmddSCQsVn37",
+    "outputId": "c9aefbe5-c83b-4446-d522-21d8b986e7f2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[K     |████████████████████████████████| 185 kB 7.8 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 115 kB 45.9 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 85 kB 3.1 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 145 kB 54.0 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 128 kB 51.7 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 237 kB 52.4 MB/s \n",
+      "\u001b[K     |████████████████████████████████| 51 kB 6.9 MB/s \n",
+      "\u001b[?25h  Building wheel for ssm-jax (PEP 517) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import ssm_jax\n",
+    "except:\n",
+    "    %pip install -U -q git+https://github.com/probml/ssm-jax.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc7de09a-aa24-4702-816f-4e1b21fcdaa3",
+   "metadata": {
+    "id": "dc7de09a-aa24-4702-816f-4e1b21fcdaa3"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import jax\n",
+    "from jax import numpy as jnp\n",
+    "from jax import scipy as jsc\n",
+    "from jax import random as jr\n",
+    "from jax import vmap, tree_map, config, block_until_ready\n",
+    "from jax.lax import associative_scan\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zDGSCr7Oc9hk",
+   "metadata": {
+    "id": "zDGSCr7Oc9hk"
+   },
+   "source": [
+    "# Parallel filtering and smoothing in a linear Gaussian state-space model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "YmYQat2xdEZl",
+   "metadata": {
+    "id": "YmYQat2xdEZl"
+   },
+   "source": [
+    "This code borrows heavily from this [example notebook](https://github.com/EEA-sensors/sequential-parallelization-examples/blob/main/python/temporal-parallelization-bayes-smoothers/parallel_kalman_jax.ipynb) from [Adrien Correnflos](https://github.com/AdrienCorenflos). Some small changes have been made here and it has been updated to work with ssm-jax.\n",
+    "\n",
+    "The parallel inference functions implemented below are available in the ssm_jax library in `ssm_jax.linear_gaussian_ssm.parallel_inference`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "815775f5-a63a-4187-ad74-f74d22a29ed3",
+   "metadata": {
+    "id": "815775f5-a63a-4187-ad74-f74d22a29ed3"
+   },
+   "outputs": [],
+   "source": [
+    "from ssm_jax.linear_gaussian_ssm.inference import LGSSMParams, lgssm_filter, lgssm_smoother, lgssm_sample\n",
+    "from ssm_jax.linear_gaussian_ssm.models import LinearGaussianSSM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "xLMBEd3Td_qI",
+   "metadata": {
+    "id": "xLMBEd3Td_qI"
+   },
+   "source": [
+    "## Model\n",
+    "The model is a simple tracking model (see Example 3.6 in *Bayesian Filtering and Smoothing* (S. Särkkä, 2013)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6357a126-28b7-4e08-9814-9ff1f7a9ce7d",
+   "metadata": {
+    "id": "6357a126-28b7-4e08-9814-9ff1f7a9ce7d"
+   },
+   "outputs": [],
+   "source": [
+    "dt = 0.1\n",
+    "F = jnp.eye(4) + dt * jnp.eye(4, k=2)\n",
+    "Q = 1. * jnp.kron(jnp.array([[dt**3/3, dt**2/2],\n",
+    "                      [dt**2/2, dt]]), \n",
+    "                 jnp.eye(2))\n",
+    "H = jnp.eye(2, 4)\n",
+    "R = 0.5 ** 2 * jnp.eye(2)\n",
+    "μ0 = jnp.array([0.,0.,1.,-1.])\n",
+    "Σ0 = jnp.eye(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25027aea-e80f-49a8-a271-142458fa03ae",
+   "metadata": {
+    "id": "25027aea-e80f-49a8-a271-142458fa03ae"
+   },
+   "outputs": [],
+   "source": [
+    "latent_dim = 4\n",
+    "observation_dim = 2\n",
+    "input_dim = 1\n",
+    "\n",
+    "lgssm_params = LGSSMParams(\n",
+    "    initial_mean = μ0,\n",
+    "    initial_covariance = Σ0,\n",
+    "    dynamics_matrix = F,\n",
+    "    dynamics_input_weights = jnp.zeros((latent_dim,input_dim)),\n",
+    "    dynamics_bias = jnp.zeros(latent_dim),\n",
+    "    dynamics_covariance = Q,\n",
+    "    emission_matrix = H,\n",
+    "    emission_input_weights = jnp.zeros((observation_dim, input_dim)),\n",
+    "    emission_bias = jnp.zeros(observation_dim),\n",
+    "    emission_covariance = R\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f46ac96e-5068-4136-a3ba-b952d86d47b9",
+   "metadata": {
+    "id": "f46ac96e-5068-4136-a3ba-b952d86d47b9"
+   },
+   "outputs": [],
+   "source": [
+    "num_timesteps = 100\n",
+    "key = jr.PRNGKey(0)\n",
+    "inputs = jnp.zeros((num_timesteps,input_dim))\n",
+    "\n",
+    "key, subkey = jr.split(key)\n",
+    "z,emissions = lgssm_sample(subkey,lgssm_params,num_timesteps, inputs)\n",
+    "ssm_posterior = lgssm_smoother(lgssm_params, emissions, inputs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d548207-2976-492c-b95a-88d5d08138db",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 265
+    },
+    "id": "9d548207-2976-492c-b95a-88d5d08138db",
+    "outputId": "f79cf911-296f-43b2-f8c8-f091c4ea1ba8"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAD4CAYAAAAJmJb0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3hUZfbA8e87LRXCkAQSSKG3BAyEKqggiqgoIOpSVFgpuqCuZe2K+wN1d1VERawgqxhQqrgoICA2pIZOIEhLCC2kQAipk3l/fyTBEJJQkskkM+fzPHk2M/fOvec668nrue89r9JaI4QQwjUZnB2AEEIIx5EkL4QQLkySvBBCuDBJ8kII4cIkyQshhAszOTuAkgICAnSTJk2cHYYQQtQqsbGxKVrrwLK21agk36RJEzZv3uzsMIQQolZRSiWUt03KNUII4cIkyQshhAuTJC+EEC5MkrwQQrgwSfJCCOHCJMkLIYQLc5kkH5uQzvQ1+4lNSHd2KEIIUWPUqHnyVys2IZ0RM9aTZ7NjMRmIGdOd6HCrs8MSQginc/hIXinVXykVr5Tar5R6zhHnWH8wlTybHbuGfJud9QdTHXEaIYSodRya5JVSRmA6cCvQDhimlGpX1efp3swfi8mAUYHZZKB7M39ASjhCCOHock1XYL/W+iCAUuorYCAQV5UniQ63EjOmO+sPptIjvA6dNj3Fic2BjNh2A3k2fckSTmxCOusPptK9mb+UeYQQLsXRSb4xcKTE6ySgmyNOFB1uJTrcSnxKHEsPLePa7BxWGxbwAM9y2Nb4fAmndDKXer4QwpU5/carUmocMA4gLCys0sf7LmE5sxoEoLQmIi+P7uemcyxrLHW92pSZzMuq50uSF0K4CkffeD0KhJZ4HVL03nla60+01p211p0DA8vslHlFHu/0OHNvn8vfoiaQ49+e/9XXmEI+Zuq+vxAY9DZG6y8UmBL5/UAyUH49vyaQewpCiMpSWmvHHVwpE7AP6Ethct8EDNda7y5r/86dO+uqbjV8JvcMm09sZtXv77Ircx+HLWYAvIw+dLL40cm7Mb6h93MqpQG9WjSqklF8VdT4pYwkhLhcSqlYrXXnsrY5tFyjtbYppR4BVgBG4LPyEryj+Hn40Te8L31DrufYt5Mw7ZrOemso29p2Y+vB5UzLPgapmzAqIz+eaYVPbHOuC+3MoLbXEuQThFLqis5XVclZykhCiKrg8Jq81vp74HtHn+eSjGYaDZ4MUTdz56Jx3Pn7HBI7P4/fpsls9fDgY48odpzLweC5nJ1nl/JBHAR6BXJN4DW0D2xP+4D2RPhH4G32rvA0VZWci8tI+TZ7jSsjCSFqD6ffeK12Ta+Hh9fC8uf4UXVjUvaXRGQfJE43wY6B50xf0N3rJ371b8VRawO2p+1hVeIqAAzKQDO/ZkQGRBLpH0lEQAStrK2wGC3nD19VybnktFCZ2imEuFoOrclfKUfU5CtSXFrJt9kxGhQaaGFPYLB5LSPrbsUjMwmMFtLbDmB3j9HsPLWTHclb2Z26m/S8DABMykAr3zDaBXcmwj+Cdv7tOJsRwObDGZKchRDVoqKavFsnefjzJqnV28LEJTux2cFkgK/H9SDadAh2LwJlgH6TwW6HVwPRdhvHTUZ2WSzs9rCwu0Fz4nQuZ/PPAmA2mGllbUU7/3bnf1rWa8mOpMyLR+ZZaeBdv/B3reEK7wE4gjwcJkTtIkn+MryweCdzNiSefz28WxivD25/8Y4bPgGLN/gEgk8AeNYDTz+0tz9H9n5D3NLxxHl4EucXQJzBzll7HgAmZSYvuyE+OfVonaeZ0FATnRaH+VwKPJcIRjMsHAt55yBqGLS8BUyWi8/vYDKrR4jax2mza2qT0uPncsfT3caV+/mw1ncS5hNM//jvIX4Z9pT9JJlMxPWfxJeJxzlxbg1ZdRLZZjQwVoOHVdE6OIKIDf8ismEUkb5Wmuz8GUP8d+Blhcgh0PF+aBRVhVdaMZnVI4RrkSRf5K5OIcyPTTp/w/SuTiFXfhCDEcK6F/7cPAnDuVTC0g8R1qAdgYG5vDIjjM72eDZZgglp40tgwClS8g/wzaGlzP1jPgC+jfyJ8I4kMuss7ffOo73ZQoNGUVCQDxlHwdqkyq65rLKMzOoRwrVIuaYER9WiS9b9dx87w/zNR7DZ/2ycFhVal8MZh9mZspNdKbvYmbKTfWn7sGkbAPU9Aon2CaL9/l9o79eSdh3H4B01vFL1+4rKMlKTF6J2kXLNZSpuclaVSifTIZ1CsNn1ReWQ5vWa07xecwa1GATAuoMneHDuNxSYE0jxPsI2jrOyvhVIwbj9X7TYPoX2Yb3pEHodHQI70NSvKQZ1+V0qKirLOOKfgxDCOSTJO1jpZKrhssohWxIyyc0Mxa5DKUiHIRGtGdajPjuTt7Nj1xx2Jv3GisSVLDiyEgBfsy8RARF0COhAh8AOtA9oj7/XhccuOUIvXZaxeluYvma/jN6FcDGS5B2sdDId0imEIZ1CLlkOKas2Xt/Tyg1hfbghrA+cS8F+OoHvzhhY9cfvmAs2kZidyme7PqNAFwAQ4htCh8DCpO9Z0JwXv04hz6bOl2eKH7ayeluYtHS3zKgRwgVJTb4aXG2N+1KfKy4FjdDf8bJpNgDZZk/2WBuxw8ePHcFt2H7mD5KzCjtuaruZguxQjNkhDGzVledvGYLvuVSO/vev7Egzkq59SaMudXqOZeStvarm4oUQDifz5F3U9DX7mfJDPEZt43rDDgY1sXFHuA3OHIEzSTB8Pvj4c2LjR6w8eZAVBzeT4ZlCooedAqUwKANt6jalfcpxmqZm0iPnLOH2DHICIvB54GtYPRla3wqtbgGzl7MvVwhRDrnx6qK6N/PHZFDkFZhYbe/Er4kGGt1SqtRiyyNow6fcn7qf+5SJE3XakePflZOtooi1ZxB7MpZvPJPIDTIA9Whuac11BTa6pu0i2mjEe/5IsNSBtgOg/d3QtDcY5f82QtQWMpKv5V4selJXA0YFT/ZrzYQ+LS7cKecMJO+FoEiw+Fx0jLyCPHac2sHGExvZeGIj209tx2a3YTaYiarThB65+fQ4sot2mWkYrvsH9H25ei5OCHFZpFzjwi5osmY0cHd04Y3dimr/l6r1Z9uy2XpyK+uOr2PdsXXEp8cDYDX50KNBNL2a9aeH9iDgj9XQ6wmoE+Sw6xNCXJokeRcXm5DOoi1JFz1kVdHN2iuZSZOSncL64+tZe3Qtvx/7nbScNADa5eZxXU4+1ze9hcjer2AokezlgSohqo/U5F1c8YLkZT1kVdrV9KYJ8ApgQLMBDGg2ALu2sydtD78l/cZvCav4NH0vH6f9hnV+X9qpRkRFjieyfhde+e9qEmz1MZlMMiVTCCeSJO8iLrfnTGV70xiUgQj/CCL8I3jomoc4nXOar9fHsGZXDJu8U1gbNxGFka6NzvGXLDsqsxUnNh6DRsNlho4QTiDlGhdyuSWSqi6lFE/ltOsCzN4JRLZI5Pi5XzlnOQdAm9w8+uTkc2PXJ2jd7ZFLrpsrpR4hrozU5IVDlbz5ay6q8wMsj9+B9tzBH6mr2JpxEA008mnEjXVbcFPyYaL6T8UY0KrMY8nTt0JcPqnJC4cqvR4tFNb++7fuQHT4DcCjpGan8kvSL6xOXM28o2v5Utuo/+0g+tRrw81d/k7XxtdiNpiln70QVUySvKgSxZ0ryxuJ+3v5E2bpTVtDe4b2fJ7M3F9ZvWU6y87Es/DHR6hr9uXG8Jsw26MwKDNglH72QlQBSfKiSpU3Ei+Z/E0GxT2dIxh63be8evZH1v3wND80acWKQyvJLvgGnxYWvDObMrD1IDqE+jr7koSo1STJiypV3uydksk/r0AzZ0MiC7ckETPmRnqP+Y3edYIJWrOXlPVPUlB3Lz/WySHmRDzff/EmN1vb0SxsNOnpYfRoHijlGyGugCR5UaVK1+dLLyuYm1/YU19TYqRf1IahZ/MgXl4zhOBzJ+hozOPGiCQ2nt3Ct+m7yDn9BPZ8P5bvaMhjXe6h37V/ueqVsWT2jnAnMrtGVJvYhHQWbkliQWwSBQV/zsQpmWjLSsAfrFjP1NjVmPy24uGzlwKlaGvTDKjTgg71+rK9oCOR7SIuK2HL7B3himR2jagRim/OVrRoSllLD3Zr0xrjb+nknY2irscJRkRt4feMzbyZfQBT1n5Cz9Xj39vu4ot77qHLqW8htDsEtQeT5aIYZPaOcDcykhe1Qlkj/MnLV/L9ns85V3cf2pSNr/JlWPpR7snIJFgr8G0Ivg2g36vQpBekH2bZpr08+pMdu664x48QtYmM5EWtV9YI/7a2nYlZayM/OQ+L3z6aR/zBDH2OmfXqcb1nEPca/OmZk4ehqJ3CwW0/02/t33nZcDPv2O/l6QHdJMELlydJXtRaF97kvZ7ocCvHMo+xYN8CFv6xkJ+ydhHiG8KIM3sY3KANq20dsNhv5j7jSm4zbmDroaeh6yNXfQO3JLmZK2oqKdcIl5RfkM/qxNXM2TuHrclb8TX70qvh7fzvt2a0zk1lsnkWHdQB6PYw3PqfSp1LbuYKZ3NKuUYp9U9gLHCq6K0XtNbfO+p8QpRkNprp37Q//Zv2Z+epncyOm80PCQvwaAIG72s51PZjOmTvgEYdCz9wYA38Pg3qNgK/EKjbuPD30G7gUfEDWXIzV9Rkji7XTNVav+XgcwhRofaB7Xnjhjd4IvMJYvbEMH/ffF6K/ZXVoX0Y59GNSABbLmSnwYmdcC75zw8/EgseLeDQr5B2ADreDwbjBcevbPtmIRzJYeWaopF85pUkeSnXiOpwJvcMMXtiiNkTQ0ZeBj0b9eSRjo8QGRBZuIMtD84egzNHIaQzmDxgySOwdXbh1Mz+/4EmPS84ptTkhTM5pdVwUZIfBWQAm4GntNbpZew3DhgHEBYWFp2QkOCQeIQo7Vz+Ob6O/5pZu2ZxOvc0N4beyCMdH6GlteXFO2sNuxfBDxMhIwnaDYJ+k6FeWPUHLkQpDkvySqlVQFmrOL8IrAdSKHyCfTIQrLV+sKLjyUheOENmXiaz98xm1s7PyS7IokfDm/m/Xv8g2Df44p3zsuD39+C3dwqTfNex1R+wEKU4fdEQpVQTYKnWOrKi/STJC2eJTUhnxGer0X4/YbauxWIyMCpiJKPbj8bH7HPxB84cLXzYyiizkIXzVZTkDQ48aclh0GBgl6POJURlrT+YSl6eF7nJt5Jz8CnCPbvz6c5PuX3R7Sz+YzF2bb/wA36NCxP8li9g0wznBC3EZXBYkgfeUErtVErtAPoATzjwXEJUSvEMGaMCE/681PVVYm6LIaROCBN/n8j9399PXGrcBZ+JTUjn4NqF2FZOgtxMJ0UuRMXkYSghipQ1Q0Zrzf8O/o8pm6eQnpPOva3v5dGOj7L/hJ0RM9bTtmAfiy0TOdP4BvxGfgUWbydfhXBHTq/JXy5J8qKmysjL4INtHzB371ysHlY6+oxkydpA7Fox1LiG180zMYR2heFfg1c9Z4cr3IxTavJC1HaxCelMX7Of2IR06lrq8lzX55h7+1yCfIJYlfo2XmGzMFlS+cbQl0N93odjWyFhrbPDFuICMpIXogwV9aMpsBfwdfzXTI19F5vdxpCmo3mu5zhMZ08W3pAVoprJSF6IK1RWP5piRoOR4W2Hs3Twt1wX0pOvD37I8O+Gs8eWUbhD/HKYNxIKbE6KXog/SZIXogwlZ9uU14+moU9D3u3zLhMiJpFw+gRDlw5jauxUcjKSIO4bWDnRCZELcSEp1whRjvL60ZR8H2DEjPXkFmTi2XAZpnqbCKsTxj+NjeiydR7cOQ06PeCsSxBuQlaGEuIqlLUaVela/V2dQsjNt6PxJvv4ECxno8hu+R0Pnl3P3U0jefK7p6jj3wLCr3XSVQh3J+UaIa5A6Vq9AoyGP1eWsp1rzp0BbzOy3UgWqUwGhQSxZvtM5wUs3J4keSGuQOla/V2dQpg0MBKTQWFQYDEZuK5FI/7R5R/E3BaDn7UZj6Vv5JmfnyE1O/XSJxCiiklNXogrVFatvvg9q7eF9Ky889vyN37KzKOr+fjsHnwtdXm267Pc3vR2tiSelv7zosrIE69CVIOS9XqTQXFP51BGhJ+h3fqnOZC+j4nBIeww2rmmfg82x/YhL7eurAkrqoTMkxeiGpSs1+cVaOZsSOSuxWeJvW0pzQfN4ItzJp5JTWdv6jrMYVMw+m0k31ZwwRx8IaqaJHkhqkhxvb74Nqym6EGqQ+kQMRjj+A3c3+c/fGaIxJ7bGM/gRXiGzqJlI9sFLRSAi14LcbWkXCNEFYpNSGfhliQWxCZRUFC4sHdZ5ZhNh1P58cexzDcdxmCwcPbY7eSmd8RiMjJxQASTlu4us6XCpc4tdX73JPPkhagmxXPrh3QKqTDhdgmw0yV5M8NtmTzVqAV7Gs5De+0m/+Rglu06flFLhUsl7Yp67Qj3JuUaIRwgOtzKhD4tyk+0voHE/mUzR0PGMTcxnt4pDTD77sWr6Tu0bnLski0VSquo145wbzKSF8IJCteUjSXP1ouJ5sNMO7uM7+vcyrT6WXydNJERLRrS1x5FcHgETdU+OO4J/i3LXZSk+H5Avs2O0aA4djqb2IR0Gc0LqckL4QzT1+xnyg/x2DWYlJ2p0Wnc0T2SnKAI3lo3ma8Pfktkbi5TklNoZCso/FDH+2Dg9HKPWfJ+gK1AyjbuRKZQClHDXLCmrMlEoy53Qkg0niZPXrruNab2nsohn/rc26w1v9/+Gtw9C+6YVuExo8OtNK7nha1AyjbiT5LkhXCC6HArMWO682S/1mWOtm8Kv4mvBnxFoE8QD8d9wkydjlYKMpPhdGK5x72cFsnCvUi5RogaLCs/i1d+f4Xlh5dzZ7MBTIxdiodnPXhwOVh8yvyMTKV0P9LWQIhaTGvNxzs+Zvq26VzjG857ceuo37I/9H4ejGYIbO3sEIWTSU1eiFpsS+JpCtJuYnCjF9h17jjDmrYmcf9y+KgnLBpXuJPWsGU22HKdG6yocWQKpRA1WPFDToULk9TF5DUaW+jnDGvSko9a3U/7BtcU7pi0Cb59BHZ8DUNjwNPPuYGLGkNG8kLUYMUPORUXVW3Z4eQc/hsaX0b/8TnrPYrGaaFd4a5PIXE9zLoNMo47LWZRs0iSF6IGK54tU/wvqkGBSTdkctcPaezbmPGrxrM6YXXhxg73woh5kH4YZt4Mp+KdFbaoQeTGqxA1XHkLkpzJPcP41ePZnbKb13u9zm3Nbiv8wLFtMHcY3PEutOrn3OBFtZDZNUK4qKz8LCasnsCW5C282vNV7mh+R+GG/Gwwezk3OFFtZHaNEC7K2+zN9L7T6dKwCy/+9iJL9i8p3KAMsHMBnDnq3ACF00mSF6IWKrmoiLfZm2l9p9EtuBsvr32Z/x34H5w+AgtHw6FfnB2qcLJKJXml1D1Kqd1KKbtSqnOpbc8rpfYrpeKVUrdULkwhRLHiaZVTfohnxIz1xCak42Xy4r0b36NLUBdeWvsSy1K2Fo7m0w85O1zhZJUdye8C7gIuGC4opdoBQ4EIoD/wgVLKWMlzCSEov3e8l8mLaTdOo2ODjjy/8TVWhkbCvhVOjlY4W6WSvNZ6j9a6rHlaA4GvtNa5WutDwH6ga2XOJYQoVF4TstiEdGb9doyxLV+jfUB7njGe4afT8ZAU6+SIhTM56onXxsD6Eq+Tit67iFJqHDAOICwszEHhCOE6ijtYlmxCVnr5v09Hvc4HBU/xpLYzbftn9AyJPv95aWDmXi6Z5JVSq4CgMja9qLVeUtkAtNafAJ9A4RTKyh5PCHdQvJZssdIlnB2JuXzU71PGLB/F39M3MP34BroFd5O1YN3QJcs1WuubtNaRZfxUlOCPAqElXocUvSeEcICySjh+Hn58cstnhNYJ5dHVE4jdu7jcen7J2TrCtThqCuW3wFCllIdSqinQEtjooHMJ4fbKW4TE6mnl074fEpSXw/j1Ewn0O3jRH4OyZusI11HZKZSDlVJJQA/gO6XUCgCt9W5gHhAHLAcmaK0LKhusEKJ80eFWJvRpcVH5JcA3iBdavUhgfj5Tdj7NpHvqXPDHoLzRvXANlZ1ds1hrHaK19tBaN9Ra31Ji22ta6+Za69Za62WVD1UIcTViE9IZtaIeXZK64Z+fy5tbHqGBNfH8HwNZMtC1yROvQri44pH6f3Pv5r6jjQiw5fD6lqdYsHMdcOn1ZkXtJouGCOHiikfqufnwQvaTRCXEkh+2mn9tfYK2aQOISDtKdI/xRPdpX+FxZOpl7SRdKIVwA7EJ6SzcksSC2CQKCuyYPc8Q3GYWuXlpfHo8mYisDAhsU7hebNs7of3dF31epl7WXBV1oZSRvBBuoHhe/ZBOIedH48H+vXlwxYOMDbHwScObiDz5B8QtKWxTXCrJl3VzVpJ87SBJXgg3cuFDVFZm3TKLv674K2NPruLDmz4kavhXZX6uuOSTb7PLzdlaRso1Qri5E+dOMOaHMSRnJRf2pg/qUuZ+UpOvuWTRECFEuYJ8gngiYiqeKoCHl4/ml6UPl7lfefPwRc0mSV4INxebkM6E2ftJihtJWJ6Nx1LX8t3B75wdlqgikuSFcHPnb6rafBmaFErHnDye+/U5YvbEODs0UQUkyQvhhko2JCv5xOsnejgfnTjBjV6N+ffGf/PWprewa7uzwxWVILNrhHAzZc15L+5P37tefTyWwNvN/sIbBSf4PO5zjp07xuu9XsfT5Ons0MVVkCQvhJspa877+RuqmXXh5skY29zOcz6BNPZtzFub3+LEuRO82+ddAr0DnR2+uEJSrhHCzVi9LRiUwlBWQzLfBtDzMfCog9o0gwfajuCdPu+w//R+hn43lAU710nf+VpGkrwQbiQ2IZ1JS3dTYNcYlGLigIiyp0TuXgzf/wNm3caNdZox+9bZ5ObBPzeP5511X0nf+VpEkrwQbqS4VKMBrTXpWXll7xg1HO76FJLj4MNeWLb+yom94yjIDsWz8ddgXcLaAyerNXZxdSTJC+FGrqh3fId74W9rIbgDTX99isf0MrITx5CX1hOz/1p+yXiNlOyU87vLEoI1k7Q1EMLNXHF7AnsBSd+/ydgNgcTbgvBS+dzZ+zQrk9/Hz+LHlN5TKMgOly6VTlRRWwNJ8kKIy1L8x2F4wstYC9KI7zSUJw7N53jmcbrVG8kP61pg1wqjgif7tWZCnxbODtltSO8aIUSlFfeusba7ETKO0nrJ43x18jS9rG1Ymz4Tz8ZfoQy5GI3SpbImkSQvhLgyXcfCY1th0EfUzc/m3W2rGBHQH4PvDrybvI8yH3d2hKIESfJCiCtnNEPUMBizGkOHe6lvuY+cI2PAmI057H2+2LnI2RGKIpLkhRBXz7s+DJxOdKswfPLCmXzEjE+uPz+mvsPkdZPJLch1doRuT5K8EKLSosOtxNwTSl/PFH47GctffVowb988Hlj2AEczj17WMWQKpmPI7BohRNXJOQMrJ0Ls5/xobchL9etgN1i4wfp37o3oV+a0ypKLjNsKZArm1ZDZNUKI6uHpB3e8C2NXc6N3Y2ZleJB5zpfvkl/j/kWT2HQ49YLdiztizt2QeFHTNFE1JMkLIape42gYvYq1LaaSdXg8hjPtMdZfxRu/PsCZs8fO71ayzQKA4jKexBVXRJK8EMIxDAauadMSi9GDa5Nb8PipbPYXJDB03k3ExwyGDR8TaM7DoBQmZcdiVAzvFialmiomNXkhhEOdb6PQpB7Gs8t4avu7nC3I4bXkFF46O43kfG+eNC+ge/s2dLn3WWeHWytJTV4I4TTFT8pGNw0gqsP9fDVkGS0Dr+HJhoGcrvcbGjuNSCFq79twOtHZ4bocSfJCiGoV6B3IrP6zuC7oNiwBP+IVEsP7aiAGg4Llzzs7PJdTqSSvlLpHKbVbKWVXSnUu8X4TpVS2Umpb0c9HlQ9VCOEqLEYL0/v9m2HNH8FcZw8+1ywjpdcjsHcpxC93dngupbIj+V3AXcAvZWw7oLWOKvp5uJLnEUK4GKUUL/R6iPf7TuNUThLDk38krmErWPYMFOTLw1FVpFJJXmu9R2sdX1XBCCHcz/Uh1zP7ttkYDSZG+dr56brxxCZlMmrGb0z5Ya8sNVhJjqzJN1VKbVVK/ayUuq68nZRS45RSm5VSm0+dOuXAcIQQNVUrayvm3D6HIJ9mPLbrQ95cN4OxeiELzK/QwHZSHo6qhEsmeaXUKqXUrjJ+BlbwseNAmNa6I/AkMEcpVbesHbXWn2itO2utOwcGBl7dVQghar2EZCP7tt1H/tk27M79ghUBaTRVx5hmeY/uTcpMH+IymC61g9b6pis9qNY6F8gt+j1WKXUAaAXIJHghRJnWH0wlL9+EPek+PBt+R2L9tYz378qsgz/jeeRzaPq0s0OslRxSrlFKBSqljEW/NwNaAgcdcS4hhGv4c5FxA6QNZHiLR9ltP8To8OakxS12dni1VmWnUA5WSiUBPYDvlFIrijZdD+xQSm0DFgAPa63TKheqEMKVRYdbmTgggmtbBDBxQATP9xzH1N5TiTcUcL8lg8S0fc4OsVaStgZCiBqhuCNlnu3CdsPbjm/i0Z+fRKGY1nca1wRe4+xQaxxpayCEqPGKO1KWbjccFdyFL2/7El+LL6NXjGZ14monR1q7XPLGqxBCVIfimny+zX5Ru+HwXf9j9qkMHg0K44k1TzC8xWPUyeuN1dtCelYe3Zv5S+fKckiSF0LUCNHhVmLGdC/sWFk6aQe2wT/1EDNP7ePvTa8hZv+75KVuJTe5PwoDHmZZTao8Uq4RQtQY5ztWlk7WLW+CRzbj1eYOPvxjI7efycfi/wuejeahlU1Wk6qAJHkhRO1QNxjunsn+/nP5a6qRoFNRmP224R36X8zmvAvKO9L35k9SrhFC1CqZwT0YUfAGuSlgsbXGM3g+odfMJrxBYfeU8mbpuCsZyQshapX1B1PJKwANdM0w8/6JEySfO8QD3z9A0tmkcmfpuCtJ8kKIGqm8ksufT8bCZmMkHep3Z8bRJDIyEnngm0E099p1frvZZMDqbXHr0o08DCWEqHEuVXI5v25sM3+iQ3xh33L+2DKLh3L2kmc08vdOH5Gc2mppAu8AAA4BSURBVBCrt4VJS3e7fOlGHoYSQtQqlyq5XDALx2iGtnfQcsQivhjwFXW8GzBl11Nc2+IEnbY8h4/ttFuXbiTJCyFqnJIlmdIPRlUkpGEHZt0eQ6BXIA/99Dhnzv7M55Y38FNZV3QcVyLlGiFEjXRBSeYKSywp2SmMWTGGo2cTmX7sOI0tbTh55xw6NQ+usnPUJBWVayTJCyFcUlpOGg8uf5BjZxP5ICmJMHMzkm/5kMj2HQHXmmopNXkhhNup71mfGbfMwM8jmDFBjfgtN4sH5h0unGVzfDub/jjqFlMtJckLIVxWgFcAN1tfId9Wj4nBHmQYU1l/IAUWjmXYoRfwMdmvuO5f20iSF0K4tL6tWlJwbBza7oFn6EyaBGdDj/H4Hf2Zn1vO48mbW9bqUs2lSJIXQri06HArMaNuZVjYq9T1MjIt7hlOtb2dpOhnqX/wWwafneOyCR4kyQsh3EB0uJWX+vXm034fk5aTxqhlD3HTpjastUdwbst8l34aVpK8EMJtRARE8HbvtzmSeQBD0GwWFfRgnb0t6w+ccnZoDiNJXgjhVno17sWDrZ/F6LOf7xuk8joP0r15oLPDchhpNSyEcDuPdx9OSs5xlvBfhkRFEV0/2tkhOYwkeSGEW5p8w5Pk/5rMwkMz6brlPU63/JjW7Tu73E1YKdcIIdySUorJPSfTyqcVL9fzJnjH33hixvcudxNWkrwQwm1ZjBZ61HsBu60ukxpaeMk01eWefJUkL4Rwa31aNiP7xFhOGyx8FpxBL58Dzg6pSkmSF0K4ldIrTkWHW4l5YBC3BDxGnIcHc09/Q3HjRldYEFxuvAoh3EZ5nScLfx6k2Q4b07ZOo/Xu/9KhziCX6FIpI3khhNu41IpTY9uPpV/wtbwTO5XFO5e5RJdKSfJCCLdxqRWnlFJMNgTRLC+Xn079i46eW2p9l0pZNEQI4VYuZzWoxLgFDN3wf4Tk5zG4wWu06ti3RpdqHLZoiFLqTaXUXqXUDqXUYqVUvRLbnldK7VdKxSulbqnMeYQQoqpcsAh4CSVvsoa1u5sxbV9mj4eFPadeJzq0rpOirbzKlmtWApFa6w7APuB5AKVUO2AoEAH0Bz5QShkreS4hhHCI4huyU36IZ8SM9czZkMgb39UhNK0liy35vL9utrNDvGqVSvJa6x+01rail+uBkKLfBwJfaa1ztdaHgP1A18qcSwghHKX0Ddllu46TZ7MTd3IUBVlNmXlgOoeO/A55Wc4O9YpV5Y3XB4FlRb83Bo6U2JZU9J4QQtQ4pW/I3hoZXPTaiP3kcLxMHjy98mFyP7sZ0g87O9wrcsl58kqpVUBQGZte1FovKdrnRcAGxFxpAEqpccA4gLCwsCv9uBBCVFp0uJWYMd0vuCHbOqjO+dfnjI2YsHoCb9tP8fwnveHuz6D5jc4O+7JUenaNUmoU8BDQV2udVfTe8wBa638VvV4B/FNrva6iY8nsGiFETfWfjf/hyz1f8p/TJvpnJGF4eC0EtgIub8aOIzlydk1/4BngzuIEX+RbYKhSykMp1RRoCWyszLmEEMKZrg8Yic5tyLO+HiTaLaQufx24+KZtTWuBUNma/PtAHWClUmqbUuojAK31bmAeEAcsByZorQsqeS4hhHCaLQmZ5Bz7C9qYw7D6XZgf/A/g0k/ROluletdorVtUsO014LXKHF8IIWqK7s38Mf0YQn7KjWQGruQ4O/l4laaxKQuLyUC+zV4jn4yVBmVCCFGO0rX2iQMi+H5XXY6Y9rMw4V3eP2IjUOfzym2LSMvRTqvJV0SSvBBClKF0x8qJAyKYtHQ3eTY7Rs+BeIS/x/v+fixI3U7s6WNMuPU6Z4dcJmlQJoQQZSjvASm7hoKcIEjrRXzddD7zbE1Eu0hnh1suSfJCCFGG8h+QAovJwLvNogjPz2dumBeRId7ODrdcUq4RQogyXOoBqehzv+CTaGSsOY2ZO2cyPmq8s0Muk7QaFkKIq5GbCcl7eObQfFYlrGJx91cJb3mbU0Jx2MNQQgjhtjx8IbQLT3d+GouGt1Y+BkufgOzyH4ZyxpqxkuSFEKISAr0DGdd+LD/5ePH77rkwrTNsmwOlqiTOejJWkrwQQlTSfR1GE1onlDebd6SgflP45m+w5vUL9nHWk7GS5IUQopIsRgtPRD/B/nNJfHv9eBj4AbToe8E+l1pf1lHkxqsQQlQBrTUjvh9BclYySwcvxdPkedE+jupWWdGNV5lCKYQQVUApxeOdHmf0D6N5f80Ueh7LokGTSJpHdgVrUzAYiA63lpncHdmqWJK8EEJUQskE3TW8K639opifuJBHkw7gcQhYA7S4Ge5bUO7nS7ZPiBnTvUoTvSR5IYS4SmUl6FYeg4k3baOj50O0PdOIrz1ew2Qp/4nYsm7IVmWSlxuvQghxldYfTCU3vzBB5+UXJui72vbGnh2Oqr+eRGMwp5vfCdcMK/cYjr4hKyN5IYS4SlZvC8VTV+xFrzs3qc/jXcbx3q4XGXWHkYCuMys8RlntE6qSjOSFEOIqpWflYVCFvxtU4WuA0Z0G0KRuE35Jno/OSoe4bys8TnS4lQl9WjikF70keSGEuEolSy2WEqUWgzJwf7v7iUuNY9uPL8P8kXBqn1NilCQvhBBXqbjU8mS/1hfNihnQbAB1LHX40gswe8NPr5d/IAeSJC+EEJVQXqnF2+zNkJZD+PHoWpK7jILdi+H49mqPT5K8EEI4yD2t7sGmbSy0BoBnPfjxtWqPQZK8EEI4SFjdMK5tdC0LDi3F1vOxwjfzc6o1BknyQgjhQPe0uofkrGR+D4+GEfPAfHFPG0eSJC+EEA50Q+gN+Hv6s2D/osI37PZqPb8keSGEcCCzwczAFgP5JekXUmKGwJx7q/X8kuSFEMLBBrUYRIEu4H8qG1Kqd768JHkhhHCQ4jVd007Xo1ODTiy2nUKjL9ruyKUApXeNEEI4QMkOlSajga7tO3NIb2G7r5UoYM6GRCYu2YVda4e0GC4mI3khhHCAki2E82x21m5vjIcd5hvyiU1IZ+KSXdjs+vx2R635KiN5IYRwAKu3BXuJ1VW13YOITE+W180ncP8xCkpsNCjlsDVfZSQvhBAOkJ6VhyrxWgEbzz5AHrl4qxX0N2/BAJgMikkDIx1SqoFKjuSVUm8CdwB5wAHgr1rr00qpJsAeIL5o1/Va64crcy4hhKhNujfzx8NsIN9mx2g0cHd0CIM7duelDYuIPTCTV6LvItKvtUN6yJdU2XLNSuB5rbVNKfUf4Hng2aJtB7TWUZU8vhBC1ErlLQYy/NwokpN3EXzD/zHB4PhiSqWSvNb6hxIv1wN3Vy4cIYRwHdHh1otG6SMjRkJE9cVQlX9GHgSWlXjdVCm1VSn1s1LquvI+pJQap5TarJTafOrUqSoMRwghxCVH8kqpVUBQGZte1FovKdrnRcAGxBRtOw6Eaa1TlVLRwDdKqQitdUbpg2itPwE+AejcubMuvV0IIcTVu2SS11rfVNF2pdQoYADQV2utiz6TC+QW/R6rlDoAtAI2VzZgIYQQl69S5RqlVH/gGeBOrXVWifcDlVLGot+bAS2Bg5U5lxBCiCtX2dk17wMewEqlFPw5VfJ6YJJSKh+wAw9rrdMqeS4hhBBXqLKza1qU8/5CYGFlji2EEKLy5IlXIYRwYZLkhRDChamiCTE1glLqLH+2QnAnAUCKs4NwArlu9+Ou1+7o6w7XWgeWtaGmdaGM11p3dnYQ1U0ptVmu232463WD+167M69byjVCCOHCJMkLIYQLq2lJ/hNnB+Akct3uxV2vG9z32p123TXqxqsQQoiqVdNG8kIIIaqQJHkhhHBhNSbJK6X6K6XilVL7lVLPOTue6qKUOqyU2qmU2qaUctkunUqpz5RSyUqpXSXeq6+UWqmU+qPofx23BpqTlHPd/1RKHS36zrcppW5zZoyOoJQKVUqtUUrFKaV2K6X+XvS+S3/nFVy3077zGlGTL+pYuQ+4GUgCNgHDtNZxTg2sGiilDgOdtdYu/YCIUup6IBP4QmsdWfTeG0Ca1vrfRX/YrVrrZys6Tm1TznX/E8jUWr/lzNgcSSkVDARrrbcopeoAscAgYBQu/J1XcN334qTvvKaM5LsC+7XWB7XWecBXwEAnxySqkNb6F6B0J9KBwOdFv39O4b8MLqWc63Z5WuvjWustRb+fBfYAjXHx77yC63aampLkGwNHSrxOwsn/YKqRBn5QSsUqpcY5O5hq1lBrfbzo9xNAQ2cGU80eUUrtKCrnuFTJojSlVBOgI7ABN/rOS103OOk7rylJ3p310lp3Am4FJhT9573bKVpVzPm1w+rxIdAciKJwqcwpzg3HcZRSvhS2HX+89PKfrvydl3HdTvvOa0qSPwqElngdUvSey9NaHy3632RgMYWlK3dxsqiGWVzLTHZyPNVCa31Sa12gtbYDn+Ki37lSykxhoovRWi8qetvlv/OyrtuZ33lNSfKbgJZKqaZKKQswFPjWyTE5nFLKp+jmDEopH6AfsKviT7mUb4GRRb+PBJY4MZZqU5zkigzGBb9zVbhU3Exgj9b67RKbXPo7L++6nfmd14jZNQBFU4reAYzAZ1rr15wcksMVrX+7uOilCZjjqtetlJoL9Kaw5epJ4BXgG2AeEAYkAPe62jKR5Vx3bwr/s10Dh4GHStSpXYJSqhfwK7CTwiVAAV6gsD7tst95Bdc9DCd95zUmyQshhKh6NaVcI4QQwgEkyQshhAuTJC+EEC5MkrwQQrgwSfJCCOHCJMkLIYQLkyQvhBAu7P8BPSbyUS4AugcAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(*emissions.T,'.');\n",
+    "plt.plot(*ssm_posterior.filtered_means[:,:2].T, '--');\n",
+    "plt.plot(*ssm_posterior.smoothed_means[:,:2].T);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c5f9126-e9c1-4384-91a1-50b72c1fa790",
+   "metadata": {
+    "id": "6c5f9126-e9c1-4384-91a1-50b72c1fa790"
+   },
+   "source": [
+    "## Parallel Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rXhPImwOMQnG",
+   "metadata": {
+    "id": "rXhPImwOMQnG"
+   },
+   "source": [
+    "### Filtering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55a391b9-f00b-49c5-b17b-c4ebb1735437",
+   "metadata": {
+    "id": "55a391b9-f00b-49c5-b17b-c4ebb1735437"
+   },
+   "outputs": [],
+   "source": [
+    "def first_filtering_element(params, y):\n",
+    "    F = params.dynamics_matrix\n",
+    "    H = params.emission_matrix\n",
+    "    Q = params.dynamics_covariance\n",
+    "    R = params.emission_covariance\n",
+    "    \n",
+    "    S = H @ Q @ H.T + R\n",
+    "    CF, low = jsc.linalg.cho_factor(S)\n",
+    "\n",
+    "    m1 = F @ params.initial_mean\n",
+    "    P1 = F @ params.initial_covariance @ F.T + Q\n",
+    "    S1 = H @ P1 @ H.T + R\n",
+    "    K1 = jsc.linalg.solve(S1, H @ P1, assume_a=\"pos\").T  \n",
+    "\n",
+    "    A = jnp.zeros_like(F)\n",
+    "    b = m1 + K1 @ (y - H @ m1)\n",
+    "    C = P1 - K1 @ S1 @ K1.T\n",
+    "\n",
+    "    eta = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), y)\n",
+    "    J = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), H @ F)\n",
+    "    return A, b, C, J, eta\n",
+    "\n",
+    "\n",
+    "def generic_filtering_element(params, y):\n",
+    "    F = params.dynamics_matrix\n",
+    "    H = params.emission_matrix\n",
+    "    Q = params.dynamics_covariance\n",
+    "    R = params.emission_covariance\n",
+    "    \n",
+    "    S = H @ Q @ H.T + R\n",
+    "    CF, low = jsc.linalg.cho_factor(S)  \n",
+    "    K = jsc.linalg.cho_solve((CF, low), H @ Q).T  \n",
+    "    A = F - K @ H @ F\n",
+    "    b = K @ y\n",
+    "    C = Q - K @ H @ Q\n",
+    "\n",
+    "    eta = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), y)\n",
+    "    J = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), H @ F)\n",
+    "    return A, b, C, J, eta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7de7080-7686-4791-b013-1a45af2bc066",
+   "metadata": {
+    "id": "c7de7080-7686-4791-b013-1a45af2bc066"
+   },
+   "outputs": [],
+   "source": [
+    "def make_associative_filtering_elements(params, emissions):\n",
+    "    first_elems = first_filtering_element(params, emissions[0])\n",
+    "    generic_elems = vmap(lambda ems: generic_filtering_element(params, ems))(emissions[1:])\n",
+    "    comb_elems = tree_map(lambda f,g: jnp.concatenate((f[None,...], g)),first_elems, generic_elems)\n",
+    "    return comb_elems"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fefe365e-0261-42cb-bd16-930881452904",
+   "metadata": {
+    "id": "fefe365e-0261-42cb-bd16-930881452904"
+   },
+   "outputs": [],
+   "source": [
+    "@vmap\n",
+    "def filtering_operator(elem1, elem2):\n",
+    "    A1, b1, C1, J1, eta1 = elem1\n",
+    "    A2, b2, C2, J2, eta2 = elem2\n",
+    "    dim = A1.shape[0]\n",
+    "    I = jnp.eye(dim)  \n",
+    "\n",
+    "    I_C1J2 = I + C1 @ J2\n",
+    "    temp = jsc.linalg.solve(I_C1J2.T, A2.T).T\n",
+    "    A = temp @ A1\n",
+    "    b = temp @ (b1 + C1 @ eta2) + b2\n",
+    "    C = temp @ C1 @ A2.T + C2\n",
+    "\n",
+    "    I_J2C1 = I + J2 @ C1\n",
+    "    temp = jsc.linalg.solve(I_J2C1.T, A1).T\n",
+    "\n",
+    "    eta = temp @ (eta2 - J2 @ b1) + eta1\n",
+    "    J = temp @ J2 @ A1 + J1\n",
+    "\n",
+    "    return A, b, C, J, eta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d692a7e2-45f3-4350-a3b7-45d33c2de5ab",
+   "metadata": {
+    "id": "d692a7e2-45f3-4350-a3b7-45d33c2de5ab"
+   },
+   "outputs": [],
+   "source": [
+    "def parallel_kalman_filter(params, emissions):\n",
+    "    initial_elements = make_associative_filtering_elements(params, emissions)\n",
+    "    final_elements = associative_scan(filtering_operator, initial_elements)\n",
+    "    return final_elements[1], final_elements[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7bee192-36ca-4fe0-953c-b39a5868565c",
+   "metadata": {
+    "id": "c7bee192-36ca-4fe0-953c-b39a5868565c"
+   },
+   "outputs": [],
+   "source": [
+    "pfms, pfPs = parallel_kalman_filter(lgssm_params, emissions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a160e709-6f81-47f2-8404-94c2346ccd4b",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 374
+    },
+    "id": "a160e709-6f81-47f2-8404-94c2346ccd4b",
+    "outputId": "b22bd04c-9995-4734-a30a-1a1581a157f9"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAFlCAYAAAAOF5jdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3gUVffA8e/dVDohCTUk9BoCJKETqhQBkY4ICKJgAYUXFVERkdf2SlXEgiBY4CeIigqogIIigpBQQ28JHQKEQAipe39/pBiSTUjZzW52z+d5eEx2ZmfOsHJyc+bOuUprjRBCCPtksHYAQgghLEeSvBBC2DFJ8kIIYcckyQshhB2TJC+EEHZMkrwQQtgxZ2sHkJmXl5euUaOGtcMQQohiJSws7KrW2tvUNptK8jVq1CA0NNTaYQghRLGilIrMaZuUa4QQwo5JkhdCCDsmSV4IIeyYTdXkhRCWkZSUxLlz54iPj7d2KKIQ3N3d8fHxwcXFJc/vkSQvhAM4d+4cZcqUoUaNGiilrB2OKACtNdeuXePcuXPUrFkzz++Tco0QDiA+Ph5PT09J8MWYUgpPT898/zYmSV4IByEJvvgryGcoSV4IYRURERH4+/tbOwz27t3L+vXrM77/8ccfeeedd6wYkXlJkhdC2I3k5OR8vydrku/bty9Tp041Z1hWJUleCGFSWGQ0CzefICwy2izHmzt3Lv7+/vj7+zN//nwgNSkPHz6chg0bMmjQIOLi4gCYOnUqjRo1IiAggOeffx6AqKgoBg4cSIsWLWjRogXbtm0DYMaMGYwcOZJ27doxcuRIWrduzcGDBzPO26lTJ0JDQ9m5cydt2rShefPmtG3blqNHj5KYmMj06dNZuXIlzZo1Y+XKlSxbtowJEyYAqb9tdOnShYCAALp27cqZM2cAGD16NM8++yxt27alVq1arF69GoCLFy/SoUMHmjVrhr+/P1u3bjXL312haK1t5k9QUJAuqNCI6/qD34/r0IjrBT6GEPbq0KFD+do/NOK6rj9tva45da2uP219of9dhYaGan9/fx0bG6tv3bqlGzVqpHfv3q0B/ddff2mttX700Uf1rFmz9NWrV3W9evW00WjUWmsdHR2ttdZ62LBheuvWrVprrSMjI3WDBg201lq/9tprOjAwUMfFxWmttZ47d66ePn261lrrCxcu6Hr16mmttY6JidFJSUlaa603btyoBwwYoLXWeunSpXr8+PEZsWb+vk+fPnrZsmVaa62XLFmiH3zwQa211qNGjdKDBg3SKSkp+uDBg7p27dpaa61nz56t33jjDa211snJyfrmzZuF+nszxdRnCYTqHPKqXUyhDIuMZvjiHSQmG3F1NrD88dYE+XlYOywhiq0dp66RmGzEqCEp2ciOU9cK9W/qr7/+on///pQqVQqAAQMGsHXrVqpXr067du0AGDFiBO+//z6TJk3C3d2dxx57jD59+tCnTx8ANm3axKFDhzKOefPmTWJjY4HUEkuJEiUAGDJkCN27d+f1119n1apVDBo0CICYmBhGjRrF8ePHUUqRlJR0z7i3b9/Od999B8DIkSOZMmVKxrZ+/fphMBho1KgRly9fBqBFixaMGTOGpKQk+vXrR7NmzQr8d2YudlGuMfU/pBCi4FrX8sTV2YCTAhdnA61reVrkPFlniyilcHZ2ZufOnQwaNIi1a9fSs2dPAIxGIzt27GDv3r3s3buX8+fPU7p0aYCMHx4A1apVw9PTk/3797Ny5UqGDh0KwKuvvkrnzp0JDw/np59+KvSDYW5ubhlfpw6moUOHDvz5559Uq1aN0aNH88UXXxTqHOZgF0m+qP6HFMJRBPl5sPzx1kzuXt8svxmHhISwZs0a4uLiuH37Nt9//z0hISGcOXOG7du3A7BixQrat29PbGwsMTEx9OrVi3nz5rFv3z4AunfvzoIFCzKOuXfv3hzPN3ToUN59911iYmIICAgAUkfy1apVA2DZsmUZ+5YpU4Zbt26ZPE7btm35+uuvAVi+fDkhISG5XmdkZCSVKlVi7NixPP744+zevfsefzOWZ/Ekr5TqqZQ6qpQ6oZSyyC3rnP6HNPeNIyEcSZCfB+M71zFL6TMwMJDRo0fTsmVLWrVqxeOPP46Hhwf169dn4cKFNGzYkOjoaJ566ilu3bpFnz59CAgIoH379sydOxeA999/n9DQUAICAmjUqBEff/xxjucbNGgQX3/9NUOGDMl4bcqUKbz00ks0b978rlk4nTt35tChQxk3XjNbsGABS5cuJSAggC+//JL33nsv1+vcsmULTZs2pXnz5qxcuZKJEycW5K/LrFT6rxkWObhSTsAxoBtwDtgFDNNaHzK1f3BwsDZHP/nbCbEcuZQkdXoh0hw+fJiGDRtaOwxhBqY+S6VUmNY62NT+lh7JtwROaK1Paa0Tga+BBy15wvjkeLZ0b0HJHm0xxMfmqU4vI34hhL2ydJKvBpzN9P25tNcyKKXGKaVClVKhUVFRhT6hm5MbpRJSv161djoVEqMz6vSmknn6zJw5G44yfPEOSfRCCLti9RuvWutFWutgrXWwt7fJJQrzRSlF9dWpdTUnDdUCvmfRqMYAJpO5zMwRQtgzS8+TPw9Uz/S9T9prFlXbJ4Dlrw/id8MxzsUf44M9z9A57hESk92zzftNn5mTlGyUmTlCCLtj6SS/C6irlKpJanJ/CHjYwucEYPjQ/zIc2HFxB7ufG0fr8Fdp0W4ooeWD70rm6TNzdpy6RutanjZ1czYsMtom4xJCFB8WTfJa62Sl1ATgV8AJ+ExrffAebzOr1lVaU2b6Qi488RTT/viaXaNK0/ShMXclzSA/D5tLovIUrxDCHCxek9dar9da19Na19Zav2np85nSuEEIdZZ/TYSPCy2+WEzFE6mNjTqu7Ejf7x8gJa0pki2RewVC/Ovjjz++59OjM2bMYPbs2dlej4qKolWrVjRv3pytW7fSq1cvbty4AZDxxGxERAQrVqwoUGxt27Yt0PuKitVvvBaVmj7+1P10KRe9DJx55SWib0VxPf467b8/ybHAIFJiYsx2LnNMyZSneIVIlZyczJNPPskjjzxSoPf/9ttvNGnShD179hASEsL69espX778XfsUJMmnP1D1999/FyiuouIwSR6ggV8Qnh++x9tDnZnw5yTW9l9LxwOpD4Mda9WaTSu+YOHvxwuVnM01JdPcj5ULYU23b9+md+/eNG3aFH9//4wnS8PCwujYsSNBQUH06NGDixcvAqntgSdNmkRwcDDvvffeXaP0Tz/9lBYtWtC0aVMGDhyY0Z7YlL179zJlyhR++OEHmjVrxp07d6hRowZXr169a7+pU6eydetWmjVrxrx580hJSeGFF16gRYsWBAQE8MknnwCpT7SGhITQt29fGjVqBPz728CWLVvo1KkTgwYNokGDBgwfPjyjp8369etp0KABQUFBPPvssxlN14qCXXShzI+gxvfxnzKzmbz5P2wY05v2d/7dVm3m29yoUpq3Gj3Iy1PGFyixmrN7ny3eKxDF3/92/o8j14+Y9ZgNKjTgxZYv5rj9l19+oWrVqqxbtw5I7SOTlJTEM888ww8//IC3tzcrV67klVde4bPPPgMgMTGR9CfgZ8yYkXGsAQMGMHbsWACmTZvGkiVLeOaZZ0yet1mzZsycOZPQ0FA++OCDHON75513mD17NmvXrgVg0aJFlCtXjl27dpGQkEC7du3o3r07ALt37yY8PNzkYtp79uzh4MGDVK1alXbt2rFt2zaCg4N54okn+PPPP6lZsybDhg3LMQ5LcLgkD9DVtytv1XuOiidn8Y+PH+/5j+K2u5FeUasYvO8YI4+s4O2dV5hX4QWql6l+7wNmIlMyhciuSZMmPPfcc7z44ov06dOHkJAQwsPDCQ8Pp1u3bgCkpKRQpUqVjPekd4/MKjw8nGnTpnHjxg1iY2Pp0aOH2ePdsGED+/fvz1gMJCYmhuPHj+Pq6krLli1NJniAli1b4uPjA6T+gImIiKB06dLUqlUr4z3Dhg1j0aJFZo85Jw6Z5AF6txlF2Le9eWfpLpKSjTgZFOurPMmvFa9SseRv3LyzjRFf/sm0rV7Un/gyvq275Om4tjwlUwgg1xG3pdSrV4/du3ezfv16pk2bRteuXenfvz+NGzfO6EKZVeb2wZmNHj2aNWvW0LRpU5YtW8aWLVvMHq/WmgULFmT7AbJly5Yc44K72w87OTkVaDlCc3PYJA8QVMvrroR89NItfg6/yP3+Henq78YP37xJuSMbuT16PL81q0b9F17D1deXi9zg/K3zJK/5GaejpylR1YcWT0yjTOXUn+BSZhHibhcuXKBChQqMGDGC8uXLs3jxYqZOnUpUVBTbt2+nTZs2JCUlcezYMRo3bpzrsW7dukWVKlVISkpi+fLlGe2DCyNru+EePXrw0Ucf0aVLF1xcXDh27FiBz1O/fn1OnTpFREQENWrUyNbp0tIcOsnDvwk5LDKamWsPkphsZFfEdepXbs240e9zsdcp/pr/EjXX7+fW8HFcKg/PPpX61/byxhRqX4YycSc59c0fXOnUmIBnXqVS/ab5iuHaxdPcvnoJ3yZtLHGJQljdgQMHeOGFFzAYDLi4uPDRRx/h6urK6tWrefbZZ4mJiSE5OZlJkybdM8n/97//pVWrVnh7e9OqVasce8HnR0BAAE5OTjRt2pTRo0czceJEIiIiCAwMRGuNt7c3a9asKdCxS5QowYcffkjPnj0pVaoULVq0KHS8+WHRVsP5Za5WwwWxcPMJZv96FE3qlKPnetRnfOc6GdvPXTrKnqXzcHMrifuQflQtVZUq7hUpVaIse3et5eTH86m74zy/tHIhfuwgRjYcSc3yd9ftMj/B2qCCJmz1x8Su+5nqh67ibITd/RrQedpCqpauWrQXn4U8aWt/pNWwdcXGxlK6dGm01owfP566devyn//8p0DHym+rYYcfyafzKOlK+o87Y9r3mflUro/PS6YXKWjWog/NWvTh1MkwUk59yw8nfuDk+lU8ElqK5Kb18WjeggS/Noxdd5lk1+O4HdjDe6tCqXbViHNZA2d6BZDi6sJqz0PM/f4BHq3Wn+H+o/ComL+bvuYgT9oKYX6ffvopn3/+OYmJiTRv3pwnnniiyM4tST5NdFwiBgVGDQaV+n1+1aodxEu1gxh7ZzK/ff4Gxm1bqPrjLpzX7KIMH/JJWcUzTxkw6hL8dV8AD7TsScvuD+Ps7AJAy9uXWLBnAS7zVnDqxAquD+1Ch0nv4FaytLkvN0fmXsBZCAH/+c9/CjxyLyxJ8mnMOfXRq4QXQ5+cD0/CzZtRHNu1gWNb/+BS+HFcT3cklkAeeCwkW/KsXKoyb7Z/k8NuHTj19uvU+uI3Qn9sjXHsQ7Qb/RIGJ6fCXuY9yRRQIeyL1OQzsXQtOv34HiVdiY5LzPU8Wmv+WbeY2HkfUu18PJt7VKbFS+/SorL5btrkdL1Sk7c/UpO3H1KTLwRLTX3MnDRb1/LMU81bKYVLk0Ecfqk91/Z/wabyO/jo1zEMUIGMbDKaOs07FzqmnOKQKaBC2A9J8haWNZkODPTJU8377vd1YGm/iRy6vY5SL7/HrVk7CX3reYIfeKzAcUntXQjH4FANyqwhazLVkKfuklnftzsylseaPEanhSuJ9nLD7cXZ/PXVrALHJV0uhb1YtmwZEyZMAHJuN5yZo7UklpG8hWW9kTkw0IeBgT73rHnndAO0sm9D3FatZdcj/aj2xmf8fiOaLhPeylMsWWvt0n5BFBfJyck4O1s2XaW3JF68eDEAISEh2fZJT/IPP5z3Be7SY7dWS2IZyVuYqZbBQX4ejO9cJ9fEmlurYQ9vH9qu/JUzjSpw+9vv+XzvknvGYaoFcuY4zNEDX4icREREZLTfbdiwIYMGDcpoETxz5kxatGiBv78/48aNy2jPm7Xd8E8//ZQx0r7vvvu4fPlyruc8efIkPXv2JCgoiJCQEI4cybnzpj23JJaRfBEo6I3M3N5XuqwnXZdvZNK659m6bz5Hz0YwxqcLNRq1wdnNPdv+udXg5QEoxxM5MvsCHGXu70mFhx/GeOcOZ8dlf1inXP/+lB/Qn+ToaM4/O/GubX5f5r5qE8DRo0dZsmQJ7dq1Y8yYMXz44Yc8//zzTJgwgenTpwMwcuRI1q5dywMPPADc3W44OjqaHTt2oJRi8eLFvPvuu8yZMyfH840bN46PP/6YunXr8s8///D000/z+++/m9zXnlsSS5Ivxg5cSeD3fb0xeCTiv/Jbkk6t5pATXK1cgjt+FXFu3IAKw4cTVCkoW/knuEY5/jj7B1v2raHBst08YnDnSgkPokp4s/2YnyR5YXbVq1enXbt2AIwYMYL333+f559/ns2bN/Puu+8SFxfH9evXady4cUaSz9xu+Ny5cwwdOpSLFy+SmJiYY7tfSG0j8PfffzN48OCM1xISEsx+TcWhJbEk+WIsdXQOxiv9+LReXXo0O49//CWcTp3Fc/9Zrp+MZIzXb/Sv05/X277OV2Na8vfG76ga+hM/fniJH/3v0DCmNJ0vxNIgJhnXlDMA7Decxdj1O+LjblKydPl7RCGKo9xG3oYSJXLd7uzhkaeRe1ZKqWzfx8fH8/TTTxMaGkr16tWZMWMG8fHxGftkbuv7zDPPMHnyZPr27cuWLVvuWkgkK6PRSPny5dm7d2++48yP4tCSWGryxVjrWp44GxSgOO3uz2eG+6ky8RPuX7Od1qEHafH9BkY1GsWev77j94GduP1IF7rNnUvdbcdpnFSRBV0WsHzCn3T4+wCJa7ey4e0PONq0Mp77j/PTs/043roNaycP4dqlCGtfqrADZ86cyegdv2LFCtq3b5+R0L28vIiNjc0YEZsSExOT0e73888/z/VcZcuWpWbNmnzzzTdAajLet29foa8hp5bESUlJABw7dozbt28X6NiZWxIDZmtJLEm+GAvy82BwcHXSx0cpKam19nTeFaozOXgy4/Z5UvXQFeLLuHJufF98t2zk4flr6VS9Ey6G1L45LWp6MbF/Vxr+bxYvPaJwOXCc656u1Fx/gIge97P+1Ue5GXPVRBRC5E39+vVZuHAhDRs2JDo6mqeeeory5cszduxY/P396dGjR65teGfMmMHgwYMJCgrCy8vrnudbvnw5S5YsoWnTpjRu3Jgffvih0NeQuSXxvHnzePzxx2nUqBGBgYH4+/vzxBNPFHhUnrklcVBQEGXKlKFcuXKFjlnaGhRz6TdN02vtpm6aJibEcfXiaarWyL1Pd7pnfnuG41ePsOr+/+Pyif0cf3cm5U5cZvqznjwSNJah9Yfi7pz95q6wXdZuaxAREUGfPn0IDw+3WgzFQV5aEktbAweTl/nurm4l85zgAeZ0mkOyMZmSLiUpG9iFul93IfzUduqcXMa8f2ZR7sX51J4ynSYd+pvzUoRweJZoSSwjeZEvO/etJ2ncFMrEpnBxTE+6/WcOBoNU/WydtUfywnzyO5KXf512JK8PNBXmwaeWTXvR6Mf1nG/gie+nv/DzyPu4ef1SQUMWQliYJHk7YeqJ1sLslxuPSr50X7WFM8M74rf7Ij+P7c3R60eznUeeoLUttvRbuyiYgnyGUpO3E3ntKmmu7pNOTs70ePVj9rRazpoTi/jfuodpFxNIR6caVG43kMe/OS1P0NoQd3d3rl27hqenZ7b56qJ40Fpz7do13N3zN+lBkrydyOuKTuZe+al59+GMq9mGCb++hu/2HTQO+4uU97/ircru/Olblw2VBkgbYxvg4+PDuXPniIqKsnYoohDc3d0znpTNK7nxakfyuqKTuVd+Wrj5BHM2HEWlJNIkbhc94g/jd/QkNaOSuOBhYPObj/Jc28fwcJdEL4Ql5HbjVZK8KDRTc/UB/lq/nLirv7PC9zglDG68eKgOLcdMoXrdQCtHLIR9kSQvLC633w5O3TjFmvVz6fbGbygNES2rUX/iy9QN7JLvYwkhspMkL2zChVMH2LNgJlU3hWPQEDfzGdoMePqufaTtsRD5J/PkRZHKafpk1VpN6D3vG3x+/pGrldy5Oe8DNpz8+a59TM3+EUIUnMyuEWaVl5G4t09dgleu4+WNk/lr21QSVQp9aqWugONR0hWDUoCWtWeFMAMZyQuzym0knnmEX86rKrMGfUZLz0AiX57Kzp8WExYZzcy1B0kxagxKMb1PYynVCFFIMpIXZpXTPPycRvhz2rxN2KyeOE2bw9ZJriQme6JJffAjOi7RuhcjhB2QJC/MKqeumJlH+IlJRuZvOsak++oR5FeZ+ku+IPKhYXSe8zZBJQxEernwTr/KhCcGcOL8SOpUa2LlqxKi+JIkL8zO1ALk6SP8xCQjRmDbiavsirieOqKvHcCdxR9xeMl84mNiuekGTav6sPfyZi6++hPHalbE+NBYIsu3lmmVQuSTTKEURSYsMpr5m46x7cRVjBqcFEzuXp/xneuY3P9a9AX+mT2ViutCKRWvOeBTgh/rd2Dic6/QopZ3EUcvhO2SKZTCJgT5eTDpvnq4OhtwUtxz9oynR1V6vfkFf7+5jKUtG1H1RgKv/PYrn6wYxOpjq0lISShQt0vpkCkciYzkRZHL7xOt6TdtjYnxtL31K1e7XCby9gmG7nCh5JXybKnShuPlW/PV2Pb3PJ48bCXskSz/J2yKqZr9vfb/92ZuJwJ9yxN6OZSDG6fQ/OhF7j/4HVFl1rDvcm3cx4yjUeveObbTNVerZSGKC0nyoljI+oOhReUWGN78jlEf/0rw1U10PLufFtuOs/nmFKYM/YjuVToREB6HZ93GVKsfhEclPwwGg9lbLQth6yTJi2IryM+DJU/2YMepYBrV8sSnxC18T/5G1Vt/s+HvL+j+aTIAV4AIN7jh5c7V/g8wIHAwChgQ6COjeGH3pCYv7FJC/G3OHg0l6th+bp0+TuKZM6gTZ1jYNZGT9ELd7Cz1eGE3pCYvHI6beynqNO1InaYdM157//fDnD74Bq5l1tPsbATbT9SWJC/snkyhFA6jXe3K6CsP0/hAA17ecIAqn08gKTHe2mEJYVGS5IXDSJ2l05b2vd5if59AGu08y8YR3YiLvVHoY8vce2GrpFwjHErGLJ2uy9lY9Tn8Fq1n2+BulH7rNWrVa0HFkhVznH6ZE5l7L2yZxZK8UmoGMBZIXx7+Za31ekudT4j86jZ5Dn9W8KLSrC947eepnNiv6HjCjb67ING3Eq51auPRMADfgHZ4V6+PwWD6F1+Zey9smaVH8vO01rMtfA4hCqzD6JeI7jWclxPOc+J2BHG3t6Cd9lBp12lK/3kK2Mh15jDhhSq82nc+Ad4B2Y4hc++FLbPYFMq0kXxsfpK8TKEUtsJoNHL1wgnO7NvGtSP7me93mKj4q7xbazJd2j6cbX9ZfFxYk1UW8k5L8qOBm0Ao8JzWOttdKaXUOGAcgK+vb1BkZKRF4hGiMK7HX2feR6N4aNEJzj3SmW4vfpBj+UaIomaxJK+U2gRUNrHpFWAHcBXQwH+BKlrrMbkdT0bywpbFxd5g87j+1Np9iZNd6tJj/ipcXN2tHZYQ1hnJZwmgBrBWa+2f236S5IWtS0lJ5uepI6j90z4iGlcg5LMfKF3Oy9phCQdnlX7ySqkqmb7tD4Rb6lxCFBUnJ2f6zPqa808/QNUj1/n2v6OtHZIQubLk7Jp3lVLNSC3XRABPWPBcQhRafm6e3vfsu8wP8uLzk/9H/8SblHUtW0RRCpE/FhvJa61Haq2baK0DtNZ9tdYXLXUuIQor/YGmORuOMnzxjjw9udq5Xg+SdTJbz/xRBBEKUTAyPUAITD/QdC9NvJrwwlpn9Ix5RRChEAUjSV4I/n2gKS9rz6YzKAMVPKtRdf9F7sTdLIIohcg/SfJC8O8Sg5O7189z75mwyGhO1W1NiUT4Z/ncIohSiPyTBmVCpMnP2rPpNfzkxMbUqOxG1YWruNBlAFVrZ297IIQ1yUheiAJIr+EnK1dmNR+NwajZOnMCKcYUa4cmxF0kyQtRAJlr+FGl67P/hdG8G3KdpQeXWjs0Ie4i5RohcpDbvPn0Gn769kDfnoT/GcXifz6gdZIv/oHdrRS1EHeThbyFMKEgC4HEJMTw+4COVLhppM2mHbi6lSyiaIWjs0pbAyGKs4LMmy/nVo7Kox+jYlQSWz54pQiiFOLeJMkLYUJB5s0DtBo4njN1ylJ++a/EXJOHvIX1SZIXwoT8zJvPvIi3wWDA56VXKBOn+et/zxVhxEKYJjdehchBTvPmM9+QBbLX7tv1ZW2rBdw5sI+LsRepUrpKtmMIUVQkyQuRD1lvyA4I9Mmo3SckGfl29zmC/DxoPvtj+v48mJ57P+DN9m9aO2zhwKRcI0Q+ZL0hqwBngwJSe2qvDjtHWGQ01bxrM7zRCP7c9yOH9222aszCsUmSFyIfst6QHRDow+Dg6qi07Skp/87Eeazxo7z1hZHIV1/CaDRaL2jh0CTJC5EPpm7IDgj0wc0l+0ycciU8uDOwK37HYti55mMrRy4clTwMJYQZ5PR0bMKdWA63bMH5gCr0Xv67FSMU9iy3h6HkxqsQZpDTTJztK+ZRKQlKde5ohaiEkHKNEGaVec48QNzpk0R6w6Z6CcQnx+e4nxCWIiN5Icwk8/RKZ4NicHB1+o2Zxe4+/8ePRxdzKeIg01tOI6pEnXz3xRGioGQkL4SZZJ5emZiiWfHPGUYuDSW4ykg+6PoBPb8+xZWHRrFt9Yf57osjREFJkhfCTNKnV6ZPp9T8m8Q7+HSgxezF3PRwo+unXzH0/JJ898URoiAkyQthJunTK4e18jXZ3MyvUSta/fgbkQFejNh5mIntvTNKNVlr9FKzF+YiNXkhzCh9ls3AQB+TUypLlalAyR7dMexfQc+qt6mXluAz1+in92nMzLUHpWYvzEKSvBAWkNui4FVC7uOtM6s4u+9lBt7ujzGm8101+p/DL2ar2UuSFwUl5Rohilj9em14fsIKmtVow/Wln1Nl9at3lXfu969SoF72UuIRpshIXggraOLdhLmd5rLuxyHUWn+AWW9c4Yxnu4zyTv3KZXJcX9aUgixXKByDjOSFsJKwyGhOdX2B6DIGSn04nwd9btG8ejkgtdwzvoGMWjIAAB9eSURBVHOdPCfqgixXKByDjOSFsILMI++OQR2ZsmUztx54mBm9yxDdqxXN3GrT5GpJ6rbtiUdF33seL336ZlKyUaZlirtIkhfCCjKPvP/06E2zKa1odGM/JX2T2HcrkoSNm2m7JoVLzOOghzOJ7s7Etw2g15ufmzxe+vTNHaeu4VHSNWMkLyUbIUleCCvIOvJu37UvQX6j6Ja2PabTZY6HrCdq93aMx05S4tw1Kq7dSdRzZ/GuUN3kMdMTutTmRWaS5IWwgswjb1M3V8uVr0Rw70eh96MARETuY+gvw3n07DqerPBkjsc1VZuXJO/Y5MarEFaSn5urNfya0qxWO745uoqklKQc98u6cpXU5oWM5IUoJoZ5dOf2G3/yT9J7tB/+vMl97vUbgnA8MpIXophoF9CbcolOJHy2nJSU5Bz3y+/0S2HfJMkLUUy4uLqT/PgQqp6P588l/7V2OKKYkHKNEMVIyOiX2fz1D1RY+A1/NQsgtmIpki5dovT+07Qe8RwlSpa1dojCxkiSF8LGpS8S7lHSlei4RKo//jTVXpvN0pXT2RJgoP5ZzX+/SuG30F30WbTe2uEKGyNJXggblv5kbEKSEQ0YFLg6V2Xu3LcYV8uLSZWr4q6d2X/1eWr/Es6WJf+l02OvWjtsYUOkJi+EDUuf967Tvk+f/366RBOaNAihdvnaVPPw4753v+RszdKUfW8Fpw78ZdWYhW2RJC+EDUuf957+D9WQw/x3F1d3/Bd+RoqT4sjUSSSkJBR9sMImSblGCBuWtSdNdFxijvPfq9ZqQuQbk5l9Yj67d81iWutpVohY2BpJ8kLYuNxWmcqqTe/H6bXrBp8fXEZbY026tB1u4eiErZNyjRB2ZmLgRJ4J9aLcU28QeXintcMRViZJXgg74+LkQs8Js3BKgQPvy0NTjk6SvBB2yLdBC1KcABcXa4cirEySvBB26E7cTUomgFMF6V/j6CTJC2GHrl84BYCrV0UrRyKsTZK8EHbodilnXhvuRHKrAGuHIqxMkrwQxVBYZDQLN58gLDLa5HZf7zoc83PmqFNUEUcmbE2hkrxSarBS6qBSyqiUCs6y7SWl1Aml1FGlVI/ChSmESJfez2bOhqMMX7zDZKJ3d3anc3RljL9uKfoAhU0p7Eg+HBgA/Jn5RaVUI+AhoDHQE/hQKeVUyHMJITC9jqspXfdp2qw+gtFoLOIIhS0pVJLXWh/WWh81selB4GutdYLW+jRwAmhZmHMJIVLltI5r1hKOW5MmlL2tObZrgzXDFVZmqbYG1YAdmb4/l/ZaNkqpccA4AF9fXwuFI4T9MLWOa3oJJzHZiKuzgeWPtyZ4xEQiP1vHuU/fo0GrntYOW1jJPUfySqlNSqlwE38eNEcAWutFWutgrXWwt7e3OQ4phN3Luo6rqRKOh3d1zoXUpfr2CK5eOJnx3nvdtBX25Z4jea31fQU47nmgeqbvfdJeE0JYQHoJJynZeFcJp8ETz3Ft+5Ns2ryUh4a/YXLELwt+2zdLlWt+BFYopeYCVYG6gHRKEsJCTJVwAOo07cjct0I4fGsbA1OSTI74Jcnbt8JOoeyvlDoHtAHWKaV+BdBaHwRWAYeAX4DxWuuUwgYrhMhZ1hJOuocDHuHa7Sg2/rM8zzdthf1QWut771VEgoODdWhoqLXDEMKuGLWR1UNaU/lCPG0272T/xTv3vGkro/viRSkVprUONrVNnngVws4ZlIFq/R/C+1oSfy17O083bYX9kCQvhANo89AkLlRzx3nZdyQmxN21LacSjrAPkuSFcAB7zsZwsMeDeF1PZusnr9+1Lf2m7eTu9aVUY4dkjVch7FxGzT0pCN8qa4jZ9BMvB3jxesgkXJxSFxXJzzqyoniRJC+EncuouWNgWtBkSnn+QlzkF0Qe+51X/MfTqG0fa4coLEjKNULYufSauwJinT25HDOc+LOj6PbLRYyPvcC6l0aQeCfunscRxZMkeSHsXHrNfVgr34wbrE4Jjak9fTkRrX2p9X0Y2+5vy47vPiQ25mqOx5G59MWTzJMXwoGERUZneyr271Xvo2Z9QvlbRhb1cqbsoAG83vb1bO+TufS2K7d58lKTF8KBmLrB2nbIs8T2GM6hzd8Sc/tnjl7ale190g6h+JJyjRCC0uU8adlvHEGRTnTYdSfbdplLX3zJSF4IkaH2P+cxJCRlez2nBmjC9kmSF0JkMCQkYXQ1nRZkLn3xJOUaIUQG54QUjO4u1g5DmJGM5IUQGbNu/BOS0W6u1g5HmJEkeSEcXObpkV8mpnC9jLu1QxJmJEleCAeXeXrkS4PqkOQTy3BtxKCkmmsP5FMUwsFlnh4ZpVoTmxJF2OUwa4clzERG8kI4uMzTI5v7BRI+ZTkXDs6Gd1daOzRhBpLkhXBAWdsbpP+5cu4YHuFGzgR5WTtEYSaS5IVwMLn1oTm1YyPlAO/ANtYNUpiN1OSFcDC5rekafWgvAJ7V61orPGFmkuSFcDAeJV0xKIXBRB+aGt36keACRyc+yY070lLYHkiSF8KBhEVGM3PtQVKMGoNSTO/T+K5WBQ3b9Cbxjcl8GWJk/OYJxCXFZXu/9JQvXiTJC+FA0ks1GtBaEx2XmG2flg+OZdSoOYRfDWfuwpHcibsJ/FvLn7PhKMMX75BEX0xIkhfCgeS1ZfB9fvfxTo1n6f/JITaP7k1iQhzf7j5HQpLpWr6wXTK7RggHkp+Wwfd3eIyNYw9Rc9F61j3ah+9q/gedNi50MijpKV9MyEheCAcT5OfB+M518tQ2uNvkOUQOD6HB7os8fWg2aCMKGBxcXdoOFxOS5IUQuer56iL292pKt8NXaJ30JW4uigGBPtn2k5uytknKNUKIexo8ewVz6kzgYKmt9PcNJ9D3/ru2y0LftktG8kKIezIYDDz/1EIG1h3I4R1fsH5wey5HHs7YntsDVsK6JMkLIfJEKcVrbV7jSa9+VDtyncj+A9n29TwgddaOs5MBBTg5yULftkSSvBAiz5RS9Bz7BqW//IhbHm5UmLGI9a88krpR67v/K2yCJHkhRL7Vad6JkLXbONnKB7/vdrHpt69JNmo0kGLUUq6xIZLkhRAF4lqiJCFzv+CXXt6sdvkM11IX7vmQlSh6kuSFEAVWzrMKI2Z+Q4USFajnsZRnGt+WmTU2RqZQCiEKpVKpSnzc9SNO9HuQEgkzqRbiD0iStxUykhdCFFpNj1pUfetNSsalcHjUw1y7eDrfx5CHqSxDkrwQwiwat+uL8e0pVIhK4ODgBzlzZFee3ysdLi1HkrwQwmyCez+Knj+dkrHJbHl1HIeuHbrnCD0sMpr5m47Jw1QWIjV5IYRZNes2jBOfV2P1gZks+Hk0tyMfJj62rsl2B+kj+ISk1B73plarEoUjI3khhNnVadqBxQNWUD7Fm/9uWUTXK9+aHKFnXsTEALSr4yWzc8xMkrwQwiIqlqzIa4FzSNElmLxtO0+dmEejEncn+cyLmLi6GJh0Xz1J8GamtA09ghwcHKxDQ0OtHYYQwoz+OXaeo2+MIXDXGVIMcK5zfQJnzKeKVw0gtWSTl0VMRM6UUmFa62BT26QmL4SwqFb1qtHqi1+JPPQPB+a9DgeP0Xt9fzr5diZg+x1uOlemcduuBPnVsXaodklG8kKIInXuxhmWHfmCzaf/YNbb5yiRtpb4gdG9GDJ1jnWDK6ZkJC+EsBk+5X2Z1noaHnce4pGe/1Aj7jBP7P+Jij9uIOWFZJycJC2Zk9x4FUJYRetaniS7VeBwmTb81KAlla4ns3vdMmuHZXfkR6YQwiqC/DxY/nhrdpy6RlDV6Xzn2p849tDC2oHZGRnJCyGsJsjPg/Gd69C6fnVKjH6YdTe2cSXuirXDsiuS5IUQNmFQvUEEH07ir8/esnYodqVQSV4pNVgpdVApZVRKBWd6vYZS6o5Sam/an48LH6oQwp75lvVl4OGyVP5iE0mJ8dKV0kwKW5MPBwYAn5jYdlJr3ayQxxdCOJAyQwbhMXMx3738GK+5P0xiCiZ73oi8K9RIXmt9WGt91FzBCCEcW+vBz3CyZTUC1u5mfPj/MKTES1fKQrJkTb6mUmqPUuoPpVRITjsppcYppUKVUqFRUVEWDEcIYev2XbhNxKgP+adbAF2ORBHo9DEuLonSlbIQ7lmuUUptAiqb2PSK1vqHHN52EfDVWl9TSgUBa5RSjbXWN7PuqLVeBCyC1Cde8x66EMKepLcdTkw24lp+NKNfOsgRvuSB6ocI8utv7fCKrXsmea31ffk9qNY6AUhI+zpMKXUSqAdIzwIhhEnpbYfTFw4p49uPXk5RXP39W643GkGFyn7WDrFYski5RinlrZRySvu6FlAXOGWJcwkh7EPmtsPpC4c8Vq4Xz319hx0LX7N2eMVWoWbXKKX6AwsAb2CdUmqv1roH0AGYqZRKAozAk1rr64WOVghhtzI/AZvRdtivI5uql8Sw94i1wyu2CpXktdbfA9+beP1b4NvCHFsI4XiC/DyyTZWM962I995IK0VU/MkTr0IIm+ZSpxZlb2uuXjhp7VCKJUnyQgibYeopV4+GAQCc2bfNWmEVa9KFUghhE+6aQpnpKVffdt0Z89gCHvExEGjtIIshGckLIWxC1imU6U+5VvKqwY1qZTlxO8K6ARZTkuSFEDbB1BRKAKUUPc57UvaHrVaOsHiSco0QwiaYnEKZvu20ovofZ9jZehEtHxxHWGQ0O05dw6OkK9Fxidn2F/+ShbyFEDbvytmjhD/yEN6X4znyeH9ejQ7JKO0owM3FsTtV5raQt5RrhBA2r2L1+gStXs+F2mXxX/Q9fSMXYzQaAdAgnSpzIUleCFEslPOsQqdVv3GkWSWqJh/GzXsDkJrEMtfwxd2kJi+EKDbcSpSm7/JNjP7hRVxvbaCDT3WaVRqQrSafXrOXWr0keSFEMbP33C127elCpRKnGLFmKVcfSyGo80sZ23Oab++opFwjhChWUufTw8UbDxPn6oLXsuUkJcZn2Z59vr2jkiQvhChW0ufTpziV5P+adKRidApbP3sz2/as8+0dlUyhFEIUO+k191Y1PIgZ241yV+O5NqonXSb+DxeDi8PV5HObQilJXghhk/KaqE+H/83Rlyezz+MmW/vV4vng5+lUvVO+j1Oc5Zbk5carEMLm5OfmaU3/tvit+ZuSZ/7g773z+WjpeGIv1abr7K84FJXi8DdhpSYvhLA5+b15ajAY6FCjM6v7rmZYciC1fz/O9t4d+WvrRoe/CStJXghhcwp689TF4EK/mV8S88YEytxIIOTd16gfv9ehb8JKTV4IYZMKW0u/cHI/Z4YO42Y5N46+9BVt61ax21KN9K4RQhQ7QX4ejO9cp8CJuWrtABKeGUGobzyeFXfZbYK/F0nyQgi71eGRqUQ+HML74R9x+fblbNtNLTdobyTJCyHsllKKaa2m0eB4PFvHDuDCyf0Z29Jn8MzZcJThi3fYbaKXJC+EsGvVy1and5le1D5wnUv9h7Jx7nOkpCQ7TPsDSfJCCLsWFhnNq9EhjO/2NMcql8Jn0Xp+69OGRiWuOUT7A3kYSghh19JH7Bdca/FK4GtMbrOJdt9uIOzHt1j+xDK7fxpWkrwQwq6lz7lPSjbi4uxM6zEzCO9Ug/lnPmOBYR/jO3eydogWJfPkhRB2L+uc+yRjEkN+GkLpCzF89PA3lC5XvEs10rtGCOHQgvw87irHuBhceLXWUzi/PJE/z02m15ufWzE6y5Ibr0IIh6TLtuBM1ZKosIPWDsWiJMkLIRxO+hz5k6XLUOFynN3OkQdJ8kIIB5Q+4+ZsGS/K3tH8tWf/vd9UTEmSF0I4nPQZN+dK+QBQM/GklSOyHLnxKoRwOEF+Hix/vDWb9yjmlN/IA7VdrR2SxUiSF0I4pCA/D5pV70bLW+400lesHY7FSLlGCOGwnAxO+KuquK9Yh9FotHY4FiFJXgjh0IZH1aPz+gssfOtlu5xlI0leCOHQPPpO4VRFF5qv+ZHHPv7V7hK9JHkhhEPbeeYWHzZ9EM9YzeBTy+yu5bAkeSGEQ2tdy5OT5duyrXZ57jt2hpa+ZawdkllJkhdCOLT06ZQ3O3ZlewNwczpt7ZDMSpK8EMLhBfl5MObZ5/mspzN/3dht7XDMSpK8EMKh5LR4d3n38jSp4M/RsE333Lc4kYehhBAOI70xWWKyEVdnA8sfb31XC+KHw9yp8fUervU6TURi+Vz3LS5kJC+EcBj3Wrzbt/MDGIAD67+ym4W+JckLIRxGemOynBbvbtiuDzfKGDB8toqG7lF2sdC3LP8nhHAoWZcCzGrf76tImfQasWVdSJmzhENxHja/0Lcs/yeEEGmyLgWYVdMuQ9g7J4Ub/3uDlcdf59OhqyjpUrIIIzQvKdcIIUQWzboNo/zSD9mfEsn60+utHU6hSJIXQgiyT5csmdKEJtcrc37+e8W6Q6WUa4QQDi/r1MrpfRozc+1Bup/zpvv2Paxbs5wHBoy0dpgFUqiRvFJqllLqiFJqv1Lqe6VU+UzbXlJKnVBKHVVK9Sh8qEIIYRlZp0v+HH6RxGQjG70e4I4LpCxeQFJivLXDLJDClms2Av5a6wDgGPASgFKqEfAQ0BjoCXyolHIq5LmEEMIisk6tvN+/Cq7OBhKdy7K0VTD1T93i1+eGWTvMAilUuUZrvSHTtzuAQWlfPwh8rbVOAE4rpU4ALYHthTmfEEJYQnqTssxTK+tXLpP2/fucnD+W2j8f5OfPpnP/mJnWDjdfzFmTHwOsTPu6GqlJP925tNeyUUqNA8YB+Pr6mjEcIYTIu6xTKzN/n/zuCpaUHsQi9QPlLvSkbdW21goz3+5ZrlFKbVJKhZv482CmfV4BkoHl+Q1Aa71Iax2stQ729vbO79uFEMLinF1cGTH9//DzrM2M9ZM5sX+rtUPKs3uO5LXW9+W2XSk1GugDdNX/Pj57HqieaTeftNeEEKJYKuVSigWdF7B74P1cWDYev9934uLqbu2w7qmws2t6AlOAvlrruEybfgQeUkq5KaVqAnWBnYU5lxBCWNul6yWJ6PwA3leT+GfVAmuHkyeFnV3zAVAG2KiU2quU+hhAa30QWAUcAn4BxmutUwp5LiGEsJr0ufTvxbTkSlkDt75addc2W+07X9jZNXVy2fYm8GZhji+EELYiYy49zqxr0IBHdx7i8PZ1xFVta9N956WtgRBC5EHmufSbqg3gjiuE/bTE5vvOS1sDIYTIg6xz6bd2Oc7Si2t4p0oirs4GkpKNNtl3XpK8EELkUea589fjh6Ev/MCmk1+x/PEXcu1Rb02S5IUQIo/SFxzxKOnKzLWn6BpVhYe2f8/tpQ8xvnOAtcMzSZK8EELkIPMqUkDGDVaDUqQYNe5xpSiVANuOnqRDoCR5IYQoNrK2Hx4Y6JNxgxU0TgZF+7PHifByoX3bTlaONmcyu0YIIUzIOmtGQ8bsGldnAy+3MtDgYgI32ze3uTp8ZjKSF0IIE9KnTKbPmhkY6MPAQJ+M8s3tzR8DEPDgECtHmjtJ8kIIYYKp9sPprwNsquvDJ/cbGF/NZINdmyFJXgghcpC1/XBmXnWb8FszAymHP+EdjzcpVaZCEUeXN1KTF0KIAmhWsRmvtn4V/0//YNvg7kRfOWPtkEySJC+EEAU0pP4QGvUbTeWzt9k3+AEung7PdX9rNDKTJC+EEIUQMmIKibNepGx0IqceeoiTOSwokj4lc86GowxfvKPIEr0keSGEKKTgXqNx+/hdnJONnHviSQ5e2pdtH2s1MpMkL4QQZtC47QNU/HwxKwd5M+a3cey+vPuu7Zm7WBZlIzP174p91hccHKxDQ0OtHYYQQhTYlbgrjPm/gTT1DuDNvgvv2pa5TYI5H6BSSoVprYNNbZMplEIIYUYVS1Zk0v/dJrHcPuh797bcpmRaipRrhBDCzIzOBgxJydYOA5AkL4QQZqddnDAk2cay1pLkhRDCzIwuTrjcSSIuLiZP+1ty/rzU5IUQwsxulylDjUPR9F3SEb96QQysO5BetXqZ3DdrS2NzLwQuI3khhCiErKPwsMhoZlR7klfu68OFlHb4rtlN2Jfzcny/pefPy0heCCEKyNQofMepa8RpV3aX7oTTJSP379jMlWCXHI+RtaWxuefPS5IXQogCMjUKz5y0/ZJOUOaO5lbTpjkeI6eWxuYiSV4IIQrI1Cg8c9KuuPtPAHzb3JfrcSw5f16SvBBCFFCQnwfT+zTm5/CL3O9f5a6FRYL8PPh563UAynpVtVqMcuNVCCEKKCwymplrD7LtxFVmrj2YbQpk3Qce5kYp2PbPt1aKUJK8EEIU2L1mxtRp3pn50/35puRBK0UoSV4IIQosL50l76/dm4NXDxBx5ZgVIpSavBBCFFheZsb0qNyRWh/+j0On3qbGzKVFHqMkeSGEKIR7zYyp4lWT/d5lKLllN0ajEYOhaAsoUq4RQggLM3TrQKUriRzbtaHoz13kZxRCCAfTfOjTJBvg5OplRX5uSfJCCGFhXlVqca5BBcpvDcdoNBbpuSXJCyFEEXAaPYRPumkORGVf5NuSJMkLIUQRaNR5IHvqGDh1M6JIzytJXgghioB3SW+anTQSd7hoH4ySJC+EEEXAzcmNiT9qyv26q0jPK0leCCGKSGxZFwzXbhTpOSXJCyFEEYn3KIlL9O0iPackeSGEKCLJHmUoeSO+SM8pSV4IIYqKwYDSRXtK6V0jhBAWEhYZfVfzsp33+3E9CNrmsN0SJMkLIYQFZF7k29nJwKAgH065JeJc0yvb9vRFwC2R6KVcI4QQFpB5QZHEZCP/988ZSv1xiupHU2vy3+0+R0JSzguOmIuM5IUQwgLSFxRJSDKiAQ0M+/sa0ZWSCRsQzTehZ0kvzzs5mV5wxBxkJC+EEBaQvsh3gE85nA3gpOBYJQ8aHbnOtq/nkWxMTfEKGBTkY7GavCR5IYSwgPRFvg+cj8FgMDC0pS/N3vqCi74l6fDlNzS+E4qTAjcXAwMDfSwWhyR5IYSwgMw1+ZQUI9XKl6Bto5o0XrIct2R48sR6Jnevb7EbrumkJi+EEBaQXpNPSjbetcj36qsbWTfWiWl1RjO+cx2Lx1GoJK+UmgU8ACQCJ4FHtdY3lFI1gMPA0bRdd2itnyzMuYQQojjJaZFvdyd3WrcZRPu2TxVJHErrgj9+pZTqDvyutU5WSv0PQGv9YlqSX6u19s/P8YKDg3VoaGiB4xFCiOJAa41SymzHU0qFaa2DTW0rVE1ea71Ba52c9u0OwHJ3D4QQwk6YM8HfizlvvI4Bfs70fU2l1B6l1B9KqZCc3qSUGqeUClVKhUZFRZkxHCGEEPesySulNgGVTWx6RWv9Q9o+rwDJwPK0bRcBX631NaVUELBGKdVYa30z60G01ouARZBarinYZQghhDDlnklea31fbtuVUqOBPkBXnVbg11onAAlpX4cppU4C9QApuAshRBEqVLlGKdUTmAL01VrHZXrdWynllPZ1LaAucKow5xJCCJF/hZ0n/wHgBmxMu5GQPlWyAzBTKZUEGIEntdbXC3kuIYQQ+VSoJK+1NjmTX2v9LfBtYY4thBCi8KStgRBC2DFJ8kIIYcckyQshhB2TJC+EEHZMkrwQQtgxSfJCCGHHCtWF0tyUUrf4tz2xI/ECrlo7CCuQ63Y8jnrtlr5uP621t6kNtrZoyNGc2mXaM6VUqFy343DU6wbHvXZrXreUa4QQwo5JkhdCCDtma0l+kbUDsBK5bsfiqNcNjnvtVrtum7rxKoQQwrxsbSQvhBDCjGwmySuleiqljiqlTiilplo7nqKilIpQSh1QSu1VStntoipKqc+UUleUUuGZXquglNqolDqe9l8Pa8ZoCTlc9wyl1Pm0z3yvUqqXNWO0BKVUdaXUZqXUIaXUQaXUxLTX7fozz+W6rfaZ20S5Jm2BkWNAN+AcsAsYprU+ZNXAioBSKgII1lrb9dxhpVQHIBb4Qmvtn/bau8B1rfU7aT/YPbTWL1ozTnPL4bpnALFa69nWjM2SlFJVgCpa691KqTJAGNAPGI0df+a5XPcQrPSZ28pIviVwQmt9SmudCHwNPGjlmIQZaa3/BLIuHPMg8Hna15+T+o/BruRw3XZPa31Ra7077etbwGGgGnb+medy3VZjK0m+GnA20/fnsPJfTBHSwAalVJhSapy1gylilbTWF9O+vgRUsmYwRWyCUmp/WjnHrkoWWSmlagDNgX9woM88y3WDlT5zW0nyjqy91joQuB8Yn/brvcNJWwTe+rXDovERUBtoBlwE5lg3HMtRSpUmdZW4SVrrm5m32fNnbuK6rfaZ20qSPw9Uz/S9T9prdk9rfT7tv1eA70ktXTmKy2k1zPRa5hUrx1MktNaXtdYpWmsj8Cl2+pkrpVxITXTLtdbfpb1s95+5qeu25mduK0l+F1BXKVVTKeUKPAT8aOWYLE4pVSrt5gxKqVJAdyA893fZlR+BUWlfjwJ+sGIsRSY9yaXpjx1+5kopBSwBDmut52baZNefeU7Xbc3P3CZm1wCkTSmaDzgBn2mt37RySBanlKpF6ugdUpvFrbDX61ZK/R/QidRufJeB14A1wCrAF4gEhmit7eomZQ7X3YnUX9s1EAE8kalObReUUu2BrcABwJj28suk1qft9jPP5bqHYaXP3GaSvBBCCPOzlXKNEEIIC5AkL4QQdkySvBBC2DFJ8kIIYcckyQshhB2TJC+EEHZMkrwQQtgxSfJCCGHH/h+5FKuehZ5i1gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(6,6))\n",
+    "plt.plot(*emissions.T,'.', label=\"observations\")\n",
+    "plt.plot(*ssm_posterior.filtered_means[:,:2].T, color=\"C2\", label=\"serial filtering\")\n",
+    "plt.plot(*pfms[:,:2].T, \"--\", color=\"C3\",label=\"parallel filtering\");\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "702dcd7b-9229-4d00-8107-4be74eb7a018",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "702dcd7b-9229-4d00-8107-4be74eb7a018",
+    "outputId": "e05ccdc2-8f49-4b13-ce1a-54a1d96c3f8a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.15887868"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.abs(ssm_posterior.filtered_means - pfms).max()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Pp55tx2jMU_9",
+   "metadata": {
+    "id": "Pp55tx2jMU_9"
+   },
+   "source": [
+    "### Smoothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ccadedd-0de9-4f1d-9e76-0e403bc33670",
+   "metadata": {
+    "id": "9ccadedd-0de9-4f1d-9e76-0e403bc33670"
+   },
+   "outputs": [],
+   "source": [
+    "def last_smoothing_element(m, P):\n",
+    "    return jnp.zeros_like(P), m, P\n",
+    "\n",
+    "def generic_smoothing_element(params, m, P):\n",
+    "    F = params.dynamics_matrix\n",
+    "    H = params.emission_matrix\n",
+    "    Q = params.dynamics_covariance\n",
+    "    R = params.emission_covariance\n",
+    "    Pp = F @ P @ F.T + Q\n",
+    "\n",
+    "    E  = jsc.linalg.solve(Pp, F @ P, assume_a='pos').T\n",
+    "    g  = m - E @ F @ m\n",
+    "    L  = P - E @ Pp @ E.T\n",
+    "    return E, g, L\n",
+    "\n",
+    "def make_associative_smoothing_elements(params, filtered_means, filtered_covariances):\n",
+    "    last_elems = last_smoothing_element(filtered_means[-1], filtered_covariances[-1])\n",
+    "    generic_elems = vmap(lambda m, P: generic_smoothing_element(params, m, P))(filtered_means[:-1], filtered_covariances[:-1])\n",
+    "    combined_elems = tree_map(lambda g,l: jnp.append(g,l[None,:],axis=0), generic_elems, last_elems)\n",
+    "    return combined_elems\n",
+    "\n",
+    "\n",
+    "@vmap\n",
+    "def smoothing_operator(elem1, elem2):\n",
+    "    E1, g1, L1 = elem1\n",
+    "    E2, g2, L2 = elem2\n",
+    "\n",
+    "    E = E2 @ E1\n",
+    "    g = E2 @ g1 + g2\n",
+    "    L = E2 @ L1 @ E2.T + L2\n",
+    "\n",
+    "    return E, g, L\n",
+    "\n",
+    "def parallel_kalman_smoother(params, emissions):\n",
+    "    filtered_means, filtered_covariances = parallel_kalman_filter(params, emissions)\n",
+    "    initial_elements = make_associative_smoothing_elements(params, filtered_means, filtered_covariances)\n",
+    "    final_elements = associative_scan(smoothing_operator, initial_elements, reverse=True)\n",
+    "    return final_elements[1], final_elements[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ad0108-9915-449d-934d-e51309072e79",
+   "metadata": {
+    "id": "86ad0108-9915-449d-934d-e51309072e79"
+   },
+   "outputs": [],
+   "source": [
+    "psms, psPs = parallel_kalman_smoother(lgssm_params, emissions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ececd5c-7439-4f9e-9b56-5e99543f19cc",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 374
+    },
+    "id": "5ececd5c-7439-4f9e-9b56-5e99543f19cc",
+    "outputId": "6748ee00-de9e-4041-d581-333d68653f9c"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAFlCAYAAAAOF5jdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deVxUZfvH8c89LCK5oZKaKO57puK+ZpZpj7mlqZlplmbZYmZZv0zNlqd60iyzzMxMHytbrcyn3EszLDAz3HJJXHNBXFFZ5v79IRAgIArDDMP3/Xr5kpkzc851GLy8uc517ttYaxEREe/kcHcAIiLiOkryIiJeTEleRMSLKcmLiHgxJXkRES+mJC8i4sV83R1AWmXLlrVVqlRxdxgiIgVKZGTkUWttcGbbPCrJV6lShYiICHeHISJSoBhjorPapnKNiIgXU5IXEfFiSvIiIl7Mo2ryIpK9hIQE9u3bx7lz59wdirhBQEAAISEh+Pn55fg9SvIiBci+ffsoXrw4VapUwRjj7nAkH1lriYmJYd++fVStWjXH71O5RqQAOXfuHGXKlFGCL4SMMZQpU+ayf4tTkhcpYJTgC68r+eyV5EUkV3bv3k2DBg3cHQYbNmxg8eLFqY+//vprXnrpJTdG5BmU5EXE4yQmJl72ezIm+e7du/Pkk0/mZVgFkpK8iJeLjI5l+sodREbH5sn+pkyZQoMGDWjQoAFTp04FLiTlgQMHUrduXfr06UNcXBwATz75JPXq1aNhw4aMGTMGgCNHjnDbbbfRrFkzmjVrxk8//QTAxIkTGTRoEG3atGHQoEG0bNmSTZs2pR73+uuvJyIigl9++YVWrVrRuHFjWrduzbZt24iPj2f8+PEsWLCARo0asWDBAubMmcODDz4IXPht44YbbqBhw4Z06tSJPXv2ADBkyBAefvhhWrduTbVq1fjss88AOHjwIO3bt6dRo0Y0aNCA1atX58n3zi2stR7zJywszF6piN3H7JsrttuI3ceueB8inm7z5s2X9fqI3cds7XGLbdUnF9na4xbn+t9HRESEbdCggT19+rQ9deqUrVevnl2/fr0F7Jo1a6y11t599932P//5jz169KitVauWdTqd1lprY2NjrbXWDhgwwK5evdpaa210dLStU6eOtdbaCRMm2CZNmti4uDhrrbVTpkyx48ePt9Zae+DAAVurVi1rrbUnTpywCQkJ1lprly5danv37m2ttfb999+3I0eOTI017eNu3brZOXPmWGutfe+992yPHj2stdYOHjzY9unTxyYlJdlNmzbZ6tWrW2utffXVV+3zzz9vrbU2MTHRnjx5Mlfft7yU2c8AEGGzyKte0UIZGR3LwFnhxCc68fd1MP/eloSFBrk7LBG3C98VQ3yiE6eFhEQn4bticvVvY82aNfTq1YurrroKgN69e7N69WoqVapEmzZtALjzzjt54403GDVqFAEBAdxzzz1069aNbt26AbBs2TI2b96cus+TJ09y+vRp4EKJpWjRogDcfvvtdO7cmWeffZZPPvmEPn36AHDixAkGDx7M9u3bMcaQkJBwybh//vlnvvjiCwAGDRrEE088kbqtZ8+eOBwO6tWrx6FDhwBo1qwZQ4cOJSEhgZ49e9KoUaMr/p65m1eUazL7QRYRaFmtDP6+DnwM+Pk6aFmtjEuOk7HrwxiDr68vv/zyC3369GHRokV06dIFAKfTSXh4OBs2bGDDhg3s37+fYsWKAaT+5wFQsWJFypQpw8aNG1mwYAH9+vUD4JlnnqFjx45ERUXxzTff5PrGsCJFiqR+fWFQDO3bt+fHH3+kYsWKDBkyhLlz5+bqGO7kFUk+v36QRQqasNAg5t/bktGda+fJb7jt2rVj4cKFxMXFcebMGb788kvatWvHnj17+PnnnwH48MMPadu2LadPn+bEiRPccsstvPbaa/z+++8AdO7cmWnTpqXuc8OGDVker1+/frzyyiucOHGChg0bAhdG8hUrVgRgzpw5qa8tXrw4p06dynQ/rVu35uOPPwZg/vz5tGvXLtvzjI6Oply5cgwbNox7772X9evXX+I747lcnuSNMV2MMduMMTuMMS651J3VD3JeX3ASKYjCQoMY2bFGnpQwmzRpwpAhQ2jevDktWrTg3nvvJSgoiNq1azN9+nTq1q1LbGws999/P6dOnaJbt240bNiQtm3bMmXKFADeeOMNIiIiaNiwIfXq1WPGjBlZHq9Pnz58/PHH3H777anPPfHEEzz11FM0btw4XRdOx44d2bx5c+qF17SmTZvG+++/T8OGDZk3bx6vv/56tue5atUqrrvuOho3bsyCBQt45JFHruTb5RFMyq8nLtm5MT7An8BNwD7gV2CAtXZzZq9v2rSpzav55FWnF2+0ZcsW6tat6+4wxI0y+xkwxkRaa5tm9npXj+SbAzustbustfHAx0APFx8TuLw6vUb8IuKtXN1dUxHYm+bxPqBF2hcYY4YDwwEqV66c6wOeOH+C+KT41Dp9QqIztU4fGR1L+K4YWlYrk66koxG/iHgrt7dQWmtnAjPhQrkmt/v775b/ctXEtyhWMZR/dxvC/iKNaVW9LECmyTyvW8xERDyJq5P8fqBSmschyc+5TLfKt/Bn0GLKr9yF7/IJ+Fe/iqM9u7K1Us9Mk3lmI34REW/h6iT/K1DTGFOVC8m9P3CHKw8YWroqoe9/y6mDe4mY/TKlvv2R0pM/48fO31C0RhgJx5rgSKySmsxTOnMylnE8QWblJRGRy+HSJG+tTTTGPAh8D/gAs621my7xtjxRvEIlOj79Js4nk4ha8hFFzO8EHFnFDdHh9Ijw5VBgK/b3f4CK1RoSFhrkcUlU1wpEJC+4vE/eWrvYWlvLWlvdWvuCq4+XkcPHh4Zd72R8l//wY/9VdG8yEAL8qDr3B47f0o/vujVn6bQnOHb2WH6Hli3dxSveaMaMGZe8e3TixIm8+uqr+RRR5ubMmcOBAwdSH1epUoWjR49e9LqCMJ2x2y+85qer/K7ipoH/BwP/j+ion9m8YCaBqyI5/fk33FByCS0rtKTXiRq0uL4/pcqGXPFx8qLMomsF4m0SExMZMWKEu8PIkTlz5tCgQQOuueaabF/XvXt3unfvnk9RXZlCleTTCm3QitAGrYj4K4a1v/3IzaW28vu+ZZR75Qf2Ot8jvE5p/G/oQKM+91G6fGiO95tXZRZPvlYghdeZM2e4/fbb2bdvH0lJSTzzzDP069ePyMhIRo8ezenTpylbtixz5syhQoUKXH/99TRq1Ig1a9YwYMAATp06RbFixRgzZgzvvvsuM2fOJD4+nho1ajBv3jwCAwOzPPann37Ks88+i4+PDyVLluTHH39kzpw5LFy4kDNnzrB9+3bGjBlDfHw88+bNo0iRIixevJjSpUuzYcMGRowYQVxcHNWrV2f27NkEBQVl+vzy5cuJiIhg4MCBFC1aNHW6hmnTpvHNN9+QkJDAp59+Sp06dZgzZw4RERG8+eabDBkyhBIlShAREcHff//NK6+8Qp8+fXA6nTz44IOsWLGCSpUq4efnx9ChQ1MnXHO1Qpvk4UJCvnP2L8Qn+uPruA5oyJM3RNDh0Fra7NlP8JtfcmD6l8zrX5Py/QZyQ+UbCA4MznafedmS6YnXCsRzvPzLy2w9tjVP91mndB3GNh+b5fbvvvuOa665hm+//Ra4MI9MQkICDz30EF999RXBwcEsWLCAp59+mtmzZwMQHx9Pyp3sEydOTN1X7969GTZsGADjxo3jvffe46GHHsry2JMmTeL777+nYsWKHD9+PPX5qKgofvvtN86dO0eNGjV4+eWX+e2333j00UeZO3cuo0aN4q677mLatGl06NCB8ePH8+yzzzJ16tQsn3/zzTd59dVXadr0n5tIy5Yty/r163nrrbd49dVXmTVr1kUxHjx4kDVr1rB161a6d+9Onz59+OKLL9i9ezebN2/m8OHD1K1bl6FDh+bg08gbhTrJp0vISRda9LcGNmV7taYUH16TjoF/snvhh2wsd5RZ657n2/mTuCs8gKS2YdTofgfVGnW4aPY9lVnEm1177bU89thjjB07lm7dutGuXTuioqKIioripptuAiApKYkKFSqkvidl9siMoqKiGDduHMePH+f06dPcfPPN2R67TZs2DBkyhNtvv53evXunPt+xY0eKFy9O8eLFKVmyJLfeemtqrBs3buTEiRMcP36cDh06ADB48GD69u2b5fNZSTlmWFhY6rTFGWU2bfGaNWvo27cvDoeD8uXL07Fjx2zPM68V6iSfNiH7OAwYQ1LSheTcqkYw9UNrUb9VN/5lLTuP72T9V7Ow4Uuo/NFq4j9azZrSfpxqUZsKo0bTsFJzfBw+KrNIvsluxO0qtWrVYv369SxevJhx48bRqVMnevXqRf369VPLGhmlnT44rSFDhrBw4UKuu+465syZw6pVq7I99owZM1i3bh3ffvstYWFhREZGAumnCnY4HKmPHQ7HFS0jmJWU/fr4+GS538ymLXY3r5hq+Eqlnb3yo+GtmHhrfVrXKMv4bvXTJWdjDDWCanD7kJe4ael6SixewJ77buFU+WIE/ryJwSuH0fGTjsx+aSBrPniJWsXO59msfyKe5MCBAwQGBnLnnXfy+OOPs379emrXrs2RI0dSk3xCQkK6ZfuycurUKSpUqEBCQgLz58+/5Ot37txJixYtmDRpEsHBwezdu/eS7wEoWbIkQUFBqUv4zZs3jw4dOmT5PGQ/bfHlatOmDZ9//jlOp5NDhw5d8j+zvFaoR/LwT907MjqWSYs2EZ/o5Nfdx6hdvniWSbpitYZUfHQyPAon42J55dA6Vu1bRcW3F1Hm0Hp2v/wBB2qUwtGmGXV6DKJSnWb5fFYirvHHH3/w+OOP43A48PPz4+2338bf35/PPvuMhx9+mBMnTpCYmMioUaOoX79+tvt67rnnaNGiBcHBwbRo0eKSSfXxxx9n+/btWGvp1KkT1113XbZz0af1wQcfpF5grVatGu+//362zw8ZMoQRI0aku/B6pW677TaWL19OvXr1qFSpEk2aNKFkyZK52uflcOlUw5crL6cavlzTV+7g1e+3Ybnw681jN9dmZMcal7WPhITzbPzhcw589xXFft1K+UPxLG1kWDmgNteHdKDazpJEB7WgVa0KHj3K1522nktTDRdMp0+fplixYsTExNC8eXN++uknypcvf0X7utyphgv9SD5FUKA/Kf/dOZMfXy4/vyKE3XgHYTdemLlh1+afufrgLwQl/s7KpbPpPCeBcgGGX0PLEN25M50HjqBYqey7dfKb7rQVyXvdunXj+PHjxMfH88wzz1xxgr8SSvLJYuPicRhwWnCYC49zq1q9VlSr14r+wOuJ4bzcfjbN/95E0+ijFJ/2Ibve+pCFj4ZRr31POoR0uGR7Zn7QrJwieS+/6/BpKcknc3XrY9sGtXk7vBery/SgyLWJvNjgb3x+XcavxQ7z6c/P0meNk7a7A0hsG0atXndRtWHbPD1+TqkFVMS7qCafhqtr0Sn7Dwr0JzbuwsImTSqXYvvx7WyaN51i36wmZO9ZAA4H+3Pq+kbUePQpagfVvqgfPy/jyXi+qsl7LtXk5XJr8kry+SBt0oTMFy9JsW/n72z6cjbOH8I5bE7x6m0+BAdcw4PbKlCjzS3Uv743Pj65/wVMtfeCSUledOHVw2RMprc1Ccm25h1S/TpCxrxOZN9YRs9eQtLBzZzx+53qC9bh9+E6fi32LDHNa1DhX71oeNMAfP2LZHP0rKn2LlI4FOqbofJDxmRqAX9fBz6GbGve4btiOB9fjPjjzTl6dBg/vDybQ0/cwdGaZan4458UfexlJjzdjolrJ7Jm1wriz565rLhSau+XikMkv8yZM4cHH3wQyNl0w5qSOGc0knexjBcyb2sSwm1NQi5Z8874vjbX1iEstBUMfYbTJ2P47evZOErt439//Y/jn3xK0ZVO/r4uhFI3d6FR97u5qnjpi/aZsdau6RckvyUmJuLr6z1ppyBMSew9320PlVUyvVRSzS4JFytRhnZ3Pk47YFzSeX4N/pADpz+hXGQ0xX+ZxfaXZnHg2vL4THqcdqHXE+gXmGUNPmW/utgqObF79266dOlCWFgY69evp379+sydO5fAwEAmTZrEN998w9mzZ2ndujXvvPMOxpiLphuuVasWzz//PPHx8ZQpU4b58+dTrly5LI+5c+dORo4cyZEjRwgMDOTdd9+lTp06Wb5eUxKnpySfD650yuCcvC9qXxy/+7Wj5TM9ubZCABuWzOfwt19z+kA0L/w0loDwAEZGXcPpq2pjzofhdBS7qAavi7AFV/Sguy56rnjXLpS+4w6cZ8+yd/h9F20v2asXpXr3IjE2lv0PP5JuW+i87FdtAti2bRvvvfcebdq0YejQobz11luMGTOGBx98kPHjxwMwaNAgFi1alDojZNrphmNjYwkPD8cYw6xZs3jllVeYPHlylscbPnw4M2bMoGbNmqxbt44HHniAFStWZPl6TUmcnpJ8AZZZcm7e7V7odi9JziSqH17P0r++p9r0jwmO/ZO2vt8QUaUUayo1oUmFa1P3o4uwcjkqVapEmzZtALjzzjt54403GDNmDCtXruSVV14hLi6OY8eOUb9+/dQkn3a64X379tGvXz8OHjxIfHw8VatWzfJYp0+fZu3atemmAD5//ny28WlK4vSU5AuwtMn5fIKTz9fvS03OPg4fmpVvRrPyzUj88Ql+X76AXZ99zLXr/6LNjhV85VzL94N7cGuVf9E8tIpugCqgsht5O4oWzXa7b1BQjkbuGWW8Z8MYw7lz53jggQeIiIigUqVKTJw4kXPnzqW+Ju10ww899BCjR4+me/furFq1Kt1CIhk5nU5KlSqV44nIQFMSZ6TumgKsZbUy+Dou/IOzwGeR+4iMjr3odb5+/oR1GUTfWd/SJHw9p15+lMSu7Vn812LenD6E+Ds68uyZuTzcMEGlGrmkPXv2pNafP/zwQ9q2bZua0MuWLcvp06f57LPPsnz/iRMnqFixInBhFsjslChRgqpVq/Lpp58CFxLi77//nu17NCVxehrJF2BhoUH0bVqJD9ftwQJJSZcutfj5B9C8x3CaA6MT4vhp8buc3PQxDRZvoOHiDUTXKsmqHv+ixcBHKRpQLN/ORQqO2rVrM336dIYOHUq9evW4//77CQwMZNiwYTRo0IDy5cvTrFnW02tPnDiRvn37EhQUxA033MBff/2V7fHmz5/P/fffz/PPP09CQgL9+/fnuuuuy/L1mpI4Pd3xWsCl1OVTSi1XOhLfv+N3fp87lRJLI0hyJvL0I0HcWqMHfcp1oXpo1v+gJH+5+47X3bt3061bN6KiotwWgzfLyZTEuuO1kMmrfveKNa6j4qT3SZqQSMQf39P6xA98tukjOoyYw44KxQno3Z2Wd4yiSFGN7kVcxRVTEmskL1k6emwfEW89x1WL11L2WCInr3IQ07kJje97igpV6rk7vELJ3SN5cb/LHcnrwqsXiYyOZfrKHZlefL2S15UtHUKXce/QevVvnHppFDHVShP6ZQSP/rc/j616jMg9P+N0OvPyFEQkj6lc4yVyekPTldz45OPjS/Oe90HP+4j+M4JmJ1bxxY4vCZn5P2IPB+DTrwdt7nwc/6KB6Y6jO2hdw1rrkqmnxfNdSeVFI3kvkdkNTbl5XVZCazXlsWZjWNZ3GQ3a9cTvfBLlJ39MZLtmzHxoAD9EbEj9j2Tykm0MnBV+yd8YJOcCAgKIiYlxeW+1eB5rLTExMQQEBFzW+zSS9xI5XdEpr1Z+KupblJvuf5Gk4ZP4eu6bnP1oPu2WbmDp4TtZ2uMmEkwjnLas7qDNYyEhIezbt48jR464OxRxg4CAAEJCQi7rPUryXiKnXTZ5Pfukj48vB6p0Y3JYTSrV3YQt+xsnElbRoOhSekVcxcKaN9OyWutcHUP+4efnl+00ACIZqbtGci1jr/70QTXZ8fVkGs//geJnLXurFqP40Lto3vv+PFnVSkTS0/J/4nKZXWg9fSKGtTMncdVnyyl9IondVYqS8OYEula7BT+H32XtS0SypiQvbhV/Po61c18hfOcq5teNoWLRCow61pQOdz1J0cAS6V6raY9FLp/65CVfZezD9y8SyPXDJjL23yuZ3mk6YQeLEjr1SzZ0aMV3Lz7A6RP/LJeW2+4fEUlPBVLJU9mNxI0xtA9pT9uH2vJbzXmcmPE2oXNXsvnT9sT0bEPb0S8RFOiPwxjAatpjkTygJC95KrsFSNLV2m8ZDLcMZuOqz4iZ9hqBi9fQpWo3Yo+2Icm2xMcEMr5bfZVqRHJJSV7yVFZ9+FmN8Bte34eG1/ch6q91BP0yg7Mlv+O1L/7H6tDqHD06Dqjs3hMSKeBUk5c8ldKHP7pz7XSlmrQj/PgEJ1OX/ZnuTtgGVVvwbMspFNl5D4eKXcXAyO20HDeE7164nzOnjrnrdEQKPHXXSL5IHcknOHECDkOm3TMpJZ3Q2J/xnfs2oVtjOVHMwboJ92Cu6kqb6uVVwhHJQC2U4hEio2OZuuxPftpxFKcFHwOjO9dmZMcaWb7ntyXz2fDRO0zpcAxnQhkq7mzBC8Mfp1m14HyMXMSzqYVSPEJYaBCjbqyFv68DH0OOumcadx7ImUHvcW7fPZQ45cvL335DzD038eui94CcT5uc1pW8R6Sg0khe8t3l3tGaUupJTIjnxpivuXPjOsqcSGJHrZK8Xus2dvnVy/GNU7rZSryRlv8TjxIWGnRZiTX9pGrtqRfsw4+vP0mFj1fy2o7Z3DegOYfOdcvRbJfZtXiKeCMleSkQMv7HcPNTb/HDTRt4b/YETlb6jaLOrQTsvJmENv+Hn3/W823n1VTLIgWFkrwUWB2aNqJY8BwqbF3P33veoeXkT1k9/2vKPPN/XHfD7Vm+r3eTEEzy3xrFi7dTkpcC7cIIvxNOZ0fWBk4h4PU5+D8wgUXtP6DN828TdPU/N1NlrMf3bnJ5iy+IFETqrhGv4HA4aDtwDA2XrmJX1wZUWb2LqFu78tWWz1OXytPkZ1IYKcmLVylWsiz/eu1TfD+YyppulRn3y0TuX3Y/B/ZtS63H57R9U8QbqIVSvJbTOlmwbQFr5r3CPd+cI3Z4T0r+awzrdsfm+YIkWuhE3El3vEqhFr3lF7Y+/hCVd5wkuk4QDSfP4JrqDfNs/+q9F3dzyx2vxpiJxpj9xpgNyX9ucdWxRLITWrc5N371E/uGd6XczlgO3Naf1R++mmf7V61fPJmra/KvWWsbJf9Z7OJjiWTJx8eXm0ZPIWjB+xwPLsq8399n4tqJxCXE5XrfqvWLJ1MLpRQqVeq15JpvfyLqjxnMjpqNc8kqBtz8BHVbXfkvmunvyFVNXjyLy2ryxpiJwBDgJBABPGatvWhGKGPMcGA4QOXKlcOio6NdEo9IRuF71hDfbwQlTyZx9IFedBr5ortDErkiLrvwaoxZBpTPZNPTQDhwFLDAc0AFa+3Q7PanC6+S344e2EnE/XcSuu04O9tXo9PUjygaWMLdYYlcFrd31xhjqgCLrLUNsnudkry4Q2JCPEueHkLVr39jf6Wi1F3wBRVLV3F3WCI55q7umgppHvYColx1LJHc8PXz55ZXPuTYxOGE17AMWHIX6w+td3dYInnCld01rxhj/jDGbAQ6Ao+68FgiuRbQagim11SKOIrxynt3s/Ldie4OSSTXXNZdY60d5Kp9i+S1dDc0+d/D8C2TKb9xAd/u3E6XFz7Ax0eNaFIwae4aETLc0BQfwN/DZrKzfTWqLVzPd3d15vzZ0+4OUeSKKMmLcPENTa1rVeSWGd8QPagD1SIPsqpvJ04cP+TuMEUum5K8CP/c0DS6c+3UuWccDgddnp7BoccHsNf/NPesup/DcYdT36MFwaUg0ARlIjmwdt9PPPrDaELPF+OlZpOILVFPk5KJx3BLC6WIN2kd0obZXWYz8JMjHBkyjNXLv9KkZFIgKMmL5FD9MvVp8Mp0knwctH39ZRrGrdOkZOLxlORFspBZzb16w3ZUnj+PuGJ+TFjxKY9c/YdKNeLRlORFMpHSNz95yTYGzgpPl+hDajamzoLPiC0bQLWv53LS6u5Y8VxK8iKZuNRCIFeH1KLxgq9YOLweo38cw3e7/uemSEWypyQvkomcLAQSdHVlpt42h0alG/D3o4+xYsYzbohUJHu6V1skEzldCKSYfzGGVZvE4cR+VJj6GcvOn+PGR/6Tz9GKZE1JXiQLYaFBmSb3yOjY1OQPMPSjrdgGjzMu6T80fXsRS86fp/MTb+R3uCKZUpIXuQzpJjLzddC7SciF2r0JZFLDsUwKmEKj2UtZ7HyAW558y93hiqgmL3I5Ml6QNYCvwwCQ4Ajg2XpPsLFVCO86f+TtDW/jSXeUS+GkJC9yGTJekO3dJIS+TSthkrcnWF8OD3qT+u178tbvbzFv/licTqdbY5bCTeUakcuQ1QXZz9fvIyHReWEGy+pX07jyJEK2HqPZv7/hfxG76DrlExwOjakk/2mCMpE8kPZibEridzqdLB7Vh+pLtrDzhpp0nfaFFh8Rl9AEZSIuFhYaxMiONdJ14zgcDm6Z+hm7/tWQ6iu2892I7iQmxLsxSimMlORF8lDG+W4cDgdd//MRf/VuSrXVfzF9zkiSnEmai17yjX53FMkjadsrfR2Gvk0r0btJCGGhQdzy4jzmN3uOWSc/4Y/vH2PN2huJTzSai15cTiN5kTyStr0yPsny4bo96SY3G9jrGUY1GcXpX5by8MZ/Y5LiNRe9uJySvEgeSWmvTGmntFw8udk9195DT9uWjtuO8fSmlwlwJGouenEpJXmRPJLSXjmgReVsJzfrP/EdNvZrT6udJ3hh+2SuLV/kohq9avaSV9RCKeICmbVUZvT9yw9R+f1lbGsYzNM1H+Os0xd/Xwfju9Vn0qJNWj9WckwtlCL5LLOWyoxuHjuNPXffyAF7FK7+BKd1kpDo5H9RB7V+rOQZJXkRN7p57DRiHhqJo9RGrg76CH8fJ10bVLjkXPaZUYlHMqMWShE3e6b9SDhzirZvf0BMg+P0braI2uWLX7Lck1bG2TFV4pEUGsmLuEnakffTN/ayr+kAAB5VSURBVD9BXLtG1F/zF/97alCOyj1pXWq5Qim8NJIXcYPMRt5dX57P4lM9qP7Ver4v/RA3j52W4/2ltG+mTJKmtkxJoZG8iBtkNvJ2OBx0mfY5uxqXo/L7y1gx98Uc7y+lfXN059qM71af8F0xqs0LoJG8iFtkNfL29fPnxtmLWPBYD2ad/YRiB2+keYXmOdpnSmlHtXlJSyN5ETdIO/LOmIiLFC1Gz6lfUrpcFR5b/gg7t4XneL+qzUtGSvIibpLdxdUS/iV4s9ObDFt4loNDhnH0wM4c7TPjylWqzYuSvIiHCikeQuOHxlP8VCKRwwYQfz7uku/J7jcEKZyU5EU82LUdenPskf5U3nmKJWMG5ug9l9t+Kd5NSV7Ew3UcNoGdXepTfelWVrzzjLvDkQJGSV6kALj5lf/yR4ureePUIrbEbHF3OFKAKMmLeLjI6Fhm/rSPk8Pf5O/yJXlo+aOcjFMPvOSM+uRFPFjKnbHnE5xYwDewL/22vsXyz3vS46OVOBwap0n29BMi4sFS+t5TVn1IjKvCIZ/a1Pn9MMtee8ytsUnBoCQv4sFS+t5T/qE6DHwVejfb6wRRbvZ3bPt1iVvjE8+nlaFEPFzKKlNBgf7ExsXTsloZKvvGsKt7d+KK+9Ni0SoCi5Vyd5jiRtmtDKWavIiHCwsNyqTnPYhd4x6mxMTXmfv1JEbcMcUtsYnnU7lGpIBq0WsEP0wdwPSEpaw9sNbd4YiHUpIXKcAeaPcEVUtU4dtpj3Hi6AF3hyMeSElepAAL8A3ghZAHGLDwOKufGOrucMQDKcmLFHDXNutKdM8wqq+NZu2C190djngYJXkRL3DT+JkcrBCAeXUmsUf2ujsc8SBK8iJewL9oIOVfeI7ip5389OQwd4cjHkRJXqQAioyOZfrKHenWca3XuhvbB7ZiQcW9/LT/JzdGJ54kV0neGNPXGLPJGOM0xjTNsO0pY8wOY8w2Y8zNuQtTRFKkzGczeck2Bs4KT5fob3nqbU40qc7EnydyJuGMG6MUT5HbkXwU0Bv4Me2Txph6QH+gPtAFeMsY45PLY4kI2a/jWsSnCJNaPUu77w6w/PFBboxSPEWukry1dou1dlsmm3oAH1trz1tr/wJ2ADlbcl5EspXVOq4pJZykc1VoElib6t9tYcPyj90crbibq6Y1qAikXWJ+X/JzFzHGDAeGA1SuXNlF4Yh4j5R1XMN3xdCyWhnCQoNSSzjxiU78fR28N/wVjv/Sk8SJL3K21S0UDSzh7rDFTS45kjfGLDPGRGXyp0deBGCtnWmtbWqtbRocHJwXuxTxehnXcc1YwtlwBHyfepirjySwYtL96d6b2UVb8V6XHMlba2+8gv3uByqleRyS/JyIuEBKCSch0ZlawgkLHc6irz4nZNF6tgxbR93qLS4a8c+/t6UW/PZyrmqh/Brob4wpYoypCtQEfnHRsUQKvZQSzujOtdMl7jYvvcur95ZmwubJJDoTs71oK94pty2UvYwx+4BWwLfGmO8BrLWbgE+AzcB3wEhrbVJugxWRrGUs4QAEXV2Zwb0msuXYFj5a9cYlL9qqhON9tGiISCEwc+JttPh0M8U+msnxkg2yvWirEk7Bk92iIbrjVaQQ6HnPiyT4GXY+8SjXXXNVthdtVcLxLkryIoXA1ZVqc3rk7VTafYYVUx9Pty2rEo54By3/J1IIREbHElXtDk7WWULluUuI/tc6Quu1ADLvuxfvoSQv4uXS1tzL1xzEywem8enXL/Bc3YU4zIVf5jNfR1a8gco1Il4ubc39gE9lhvfozdcV/uLVn+e4OzTJB0ryIl4upeZukh+fPdWSpNM1+PvTN9iz9Ve3xiaupyQv4uVSau4DWlROvsBqKLm3C3cuP8/mxx8iKSkxR/tRL33BpJq8SCGQUnO/rUlI8gXW1sRW/IvQ6V+x4vWx3DR6crbvVy99waWRvEghkvau2I4jXyS6ThDB7y8mekv2s46ol77gUpIXKaQcDgcNJ88gyQFbxzxIkjPrmUfUS19wqVwjUohdU70hW0YNYN7uBfy95b8Mrj8409epl77gUpIXKeRuGPIMX608yhvr36D11S2pGVw709epl75gUrlGpJAzxjCh1QR6RDjYfccA4s/GuTskyUNK8iLC7sMOSl3TlZC9Z1n6zN3uDkfykJK8SCGX0h459XgLltQrR7VFG/n1m1nuDkvyiJK8SCGXtj3ynRr3c6CsH0nPvsbRAzvdHZrkASV5kUIubXuks0gJzj81Af94J+9/NBandbo7PMklddeIFHKZtUd+EnycuVumEhQ1m3uvvdfdIUouKMmLFEKR0bHpknrG9si+zYYScXYbaxe8TuN9/oR1vcuN0UpuaI1XkUImp/PQnI47QUSXdgTEJVH1888oF1rXDdFKTmiNVxFJldN5aIoFlqTia68RcN7J7/cNIv7smXyOVPKCkrxIIRMU6I/DGBw5mIemZlgnTj4+hEq7z7BkVL98jFLyipK8SCESGR3LpEWbSHJaHMYwvlv9S05V0P6usezq3pjqP+xk9vuTNKd8AaMLryKFSEqpxgLWWmLj4nP0vptfmMPzZfrzmfmCc6tL47uiuuaULyA0khcpRK50ymBfP3/O1HwCG1+aWn5zKHPmT80pX0BoJC9SiFzplMGR0bF8tT4Wa+/kyaWvcs5vFoFDbnZxtJIXNJIXKWTSrg6VU+G7YkhMcpKQVI7Xmt1KhdhETk0cSkL8ORdGKnlBSV5ELiltmWdL6evZcldXqmyO5ftRt+N0Xpj6QAt9eyaVa0Tkki4u83Tl28P7qb54I4vfe5oKnZ/QQt8eSkleRHIk49QHXf4zn9kl+/GWzyI6RTUgPrFUuhuslOQ9g8o1InJFfHx8ufPp/1K33LVE7J1CzfMbMICPjxb69iRK8iJyxYr6FuWNG97g4a+TmLhqPuXid4EHzYclSvIikktli5Zlb/8n8E2yTAqfSUD8UfXQexAleRHJtbYduvJyh55UOJ7IM79Npek1Ae4OSZIpyYtIroWFBvHUY0/wQ7+uNNh3lr1vPYAnTWNemCnJi0ieCAsN4sEJU9j6QGem1NnF9A3T3R2SoCQvInms50NTuem625j12wy++3JKjt+nm6lcQ33yIpKnjDGMazmOqgvCqbj0XX71LUGzW7NfJzanq1XJ5dNIXkTynJ/Dj94TPuDo1UVwjJvM63P+m+UIPTI6lqnL/szRalVy+ZTkRcQlSpQuj/P5aZz3NTSe/m9GvvXFRYk+ZQS/ZvtRnJYcrVYll0dJXkRcZmtCBZ5t05/i55yMjnyT1TsOpNuedhETB9CmRlmVavKYkryIuEzLamWILtmMl9p1Zk7nRH4/PwOndabbnjK7pb+fg1E31lKCz2PGk3pZmzZtaiMiItwdhojkocjoWMJ3xRDrt5QFO99iTMCtDO734kXbL2cRE0nPGBNprW2a2TZ114iIS6XMXmltdSr88gvNZ37JypNF6DhsghJ8PlCSF5F8YYxh0P3TWbmiI+WnfsyiMtUY81tZtU26mGryIpJv/IsG0mzWJ5wq4UvpF1+i+Nm9apt0MSV5EclXpcuHEvzGZIqedzIu4i18zXm1TbqQkryI5LvazToT93/D+ap1AteFreK/97RQqcZFlORFxC3aDHiUpreP5M8zK9l16At3h+O1lORFxG1GXDeCu2LrU+ueyWxY9pG7w/FKuUryxpi+xphNxhinMaZpmuerGGPOGmM2JP+ZkftQRcTbOIyDYXdO5mRJP849+Tx/R29O3aZZKfNGblsoo4DewDuZbNtprW2Uy/2LiJcrVbYiFd54jdNDHmTjiMGUXvgDf/x9XrNS5pFcjeSttVustdvyKhgRKZxqhnXi5Og7qfTXaZaMvSt1Thu1V+aeK2vyVY0xvxljfjDGtMvqRcaY4caYCGNMxJEjR1wYjoh4sg53P80fHWsRcWYLfyeEp85po/bK3LlkucYYswwon8mmp621X2XxtoNAZWttjDEmDFhojKlvrT2Z8YXW2pnATLgwd03OQxcRbxIZHcv4MvfgqPgOjv2vMfKmaTiSrtaUB7l0ySRvrb3xcndqrT0PnE/+OtIYsxOoBWj2MRHJVPiuGOKTfLD7B9LcZwohC0bS+ZPlXFVCCT43XFKuMcYEG2N8kr+uBtQEdrniWCLiHVKmHXYklcTEXE+t3edY+cgAnE7npd8sWcpVd40xphcwDQgGvjXGbLDW3gy0ByYZYxIAJzDCWnss19GKiNcKCw1i/r0tk2elbE10qaNU/2wdK996mk4P/tvd4RVYmk9eRDxSYkI8y/peT4Xtsfi/N4W6Lbu6OySPld188rrjVUQ8kq+fP03fmseZqxz88O5ETsWfcndIBZKSvIh4jIx3uZa9pjpF33+DGe3PMWHtBDyp8lBQKMmLiEeIjI5l4KxwJi/ZxsBZ4amJvnH9TowKe5TfNyxh8btPuznKgkdJXkQ8QnZ3uQ6uP5iHI4OpPPVLNq76zI1RFjxK8iLiEVJaKDO7y9UYQ/spczlR0odTYydy7O9oN0ZasKi7RkQ8xqUW9o5avRDniKfYXas0e0a+R+nigcTGxRf6u2Kz667RQt4i4jHCQoOyTdYN2vVkQb+lNPxwBUs/msA3wXdhgCJ+mqkyKyrXiEiBcqTNI7zTIYS1LbbgU3Q3Fs1UmR0leREpUFrVCOa78vdzzpSmVPB8SiQd0UyV2VCSF5ECJSw0iPG3NKUuI3huwXEmbn2H/w5tnq5Uo1Wl/qEkLyIFSmR0LJMWbWL9ruIsr9aQutuPE/Px+HTbM+u3L6yU5EWkQEnbT7+w3ECi6pbmmnkriFq98KLtqtUryYtIAZOun97Pl3Lj3+FkcR9ixz7DyWN/Z9tvXxipT15ECpyM/fQbln/MX/+exKaHbmZcj9cu2W/vbdQnLyIFTnaJOmM/faNO/VlbOoYFG2fQZNdibql2S+r2wpbwM1KSFxGPk3LxND7Rib9vzm50Gn7dfWzYvpqDY59k7wvlqFQr7Ir2421UkxcRj3MlF099Hb6Ma/gYjf5MYMuo+0lMiNdFWJTkRcQDXenF08p1mnHygb5U2nWK5a+O0kVYdOFVRDzUldbSnU4n3w3oSEjUYQI+mMap4DCvr8lnd+FVSV5EvM6R/TvY1b07h6+5ii5frcXP4efukFxKa7yKSKESXLEG518YzUtdz/J+1PtZvq4wTH+g7hoR8Urtu9xLqx+28s5vb9PxqibUrJ5+oFtYOm80khcRr/VU86d4/HMnu0bcx7Rlm9ON2AtL542SvIh4rTJFy+Bzw61U3htH9NwJ6SYsKyydNyrXiIhXO3TtXZwP/Z6Bv0WxJvgvwnfVTL1jdv69Lb2+80YjeRHxaq1qBPNOwyEYC/dv/iDdiD0sNIiRHWt4bYIHJXkR8XJhoUFMffAOwjs3I+T4SU6eWu3ukPKVkryIeL2w0CCG/nsG74ypzYtbpxGXEOfukPKNkryIFAr+RQJ5su14YmMP8sX8CYWiRx504VVECpEm5Zrwf7+FUuOHRTwSFUK0Xw2v7pEHjeRFpJBpM/ZVEn3gnj/+i9Pp9OoeeVCSF5FCplxoXbb3aEtY9GlanVjm1T3yoCQvIoVQr/97nUNl/Bi+cQUf3NXIa0s1oCQvIoWQf9FAijw6nKPFkth1eKG7w3EpJXkRKZRa9H6AZWPaMm3PPGLPeW+HjZK8iBRKDoeDJ5qPJSDmDPNfe9Rr2ymV5EWk0Kpeqjojfg+hw7x1LPj6q3QTmHkLJXkRKdT+7jqaBB8YuvUTr2ynVJIXkUKtTVgTvmhUmxZ/naTRmTVe106pJC8ihVpYaBD/+r/XiSnh4L7N39OoUgl3h5SnlORFpNBrVTeU+Hv7sL30OZZtW+TucPKUkryIFCpZTUzW4d7xLL+zDlM3zyAhKSHb1xYkmqBMRAqN7Bbv9nH48GiTR5k8736+n/ccFTo+6hULfWskLyKFxqUW725bsS0j1hYjeNpnrI3a4RULfSvJi0ihcanFu40xVHzscUqcsVz9wzSvWOjbWGvdHUOqpk2b2oiICHeHISJeLDI69pKLdy/u14FyWw9z5v0F/HEi0OMX+jbGRFprm2a6TUleRCS97ZHLib/zQXZ3vZZ/TfnE3eFcUnZJXuUaEZEMaoZ14s+O1fnl3FaOxB1xdzi5oiQvIsLF7ZIBD7/Ely0ML66d7ubIckctlCJS6GVsrRzfrT6TFu3FlGnCyS2fszzgRjq1bevuMK9Irkbyxpj/GGO2GmM2GmO+NMaUSrPtKWPMDmPMNmPMzbkPVUTENTK2Vv4v6iDxiU6u2tOMUV8nsn/mc+4O8YrltlyzFGhgrW0I/Ak8BWCMqQf0B+oDXYC3jDE+uTyWiIhLZGyt7NqgAv6+DmKLhLK8bnkaR+zhwM6N7g7ziuSqXGOtXZLmYTjQJ/nrHsDH1trzwF/GmB1Ac+Dn3BxPRMQVwkKDmH9vy3StlbXLFyd8Vwy1b5kI941g/WvjuebNgrdUYF7W5IcCC5K/rsiFpJ9iX/JzFzHGDAeGA1SuXDkPwxERybmw0KB0vfD/PK7BorbVqLRyG4eit1AutK77grwClyzXGGOWGWOiMvnTI81rngYSgfmXG4C1dqa1tqm1tmlwcPDlvl1ExOWufXQCR0savlnznrtDuWyXHMlba2/MbrsxZgjQDehk/7mzaj9QKc3LQpKfExEpcELrNmfGS91ZvncFfc+foGSRku4OKcdy213TBXgC6G6tjUuz6WugvzGmiDGmKlAT+CU3xxIRcae7rx1K4tk4Xnp3UoGaeji33TVvAsWBpcaYDcaYGQDW2k3AJ8Bm4DtgpLU2KZfHEhFxm1MngxnxTTF6vvc/7n5nWbpE78nzzue2u6ZGNtteAF7Izf5FRDxF+K4Yvq90A+22fckNB74gfFdjwkKDsp2j3hNoWgMRkRxoWa0Mf5Zqw5/litB96x80D71Ql7/UHPXupiQvIpIDYaFBzB/Wmj033UyF40kk/PohcOk56t1NUw2LiFyGhPhz/NKuKdvrlubM4NmpSf1Sc9S7UnZTDWuCMhGRHEpZcGTv6Dv49uyHnP1hBb4rKjH/3paM7JjlJUq3UpIXEclC2lWkgNQLrA6f2gRU96dIiZ84d+R2wnfFeNTF1rSU5EVEMpGxa+a2JiGpF1hJCqBNRAj3/PQLI7t08rg6fFq68CoikomMXTMWUi+w+vs6aN52AMXPwRifHzx2FA8ayYuIZCqlayYh0Ylf8kj+tiYh6S6wfv/hVCquWEdiQjy+fv7uDjlTSvIiIpnIbPrhlOdTFO3bmzIvziHim1m07P2Au0LNlso1IiJZCAsNYmTHGlmWY1r2fYgTxRwc++ijfI4s55TkRUSukH/RQHaNuJk3W57g4OmD7g4nU0ryIiK50KH/Y+wrCwt3XHrVKHdMZKYkLyKSCxWLVaR7Qn18XptNUlJilq9LacmcvGQbA2eF51uiV5IXEcmlm3yvpd2600R++36Wr3HXRGZK8iIiudT89gc5E2A48snHWb7GXROZqYVSRCSXigaW4O+2tai0ahsnYg5SskyFi16TVUumq2kkLyKSB0L7DMI/ESI/mZ7lay7VkukKSvIiInmgfvte7KgawB+HNrg7lHSU5EVE8oDD4WDvv4fxXtU9HDpzyN3hpFKSFxHJI12rdgWnk1Ubvrys97myf14XXkVE8kjVklV58fMi+CTOYvrYG3N0gdXVC4FrJC8ikgsZR+Fn6taj8u4zzPl2RY5uenJ1/7ySvIjIFcrsLta/r+2KA2hzZHmOkrar++eV5EVErlBmo/C2Hbqyr7QvrfbvyFHSTumfH925dp6XakA1eRGRK5ZxYZGUGvwnzepQf0kU795WOUdJOyw0yGW98xrJi4hcobDQIMZ3q0/rGmUZ361+aqKuNfgeXuzn4FTgLjdHqCQvInLFIqNjmbRoEz/tOMqkRZtSL7I2bNyZ/XXLsvLgj26OUEleROSKZdUZ4zAOuvk0ouz8ZSTEn3NrjEryIiJXKLvOmJbnKtL9x3Ns+uHybozKa0ryIiJXKLvOmIZdB5HogP1Lv3FjhOquERHJlaw6Y0qWqcCBqsUp+usWN0T1D43kRURcxNniOiocPMfhvdvcFoOSvIiIi4Te2IM4f9j462K3xaAkLyLiIrVbdOGxsWVZEXzEbTEoyYuIuIiPjy/NK7Vi7YG1WGvdEoOSvIiIC3U8FcKTbx5ie+RytxxfSV5ExIWurd2O0COwe8XXbjm+kryIiAuF1GjMkTK+JP76m1uOryQvIuJiJ6+tQvltR90yxYGSvIiIi5Vo3Zqi8bB17bf5fmwleRERF6vbqS8/1TVEndya78dWkhcRcbHgijX4dkhtVgZE5/uxleRFRFwk7SLfzcs3Z++fkcSfi8t0u6togjIRERdIWeQ7PtGJr4+DQUVOM2V+HJvrfk2jTv3Tbff3dbhkfVfQSF5ExCXSLigSn+jk0xM1cQLbllyYx+aL9fs4n3DxgiN5TUleRMQFUhYUMcmPT/oGEx3sR8DGrURGx/JpxF5SJjrw8Um/4EheUpIXEXGBlEW+G4aUxNcBPgY2lb+aKntPsXbrXhKdF1K8AfqEhbikVANK8iIiLpGyyPcf+0/gcDjo17wy1Tp1wj8RQo//mrpsYBE/B7c1CXFZHLrwKiLiAmlr8klJTiqWKsoNbQfx1F/zaV7pDPNbtiR8Vwwtq5Vx2SgelORFRFwipSafkOhMXeQ7KDiII21q8/PpPxiaxbKBeS1XSd4Y8x/gViAe2Ancba09boypAmwBUta8CrfWjsjNsURECpKURb4zjtZvCr2Jv8/8nW9xmNxMZG+M6QyssNYmGmNeBrDWjk1O8oustQ0uZ39Nmza1ERERVxyPiEhhZIyJtNY2zWxbri68WmuXWGsTkx+GA667eiAiIpctL7trhgL/S/O4qjHmN2PMD8aYdlm9yRgz3BgTYYyJOHLEfesgioh4o0vW5I0xy4DymWx62lr7VfJrngYSgfnJ2w4Cla21McaYMGChMaa+tfZkxp1Ya2cCM+FCuebKTkNERDJzySRvrb0xu+3GmCFAN6CTTS7wW2vPA+eTv440xuwEagEquIuI5KNclWuMMV2AJ4Du1tq4NM8HG2N8kr+uBtQEduXmWCIicvly2yf/JlAEWGqMgX9aJdsDk4wxCYATGGGtPZbLY4mIyGXKVZK31tbI4vnPgc9zs28REck9zV0jIuLFlORFRLyYkryIiBdTkhcR8WJK8iIiXkxJXkTEi+VqFsq8Zow5xT/TExcmZYGj7g7CDXTehU9hPXdXn3eotTY4sw2etmjItqymy/RmxpgInXfhUVjPGwrvubvzvFWuERHxYkryIiJezNOS/Ex3B+AmOu/CpbCeNxTec3fbeXvUhVcREclbnjaSFxGRPOQxSd4Y08UYs80Ys8MY86S748kvxpjdxpg/jDEbjDFeu6iKMWa2MeawMSYqzXOljTFLjTHbk/8OcmeMrpDFeU80xuxP/sw3GGNucWeMrmCMqWSMWWmM2WyM2WSMeST5ea/+zLM5b7d95h5RrkleYORP4CZgH/ArMMBau9mtgeUDY8xuoKm11qt7h40x7YHTwFxrbYPk514BjllrX0r+jz3IWjvWnXHmtSzOeyJw2lr7qjtjcyVjTAWggrV2vTGmOBAJ9ASG4MWfeTbnfTtu+sw9ZSTfHNhhrd1lrY0HPgZ6uDkmyUPW2h+BjAvH9AA+SP76Ay78Y/AqWZy317PWHrTWrk/++hSwBaiIl3/m2Zy323hKkq8I7E3zeB9u/sbkIwssMcZEGmOGuzuYfFbOWnsw+eu/gXLuDCafPWiM2ZhczvGqkkVGxpgqQGNgHYXoM89w3uCmz9xTknxh1tZa2wToCoxM/vW+0EleBN79tcP88TZQHWgEHAQmuzcc1zHGFOPCKnGjrLUn027z5s88k/N222fuKUl+P1ApzeOQ5Oe8nrV2f/Lfh4EvuVC6KiwOJdcwU2qZh90cT76w1h6y1iZZa53Au3jpZ26M8eNCoptvrf0i+Wmv/8wzO293fuaekuR/BWoaY6oaY/yB/sDXbo7J5YwxVyVfnMEYcxXQGYjK/l1e5WtgcPLXg4Gv3BhLvklJcsl64YWfuTHGAO8BW6y1U9Js8urPPKvzdudn7hHdNQDJLUVTAR9gtrX2BTeH5HLGmGpcGL3DhcniPvTW8zbGfARcz4XZ+A4BE4CFwCdAZSAauN1a61UXKbM47+u58Gu7BXYD96WpU3sFY0xbYDXwB+BMfvr/uFCf9trPPJvzHoCbPnOPSfIiIpL3PKVcIyIiLqAkLyLixZTkRUS8mJK8iIgXU5IXEfFiSvIiIl5MSV5ExIspyYuIeLH/B9toQVzJP3opAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(6,6))\n",
+    "plt.plot(*emissions.T,'.', label=\"observations\")\n",
+    "plt.plot(*ssm_posterior.smoothed_means[:,:2].T, color=\"C2\", label=\"serial smoothing\")\n",
+    "plt.plot(*psms[:,:2].T, \"--\", color=\"C3\",label=\"parallel smoothing\")\n",
+    "plt.legend();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Ju0dlre3Bf9K",
+   "metadata": {
+    "id": "Ju0dlre3Bf9K"
+   },
+   "source": [
+    "## Timing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mHz92DIeJlGT",
+   "metadata": {
+    "id": "mHz92DIeJlGT"
+   },
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pMkWU1emEMFG",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "pMkWU1emEMFG",
+    "outputId": "7f9f1b96-22b1-4666-e61e-d9e8b7df0c48"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num timesteps=100, \t time serial = 0.4385208288828532\n",
+      "Num timesteps=100, \t time parallel = 0.2780752976735433\n",
+      "Num timesteps=1000, \t time serial = 0.5768963495890299\n",
+      "Num timesteps=1000, \t time parallel = 0.37906479835510254\n",
+      "Num timesteps=10000, \t time serial = 1.8795080184936523\n",
+      "Num timesteps=10000, \t time parallel = 0.5674033164978027\n",
+      "Num timesteps=100000, \t time serial = 15.201645930608114\n",
+      "Num timesteps=100000, \t time parallel = 0.6993365287780762\n",
+      "Num timesteps=1000000, \t time serial = 148.4404614766439\n",
+      "Num timesteps=1000000, \t time parallel = 0.9188536008199056\n"
+     ]
+    }
+   ],
+   "source": [
+    "key = jr.PRNGKey(0)\n",
+    "Ts = [100, 1_000, 10_000, 100_000]\n",
+    "serial_filtering_durations = []\n",
+    "parallel_filtering_durations = []\n",
+    "num_repeats = 5\n",
+    "compiled = False\n",
+    "\n",
+    "for T in Ts:\n",
+    "    inputs = jnp.zeros((T,input_dim))\n",
+    "    \n",
+    "    key, subkey = jr.split(key)\n",
+    "    z,emissions = lgssm_sample(subkey,lgssm_params,T, inputs)\n",
+    "\n",
+    "    if not compiled:\n",
+    "        ssm_posterior = block_until_ready(lgssm_filter(lgssm_params, emissions, inputs))\n",
+    "        pfilt_means, pfilt_covs = block_until_ready(parallel_kalman_filter(lgssm_params, emissions))\n",
+    "    \n",
+    "    start = time.time()\n",
+    "    for _ in range(num_repeats):\n",
+    "        ssm_posterior = block_until_ready(lgssm_filter(lgssm_params, emissions, inputs))\n",
+    "    end = time.time()\n",
+    "    mean_time = (end-start)/num_repeats\n",
+    "    serial_filtering_durations.append(mean_time)\n",
+    "    print(f\"Num timesteps={T}, \\t time serial = {mean_time}\")\n",
+    "    \n",
+    "    start = time.time()\n",
+    "    for _ in range(num_repeats):\n",
+    "        pfilt_means, pfilt_covs = block_until_ready(parallel_kalman_filter(lgssm_params, emissions))\n",
+    "    end = time.time()\n",
+    "    mean_time = (end-start)/num_repeats\n",
+    "    parallel_filtering_durations.append(mean_time)\n",
+    "    print(f\"Num timesteps={T}, \\t time parallel = {mean_time}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "xpKwVlDzE7T-",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 369
+    },
+    "id": "xpKwVlDzE7T-",
+    "outputId": "f3fcd575-ef23-4de2-f886-02883a2b7c07"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAFgCAYAAACFYaNMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xUVf7/8dcnIZAQUoBAIAmQIL2XACriYmERFSuioK5tYVcXu1h+YlldvxZ07WtbXTuIqCg2rNgbLSGUIFWSUANppM+c3x93QgopkzK5Uz7PxyOPZO7cmflwDG8P5557jhhjUEop1fqC7C5AKaUClQawUkrZRANYKaVsogGslFI20QBWSimbtLG7gOaIiYkxiYmJjX7doUOHCA8Pb/mCfJC2RXXaHtVpe1TX1PZYuXLlfmNMl5rHfTKARWQqMLVPnz6sWLGi0a9fvnw5EydObPG6fJG2RXXaHtVpe1TX1PYQkR21HffJIQhjzFJjzOyoqCi7S1FKqSbzyQBWSil/oAGslFI28ckx4PqUlZWRkZFBcXFxnedERUWxYcOGVqzKe4SGhpKQkEBISIjdpSgV8PwugDMyMoiIiCAxMRERqfWc/Px8IiIiWrky+xljyM7OJiMjg6SkJLvLUSrg+d0QRHFxMZ07d64zfAOZiNC5c+d6/3WglGo9fhfAgIZvPbRtlPIefhnASinlCzSAvcyzzz7Lq6++Wu85d999Nw8//HArVaSU8hS/uwjXWEtWZzJ/WTpZOUXERYcxd3J/zhoZb0st5eXl/P3vf7fls5VSdavIicycIuJ//qrFciKgA3jJ6kxue3ctRWUOADJzirjt3bUAzWrcQ4cOMX36dDIyMnA4HNxxxx306dOHG264gYKCAmJiYnj55Zfp3r07EydOZMSIEXz//ffMmDGD/Px8OnTowE033cQLL7zA888/T2lpKX369OG1116jffv2LfJnV0q5x1M5AX4ewP9cuo71WXlHHHc4HAQHB7P6jxxKHc5qzxWVObh5cSoLfv2j1vccFBfJXVMH1/u5n376KXFxcXz00UcA5ObmMmXKFN5//326dOnCW2+9xe23385LL70EQGlp6eE1Le6+++7D73POOecwa9YsAObNm8eLL77I1Vdf7d4fXinVIuYvSz8cvhWKyhzMX5auAdwcNcO3oePuGjp0KDfeeCO33HILp59+Oh07diQtLY1JkyYB1v8Aunfvfvj8888/v9b3SUtLY968eeTk5FBQUMDkyZObVZdSqvGycooadbwx/DqA6+qpVtyIMf6Br8ispRHjo8N462/HNPlz+/Xrx6pVq/j444+ZN28eJ554IoMHD+ann36q9fy6lre79NJLWbJkCcOHD+fll19m+fLlTa5JKdU03aNDyco5cu58XHRYs987oGdBzJ3cn7CQ4GrHwkKCmTu5f7PeNysri/bt23PRRRcxd+5cfvnlF/bt23c4gMvKyli3bl2D75Ofn0/37t0pKyvjjTfeaFZNSqmmGZvY6YhjLZET4Oc94IZUjN+09CyItWvXMnfuXIKCgggJCeGZZ56hTZs2XHPNNeTm5lJeXs51113H4MH1jyXfe++9jBs3ji5dujBu3Djy8/ObVZdSqnG27Cvgk7TdDOoeQW5RGZk5xcS34GwpMca0QJn2SE5ONjUXZN+wYQMDBw6s93WBuhZEhaptpAtuV6ftUV0gt0e5w8m0Z39ie/YhPrvueLpGhjZnQfaVxpjkmscDugeslFJ1ef67razZmcMTM0bSNTLUI58R0GPASilVm42783j0802cNrQ7U4d1b/gFTaQBrJRSVZSWO7lxUQpRYSHce9YQjy5gpUMQSilVxVNfb2ZdVh7PXTyaTuFtPfpZ2gNWSimXtRm5PP31Zs4ZGc/kwd08/nkawEopBRSXObhh0Rq6dGjX4HIDLUUD2Ie8/PLLzJkzB3BvSUpdtlIp9z36xSZ+31vAA+cOJap96+yZqAGcuggeHQJ3R1vfUxfZWk55ebmtn69UIFq54wDPf7uVGWN7MLF/11b73MAO4NRFsPQayN0JGOv70muaHcLbt29nwIABXHjhhQwcOJBp06ZRWFjIPffcw5gxYxgyZAizZ8+m4iaYiRMnct1115GcnMzjjz/O0qVLGTduHCNHjuTkk09mz5499X7eli1bOOWUUxg9ejQTJkxg48aNzapfqUBSWFrOjYtSiI8O4/bTBrXqZ3vVLAgROQs4DYgEXjTGfNasN/zkVti99ojDYY5yCG4DGb+Bo6T6k2VF8P4cWPlK7e/ZbShMeaDBj05PT+fFF19k/PjxXH755fznP/9hzpw53HnnnQBcfPHFfPjhh0ydOhWoviTlwYMH+fnnnxER/vvf//LQQw/xyCOP1PlZs2fP5tlnn6Vv37788ssvXHXVVXz11VcN1qiUgoc+TWd7diFvzhpHh3atG4ke/zQReQk4HdhrjBlS5fgpwONAMPBfY8wDxpglwBIR6Qg8DDQvgBtSM3wbOt4IPXr0YPz48QBcdNFFPPHEEyQlJfHQQw9RWFjIgQMHGDx48OEArrokZUZGBueffz67du2itLS03i3kCwoK+PHHHznvvPMOHyspaX79SgWCH7fs5+Uft3PpsYkce1RMq39+a8T9y8BTwOGNzkQkGHgamARkAL+JyAfGmPWuU+a5nm+eOnqqRRVrQTw6xDX8UENUD7jso2Z9dM3J2yLCVVddxYoVK+jRowd33313te3hqy5JefXVV3PDDTdwxhlnsHz58mqLtNfkdDqJjo5mzZo1zapXqUBTUFLO3LdTSYoJ55ZTBthSg8fHgI0x3wIHahweC2w2xmw1xpQCC4EzxfIg8IkxZpWna+OkOyGkxpqeIWHW8Wb6448/Di8/+eabb3LccccBEBMTQ0FBAYsXL67ztbm5ucTHWystvfJKHUMhLpGRkSQlJfH2228DYIwhJSWl2fUr5e/u+2g9u3KLePi8YYS1DW74BR5g1xhwPFC165kBjAOuBk4GokSkjzHm2ZovFJHZwGyA2NjYIxYpj4qKanDZRofDYZ2TNIU2kx6i3XcPIPlZmIg4SibcSnnSFGjG0o8FBQX07duXxx57jEsvvZQBAwZw3333sXv3bgYNGkRsbCwjRoygpKSE/Px8HA4Hhw4dOlz3LbfcwrRp04iOjub4448/XG9xcTGlpaXk5+dTUlJCSEgI+fn5PPfcc1x//fXcc889lJWVce6559K7d+9q51RVXFx8uN0KCgp0ofcqtD2q89f2SN1XzoKVJZyaFEL+tlSWb3PvdS3eHsYYj38BiUBalcfTsMZ9Kx5fDDzV2PcdPXq0qWn9+vVHHKspLy+vwXOaY9u2bWbw4MEe/YzmqNpGX3/9tX2FeCFtj+r8sT1yDpWasfd9bib9e7kpKi1v1Gub2h7AClNLhtnVA84EelR5nOA6ppRSHvXPpevYX1DKf/8yhtAQe4YeKtg1D/g3oK+IJIlIW+AC4AObamlxiYmJpKWl2V2GUqqGZet28+7qTOac0IehCVF2l+P5ABaRBcBPQH8RyRCRK4wx5cAcYBmwAVhkjGl4k7TK95wqIs/n5ubW+rzx4V0+PE3bRgWq7IISbn9vLYPjIplzYh+7ywFa4SKcMWZGHcc/Bj5u4nsuBZYmJyfPqvlcaGgo2dnZdO7c2aPrePoiYwzZ2dmEhnpmdX+lvJUxhjveTyO3qIzX/zqOkGDvuAnYq+6EawkJCQlkZGSwb9++Os8pLi4O2BAKDQ0lISHB7jKUalVLU3fx8drd3HxKfwZ0i7S7nMP8LoBDQkLqvXMMrI0GR44c2UoVKaXstDevmDuWpDGiRzSzJ/S2u5xqvKMfrpRSHmCM4bZ311Jc5uCR6cNp4yVDDxW8qxo3NXQRTimlABavzODLjXu5+ZQBHNWlg93lHMEnA9gYs9QYMzsqyv5pJEop75SVU8Q9S9czLqkTlx2baHc5tfLJAFZKqfoYY7h5cSoOY5g/bThBQd45I0oDWCnld17/5Q++37yf208bSM/O7e0up04awEopv7Ij+xD3f7yBCX1jmDm2p93l1EsDWCnlN5xOw9y3UwkOEh48d5jX34zlkwGssyCUUrV56Ydt/Lr9AHdNHUxcdFjDL7CZTwawzoJQStW0eW8BDy1L5+SBXTl3VLzd5bjFJwNYKaWqKnc4ufHtFNq3Deb/zhnq9UMPFfzuVmSlVOB57tutpOzM4ckZI+ka4TvrvGgPWCnl0zbsyuOxLzZx2rDuTB0eZ3c5jaIBrJTyWaXlTm5clEJUWAj3njnE7nIaTYcglFI+66mvfmf9rjxe+EsyncLb2l1Oo/lkD1inoSmlUjNyeHr5Fs4ZFc+kQbF2l9MkPhnAOg1NqcBWXObghkUpdOnQjrumDra7nCbTIQillM959PNNbN5bwCuXjyUqLMTucprMJ3vASqnAtWL7AZ7/biszx/XkT/262F1Os2gAK6V8RmFpOTe9nUJ8dBj/79SBdpfTbDoEoZTyGQ9+spHt2YUsmHU0Hdr5fnxpD1gp5RN+3LyfV37awWXjEznmqM52l9MiNICVUl4vv7iMuYtTSYoJ5+bJA+wup8X4ZADrPGClAst9H21gV24RD583nLC2wXaX02J8MoB1HrBSgePr9L0s/G0ns48/itG9OtpdTovyyQBWSgWG3MIybn0nlX6xHbh+Ul+7y2lxvn8ZUSnlt+5euo7sglJevGQM7dr4z9BDBe0BK6W80qdpu3lvdSZzTuzDkHj/HG7UAFZKeZ3sghJuf28tQ+Ij+ccJfewux2N0CEIp5VWMMcxbkkZ+cTlvnjeCkGD/7Sf6759MKeWTPkjJ4pO03Vw/qR/9u0XYXY5HaQArpbzGnrxi7nx/HSN7RjP7+N52l+NxGsBKKa9gjOG2d9dSUu7gkfOGExzkGzsbN4dPBrDeCaeU/3l7RQZfbdzLzZMH0LtLB7vLaRU+GcB6J5xS/iXjYCH3fLiecUmduPTYRLvLaTU+GcBKKf/hdBpueScVYwwPnzecoAAYeqigAayUstUbv+zgh83Z3H7aIHp0am93Oa1KA1gpZZsd2Yf4v483cny/LswY28PuclqdBrBSyhYOp+Gmt1NoEyw8eO5QRAJn6KGC3gmnlLLF/37Yxm/bD/LIecPpHhVmdzm20B6wUqrVbd6bz0PL0pk0KJZzRsXbXY5tNICVUq2q3OHkxkUphLcN5v/ODsyhhwo6BKGUalXPfrOFlIxcnpo5ki4R7ewux1baA1ZKtZr1WXk8/uXvnD6sO6cPi7O7HNtpACulWkVpuZMbFq0hKqwt9545xO5yvIJPBrCuBaGU73nyq9/ZuDuf+88ZSsfwtnaX4xV8MoB1LQilfEvKzhz+s3wL545KYNKgWLvL8Ro+GcBKKd9RXObgxrdT6BrRjjunDrK7HK+isyCUUh717883sXlvAa9ePpaosBC7y/Eq2gNWSnnMb9sP8MJ3W7lwXE+O79fF7nK8jgawUsojCkvLuentFBI6hvH/Th1odzleSYcglFIe8cAnG/njQCELZh1NeDuNmtpoD1gp1eJ+2LyfV3/awWXHJnF07852l+O16v3fkogcA1wETAC6A0VAGvAR8LoxRifiKqWqyS8u4+bFqfSOCefmU/rbXY5Xq7MHLCKfAH8FlgGnYAXwIGAeEAq8LyJntEaRSinf8a8PN7Art4iHpw8nNCTY7nK8Wn094IuNMftrHCsAVrm+HhGRGI9VppTyOV9t3MNbK3Zy5cSjGNWzo93leL06e8AV4Ssi4SIS5Pq5n4icISIhVc9RSqmcwlJufWct/WMjuO7kvnaX4xPcuQj3LRAqIvHAZ8DFwMueLEop5Xvu+mAdBw6V8sj04bRro0MP7nAngMUYUwicA/zHGHMeMNizZSmlfMmnabt4f00WV5/YlyHxukaLu9wKYNdsiAuxZj8A6P/elFIA7C8o4fb30hgaH8VVJxxldzk+xZ0Avha4DXjPGLNORHoDX3u2LKWULzDGMO+9NPKLy3lk+nBCgvXWgsZo8PYUY8y3WOPAFY+3Atd4siillG/4ICWLT9ft5tYpA+gXG2F3OT6nvnnAL4jI0DqeCxeRy0XkQs+VppTyZnvyirljSRqjekYza0Jvu8vxSfX1gJ8G7nCFcBqwD+sGjL5AJPAS8IbHK6yFiEwFpvbp08eOj1cq4BljuPWdVEodTh6ZPoLgoMDd2bg56gxgY8waYLqIdACSqbwVeYMxJr2V6qurtqXA0uTk5Fl21qFUoFq0Yidfp+/jrqmDSIoJt7scn+XOGHABsNzzpSilfEHGwULu/XADR/fuxCXHJNpdjk/TS5ZKKbc5nYabF6dijGH+tOEE6dBDs2gAK6Xc9vovO/hxSzbzTh9Ej07t7S7H5zUqgEUkSEQiPVWMUsp7bd9/iPs/3sif+nXhgjE97C7HLzQYwCLypohEikg41myI9SIy1/OlKaW8hcNpuOntFEKChQfPHYaIDj20BHd6wIOMMXnAWcAnQBLWgjxKqQDx0vfbWLHjIHefMZhuUaF2l+M33AngENfyk2cBHxhjygDj2bKUUt7i9z35zP8snT8PiuXskfF2l+NX3Nkp7zlgO5ACfCsivYA8TxallLLXktWZzF+WTmZOESGff0dIkHDf2UN16KGFNdgDNsY8YYyJN8acaiw7gBNaoTallA2WrM7ktnfXkplTBECZw1DuNPywWfdfaGnuXIS71nURTkTkRRFZBZzYCrUppWwwf1k6RWWOasdKHYb5y2y9AdYvuTMGfLnrItyfgY5YF+Ae8GhVSinbZLl6vu4eV03n1oLsru+nAq8ZY9ZVOaaU8jNx0WGNOq6azp0AXikin2EF8DIRiQCcni1LKWWXEwd0OeJYWEgwcyf3t6Ea/+bOLIgrgBHAVmNMoYh0Bi7zbFlKKTts23+Id1dlkhTTnpJyJ1k5xcRHhzF3cn/O0iloLc6d1dCcIrIN6CciOgNbKT9VUu7g6gWrCGkTxBt/PZq46DCWL1/OxIkT7S7NbzUYwCLyV6x94RKANcDRwE/oTAil/Mr9H28kLTOPF/6SrOO9rcTdTTnHADuMMScAI4Ecj1allGpVy9bt5uUft3PZ+EQmDYq1u5yA4U4AFxtjigFEpJ0xZiOgo/FK+YnMnCJuXpzKkPhIbp0ywO5yAoo7F+EyRCQaWAJ8LiIHgR2eLUsp1RrKHE6uWbAah9Pw1IxRtGsTbHdJAcWdi3Bnu368W0S+BqKATz1alVKqVTz6+SZW7jjIEzNGkqh7u7U6d3rAiMgo4DisVdB+MMaUerQqpZTHfff7Pp75ZgsXjOnBGcPj7C4nILmzFsSdwCtAZyAG+J+IzPN0YUopz9mbX8z1b62hb9cO3DV1sN3lBCx3esAXAsOrXIh7AGs62r88WZhSyjOcTsMNb6VQUFLOm7OOJqytjvvaxZ1ZEFlA1Rsw2gGZnilHKeVpz3yzhe837+fuqYPpFxthdzkBzZ0ecC6wTkQ+xxoDngT8KiJPABhjrvFgfUqpFrRi+wH+/fkmpg6P43zdWNN27gTwe66vCss9UYiI9AZuB6KMMdM88RlKBbKDh0q5ZsFqEjqG8X9nD9HdLbyAO9PQXmnqm4vIS8DpwF5jzJAqx08BHgeCgf8aYx4wxmwFrhCRxU39PKVU7YwxzF2cyr6CEt658lgiQkPsLknh3hhwc7wMnFL1gIgEA08DU4BBwAwRGeThOpQKaP/7YTtfbNjDrVMGMiwh2u5ylItHA9gY8y1woMbhscBmY8xW13zihcCZnqxDqUC2NiOX+z/ZwMkDu3L5+ES7y1FVuHUjRguLB3ZWeZwBjHOtM3wfMFJEbjPG3F/bi0VkNjAbIDY2luXLlze6gIKCgia9zh9pW1Tnb+1RVG6468ciIkLgrO4FfPPNN416vb+1R3O1dHvUGcAishRr1kOtjDFntFgV1vtlA39347zngecBkpOTTVPWKtU1TitpW1TnT+1hjOHahWvILi5i4eyjGZPYqdHv4U/t0RJauj3q6wE/7Pp+DtANeN31eAawpxmfmQlUnf+SgM4rVqrFLVqxkw9Ssrjpz/2aFL7K8+oMYGPMNwAi8ogxJrnKU0tFZEUzPvM3oK+IJGEF7wXAzGa8n1Kqhk178rnrg3WM79OZKyf2sbscVQd3LsKFu+boAuAKTreWTRKRBVi7Z/QXkQwRucIYUw7MAZYBG4BFrp2W3SYiU0Xk+dzc3Ma8TKmAUFTqYM6bq+jQrg2Pnj+C4CCd7+ut3LkIdx2wXES2Ym1H3wvXRbCGGGNm1HH8Y+Bjd4us5fVLgaXJycmzmvoeSvmrez5cx6Y9Bbx6+Vi6Rug2jt6s3gAWkSCs9X/7AhVL5W80xpR4ujClVOMtTcliwa87uXLiURzf78jt5ZV3qXcIwhjjBG42xpQYY1JcXxq+SnmhHdmHuO3dtYzqGc0Nk/rZXY5ygztjwF+IyE0i0kNEOlV8ebwypZTbSsodzHlzNUECT8wYSUiwp29yVS3BnTHg813f/1HlmAF613KuUsoGD36SztrMXJ67eDQJHdvbXY5ykzuL8SS1RiGNISJTgal9+uj0GqW+WL+Hl37YxiXH9GLy4G52l6Mawd094YZgLZxz+JKqMeZVTxXVEJ0FoZQlK6eImxanMDgukttOHWh3OaqRGgxgEbkLmIgVwB9jrWL2PWBbACuloNzh5NqFqykrd/LUzFGEhujWQr7GnZH6acBJwG5jzGXAcKypaUopGz3+5e/8tv0g9509lCTdUt4nuRPARa7paOUiEgnspfpaDkqpVvbD5v089fVmzhudwFkj4+0uRzWRO2PAK0QkGngBWAkUYN1ebBu9CKcC2b78Eq57aw1HdenAP8/ULeV9WYM9YGPMVcaYHGPMs1gbcl7iGoqwjTFmqTFmdlSUjoSowOJ0Gm5YtIa8ojKemjmS9m3tWNJbtRR3LsK9BnwLfGeM2ej5kpRSdXnu26189/t+7jt7CAO6Rdpdjmomd8aAXwK6A0+KyFYReUdErvVwXUqpGlbuOMDDn6Vz2tDuzBzb0+5yVAtw50aMr0XkW2AMcALWrhWDsXY1Vkq1gpzCUq5ZsIa46FDuP3eobinvJ9wZgvgSa/3fn4DvgDHGmL2eLkwpZTHGcPPiVPbkFbP4ymOJ1C3l/YY7QxCpQCkwBBgGDBGRMI9WpZQ67NWfdvDZ+j3ccsoARvTQLeX9iTtDENcDiEgEcCnwP6w94tp5tLJ66DQ0FSjSMnO576MNnNC/C1cc53XLsqhmarAHLCJXi8hbwGrgTKyLclM8XVh9dBqaCgQFJeVcvWA1HcNDeGT6CIJ0ayG/484kwrbAv4GVrv3clFIeZozhjiVp7Mg+xIJZR9MpvK3dJSkPqLcHLCLBwCxjzC8avkq1nsUrM3hvdSbXntSPcb07212O8pCGtiRyAOkiopMOlWolm/fmc+f76zimd2fmnKjXOfyZO0MQHYF1IvIrcKjioDHmDI9VpVSAKi6zthZq3zaYxy7QLeX9nTsBfIfHq1BKAXDvh+vZuDufly8bQ2ykbinv79yZhvaNiMRi3QkH8KveiKFUy/sodRdv/PIHfzu+NxP7d7W7HNUK3JmGNh34FTgPmA78IiLTPF1YAzVNFZHnc3Nz7SxDqRbzR3Yht76Tyoge0dw0ub/d5ahW4s6dcLdj3X58iTHmL8BYbB6W0HnAyp+Ulju5esEqEHhSt5QPKO6MAQfVGHLIxr3gVkq5Yf6yjaRk5PLMhaPo0Um3lA8k7gTwpyKyDFjgenw+1uacSqlm+mrjHl74bhsXHd2TKUO7212OamV1BrCItDPGlBhj5orIOcBxrqeeN8a81zrlKeW/ducWc+OiFAZ0i2DeaYPsLkfZoL4e8E/AKBF5zRhzMfBuK9WklN9zOA3XLlxNSbmTpy/ULeUDVX0B3FZEZgLHunrA1RhjNJCVaqInvvydX7Yd4JHzhnNUlw52l6NsUl8A/x24EIgGptZ4zqA9YqWa5Kct2Tz51e+cMyqec0cn2F2OslGdAWyM+R74XkRWGGNebMWalPJb2QUlXLtwNYkx4dx75hC7y1E2c2dbeg1fpVqA02m48e0UcorKeGrGKMLb6Zbygc4n5/PqnXDKF73w3VaWp+/jjtMGMihOt5RXDa8HLCLSo7WKcZfeCad8zao/DjJ/WTpThnTjoqN72V2O8hINrQds0JsulGqW3KIyrlmwmtjIUB44d5huKa8Oc2cIYpWIjGn4NKVUTcYYbn0nld25xTw5cyRRYbqlvKrkzlWAccCFIrIDa0F2weocD/NoZUr5gdd/+YNP0nZz65QBjOrZ0e5ylJdxJ4Ane7wKpfzQ+qw87v1wPX/q14XZE3rbXY7yQu5MQ9sB9ABOdP1c6M7rlApkh0rKmbNgFdFhIfx7+nDdUl7Vyp0F2e8CbgFucx0KAV73ZFFK+bo731/Htv2HeOyCEXTu0M7ucpSXcqcnezZwBq4NOY0xWUCEJ4tSype9uyqDd1ZlcPWJfTn2qBi7y1FezJ0ALnVNRzMAIhLu2ZKU8l1b9hUwb0kaY5M6cY1uKa8a4E4ALxKR54BoEZkFfAG84NmylPI9FVvKt2sTxBMXjKSNbi2kGuDOrsgPi8gkIA/oB9xpjPnc45Up5WPu+2gDG3bl8dKlyXSL0i3lVcPcXQ1kLRCGNQyx1nPlKOWbPlm7i9d+3sFfj0vixAGxdpejfIQ7syD+irUt/TnANOBnEbnc04U1UJMuxqO8xs4Dhdz8TirDE6K4+ZQBdpejfIg7g1RzgZHGmEuNMZcAo7GmpdlGF+NR3qLM4eSahavBwJMzRtG2jY77Kve5MwSRDeRXeZzvOqZUwHv4s3RW/5HDUzNH0rOzbimvGsedAN4M/CIi72ONAZ8JpIrIDQDGmH97sD6lvNby9L08981WZo7ryenD4uwuR/kgdwJ4i+urwvuu73ozhgpYe/Iqt5S/83TdUl41jTvT0P7ZGoUo5SscTsN1C9dQWOrgqZkjdUt51WS6KZVSjfT015v5aWs2D00bRp+u+g9B1XR6yVapRvhlazaPfbGJs0bEcZ5uKa+aSQNYKTcdOFTKtQvX0KtzOP86e6huLaSazZ0bMfqJyJciktzMwTIAABmMSURBVOZ6PExE5nm+NKW8hzGGm95O4cChUp6cMZIOuqW8agHu9IBfwFoLuAzAGJMKXODJopTyNi9+v42vNu7l/506gCHxegOQahnuBHB7Y8yvNY6Ve6IYpbxRys4cHvx0I38eFMslxybaXY7yI+4E8H4ROYrK9YCnAbs8WpVSXiKvuIw5C1bRNSKUh6bplvKqZbkzkPUP4HlggIhkAtuAizxalVJewBjDbe+uJSunmEV/O5ro9m3tLkn5GXduxNgKnOzaCSPIGJPf0GuU8gcLft3JR6m7mDu5P6N7dbK7HOWHGgxgEYkG/gIkAm0q/glmjLnGo5UpZaONu/P459J1TOgbw5V/OsrucpSfcmcI4mPgZ6yF2J2eLUcp+xWWljPnzdVEhoXw7+kjdEt55THuBHCoMeYGj1fSCCIyFZjap49ueqhaxpLVmcxflk5mThHtv/qCwlIHb/x1HF0idEt55TnuzIJ4TURmiUh3EelU8eXxyuqhC7KrlrRkdSa3vbuWzJwiAApLHbQJEvbll9hcmfJ3bm1LD8wHfgJWur5WeLIopVrT/GXpFJU5qh0rdxrmL0u3qSIVKNwZgrgR6GOM2e/pYpSyQ5ar5+vucaVaijs94M1AoacLUcoOJeUO2retfT3fuOiwVq5GBRp3esCHgDUi8jVweFBMp6EpX5dxsJB/vLGKQ6UOgoMEh9Mcfi4sJJi5k/vbWJ0KBO4E8BLXl1J+4+uNe7nurTU4nYZnLxpFcZnz8CyI+Ogw5k7uz1kj4+0uU/k5d+6Ee6U1ClGqNTichkc/38RTX29mYPdInrlwFIkx4QCcNTKe5cuXM3HiRHuLVAGjzgAWkUXGmOkishbXQjxVGWOGebQypVrYvvwSrl24mh+3ZHN+cg/+eeZg3c9N2aq+HvC1ru+nt0YhSnnSr9sOMOfNVeQWlfHQtGFMT+5hd0lK1T0LwhhTseTkVcaYHVW/gKtapzylmscYw3PfbGHGCz8T3q4NS/4xXsNXeQ13pqFNquXYlJYuRKmWlltUxuzXVnL/JxuZPDiWD+aMZ2D3SLvLUuqw+saAr8Tq6fYWkdQqT0UAP3i6MKWaIy0zlyvfWMmunGLuPH0Ql41P1MXUldepbwz4TeAT4H7g1irH840xBzxalVJNZIxhwa87uXvpOjqHt+Wtvx3D6F4d7S5LqVrVGcDGmFwgF5jReuUo1XSFpeXMey+Nd1dnMqFvDI9fMJJO4bqLhfJeure28gtb9hVw5esr+X1vAded3JerT+xLsK7jq7ycBrDyeUtTsrj1nVTahQTz6uVjmdC3i90lKeUWDWDls0rKHfzfRxt45acdjOoZzdMXjqJ7lC6go3yHBrDySRkHC/nHm6tJ2ZnDFcclceuUAYQEuzOrUinvoQGsfM7X6Xu5/q01OByGZy4cxZSh3e0uSakm0QBWPsPhNDz2xSae/GozA7pF8MxFo0lyLaSjlC/SAFY+YX+BtZDOD5uzmZ6cwD1nDtGFdJTP0wBWXu+37dZCOjmFupCO8i8awMprGWN44butPPhpOj06hvG/q8YyKE7XclD+QwNYeaXcojLmvp3CZ+v3MGVINx6cNozI0BC7y1KqRWkAK6+TlpnLVW+sIiuniDtOH8TlupCO8lMawMprGGN467ed3PnBOjq1b8tbfzua0b062V2WUh6jAay8QlGpg3lL0nhnVQYT+sbw2Pkj6Nyhnd1lKeVRXhPAIhIO/AcoBZYbY96wuSTVSrbsK+Cq11exaW8+157Ul2tO0oV0VGDw6L2bIvKSiOwVkbQax08RkXQR2SwiFWsNnwMsNsbMAs7wZF3Ke3yYmsUZT37P3vxiXrlsLNdP6qfhqwKGp2+efxk4peoBEQkGnsba1mgQMENEBgEJwE7XaQ4P16VsVlru5O4P1jHnzdX07xbBR9dM4Ph+uoqZCixizBE7zrfsB4gkAh8aY4a4Hh8D3G2Mmex6fJvr1AzgoDHmQxFZaIy5oI73mw3MBoiNjR29cOHCRtdUUFBAhw4dGv06f2RHW2QXOXl6TQlbc538uVcbpvdvSxsv6fXq70Z12h7VNbU9TjjhhJXGmOSax+0YA46nsqcLVvCOA54AnhKR04Cldb3YGPM88DxAcnKymThxYqMLWL58OU15nT9q7bZYnr6Xf721hjJHEP+5cASnetlCOvq7UZ22h0vqIvjyHkxuBhKVACfdCcOmN/ttveYinDHmEHCZ3XUoz3A4DY9/sYknv95M/9gI/nPhKHp30Z6V8gGpi2DpNVBWhADk7rQeQ7ND2I4AzgSq3syf4Dqm/FTVhXSmjU7g3jOHENZWF9JRXsoYyM2AvethTxp8+zCUFVU/p6wIvrzHJwP4N6CviCRhBe8FwEwb6lCtYMX2A/yjYiGdc4cxfYwupKO8SHEu7FkPe9dZ3/esg70boCS34dfmZjT74z0awCKyAJgIxIhIBnCXMeZFEZkDLAOCgZeMMesa+b5Tgal9+vRp6ZJVCzHG8N/vtvHApxtJ6BjGu1eNYXBclN1lqUDlKIP9v7sC1hW2e9dbwwkV2kVB7CAYOg1iB1tfXQfCM+Orn1chKqHZZXk0gI0xtW5pb4z5GPi4Ge+7FFianJw8q6nvoTwnr9haSGfZuj2cMrgbD52nC+moVmIM5GVW6dW6wnb/JnCWWecEtYGYftDzaOh6uStoB1mBWtuaIyfdeXgM+LCQMOt4M3nNRTjlH9ZlWQvpZB4sYt5pA7niuCRdSEd5RnGea5x2neu7K3SLqwwfRCZYvdq+kyB2iPVz577Qpq37n1MxzuvPsyCU73vrtz+4431rIZ2Fs48mOVEX0lEtwFEG2ZurBK2rV5v7R+U5bSOscB1yrtWbrRg+COvYMjUMmw7DpvNNC0/L0wBWzVZU6uCO99NYvDKD4/rE8NgFI4jRhXRUYxkD+btcAVulV7s/HRyl1jlBbawebI8xMPqSyl5tVI/ahw+8nE8GsF6E8x5b9xVw1RurSN+TzzUn9eVaXUhHuaMk35ptUC1s10FxTuU5EXFWuPY5EboOtn6O6Qdt/Od/7j4ZwHoRzjt8vHYXNy9OJSRYePmysfxJ13JQNTnKreGDqjMP9qRBTtXhgw7WsMHgs1xB6xo+aO//Q1g+GcDKXqXlTu7/ZAP/+2E7I3tG8/TMUcRFh9ldlrKTMZC/u8Z82nWwbxM4SqxzJBg694H40TDqL5W92qieEOTpdcG8kwawapSsnCL+8eYqVv+Rw2XjE7ltykDatgnMvzx+zbX2wZ9yM2B1jav+JQXW8EHNXm3RwcrXR3S3erW9J1b2amP6QUioHX8ar6UBrNz2zaZ9XLdwNWUOw9MzR3HaMO9aSEe1kNrWPlhyJfz4NJTkwMHtleeGhFvDBQOnWhfEKmYgBMDwQUvQAFYNcjgNT3z5O0989bsupONvivPg4DYrVA9ss35OWQDlJdXPc5bD3jQYcDqMuLAyaKN7BezwQUvwyQDWWRCtJ7ughGsXruH7zfs5d1QC/zpLF9LxKU4nFOyuDNeqQXtwOxRmVz8/rNOR4Xv4vRww/RVPVxxQfDKAdRZE61i54wD/eGM1BwpLefDcoUxP7qF3tXmjsmLI2XFkuB7YZh0vL648V4KsW247JlnDBh0TrZ87JVk/h0bBo0M8tvaBqs4nA1h5ljGGF7/fxgOfbCS+YxjvXXWsLqRjJ2OsC1yHw3UbHNheGbR5WUCVnW1Cwq1Ajelr3YJbEa4dkyC6JwQ3sC6HB9c+UNVpAKtq8orLuPntVD5dt5s/D4pl/nnDiQrThXQ8zlEOeRm192IPboeSvOrnd4i1AjXp+CN7seFdmndXmAfXPlDVaQCrw9Zn5XHVGyvZqQvpeEZJgRWmtY3F5vxhXeiqEBQCHXtZgdpjXPVebMde0Dbcs7V6aO0DVZ0GcIBasjqT+cvSycwpIv7nr5jQN4b3VmcS3T6EhbOPZowupNN4xkDBnjp6sdvg0L7q54dGWYHafTgMOrN6LzYyHoL0Yqe/88kA1lkQzbNkdSa3vbuWojIHAJk5RSz8bSd9u4azYPYxgbmQTn03HlRVXmr1Vit6slWD9uB2KCuscrK4LnglQr9TqvdiOyW13Epdymf5ZADrLIimM8bwwCcbDodvVYdKHYEbvjVvPPhgDmT8Zt3RdThod1jjtMZZ+do2YVaodkqy7vqq2ouN7ulXC8eolueTAazcU1BSTvrufDbuzrO+77J+zisur/X8XTnFtR73a04nfDbvyE0Xy0vg1+etn8O7WMHa82hXuCZVhm6HWJ9cBlF5Bw1gP1DucLI9u/Bw0G7YlU/6njx2HqgMlQ7t2tC/WwSnD4/jo9Rd5BaVHfE+AbGgjjFwYCts+wa2fgPbvzvyZoTDBG7bCe0iWrVEFTg0gH3MvvySI4J2054CSsutfxYHBwlJMeEMT4jm/OQe9O8WyYBuESR0DDs8o2FsYqdqY8AAYSHBzJ3c35Y/k8fl77bCdtu3VvBW3GQQEQd9/wyblkHRgSNfF5Wg4as8SgPYSxWVOvh9b8WwQeUwQvah0sPndIlox4BuEVxyTC8GdIukf7cI+nTtQGhI/VfPzxoZD1A5CyI6jLmT+x8+7vOKcmD795W93P3p1vGwjpA4AY67DpL+ZC2NKFJtDPgwvfFAtQINYJs5nYadBwut3myVoN2WfQjjurkpNCSI/rERnDSwKwNcPdr+3SLo3IwLZmeNjOeskfEs94d5nmVF8MdPVg936zewa411oSykPfQ8BkZeaAVut2G1LxyjNx4om2gAt6KDh0rZuDuf9N15rl5tPpv25FNYag0FiECvTu0Z0C2SqcPjGNAtggHdI+nZqb1u81OVoxyyVrmGFb6Bnb9Ye4YFtYGEMXD8zdYdYglj3N/9Vm88UDbwyQD29nnAJeUOtuw9VDn7wNWz3ZNXucpUx/YhDOgWyfTkHgzsHkH/bpH0i+1A+7Y++Z/Es5xOa9HvijHc7T9Aab71XLehMHa2NQWs5zHQTpfJVL7DJ/+2e8s8YGMMWbnFbNxV2aNN353H1n2HKHda4wdtg4Po07UD44+KYYAraAd2i6BLRDu9zbc+B7ZVjuFu+xYK91vHOx0Fw86zeriJx0N4Z3vrVKoZfDKA7ZBfXFatN1vxc36VObXx0WEM7B7BpEGxh8dqE2PCCQnWBasblL/HmhK2dbkVvBWbNnboBn1OssZwk46H6B62lqlUSwqoAK65/kFtV/7LHU627T/EBldvtmK6V2ZO5RXyiHZtGNA9gjNHxB0O2n7dIogM1VXD3Facaw0lVPRy922wjodGWTMVjrkaev/J2kdM/6Wg/FTABHBt6x/c+k4qG3bn0Tm87eHpXpv3FlDqsObUtgkSencJZ3Svjswc1/PwRbG4qFAdPmissmLY+XPlTIWsVdZMhTZh1h1mw8+3erndh+siNCpgBEwAz1+WfsT6B8XlTp77ZisAsZHtGNAtkgl9XWO1sZEc1TWcdm00DJrEUW5NB6sYUvjjF2t7cgm2tiWfcKMVuD3G6noJKmAFTABn5RTVelyAVXdMomO4m9OVVO2MsbYq3+a6aLb9+8pFxGOHwJi/WkMKPY+B0Eh7a1XKSwRMAMdFh1Ubx616XMO3iQ7uqD5T4dBe63jHRBh8thW4icdDhy62lqmUtwqYAJ47uX9grX/gCQX7XD1cV+Ae3G4dD+9qhW3FTIWOvWwtUylfETAB7PfrH3hCcR7s+LGyl7t3nXW8XSQkHgfjrrSCt8sAnamgVBP4ZAA39U44v1r/oLlq2wFi4BmQ8WvlkELmSjAOCG5nzVQ46U7XTIUREOyTvzpKeRWf/FvkLXfC+azadoB472/w3pVgykGCIG5U5aphPcZBSKjdVSvld3wygFUTOMqs9RSy1sCy247cAcI4oW17OOcFSBxv3RChlPIoDWB/5CizpoTtWgNZq63Q3bPOmodbn9JDMODU1qlRKaUB7PMcZbBvY2XQ7loDu9Mqw7ZdpHV32bjZ1tht3Eh49QzIzTjyvaISWrd2pQKcBrAvcZRXhu2uNVbg7l5bGbZtIyBuBIydZQVt3EhrA8mai5CfdJfuAKGUF9AA9laOcmsrnWo927VQ7tq5uG2E1bMdO6uyZ9upd+07PtSkO0Ao5RU0gL2Boxz2b6rSs11tDSOUu3qobTtYYZt8hatnO8JaF9edsK2L7gChlO00gFub0wH70iuHELJWu3q2VcK22zBIvtwK2u4jrM0jmxO2SimvpAHsSU6Hq2e7pkrPdi2UFVrPh4RD92GQfJlrGKEibHUFNqUCgQZwS3E6YP/vR/Zsyw5Zz4e0t4YRRl1iBW3cSA1bpQKcBnBTOB2QvbkyaHetgV2p1cO22zAYdXHlBbKYvhq2SqlqNIAb4nRaYVv1poZdKZVh2ybMGkYYeVHlBbKYfhq2SqkG+WQAN3lb+toWoKk69crphANbavRsU6C0wHq+TZi1DfrIiyovkMX004VplFJN4pPJ0aTFeGpbgOaDq62tckJCK3u2pfnW+W1CrbAdMbPyAllMfw1bpVSLCZw0+fKeIxegKS+GFf+tDNvhF1ReINOwVUp5WOAkTG1rHwAgcFsGBOuW8kqp1hU4s/vrWmgmKkHDVylli8AJ4JPutBacqUoXoFFK2ShwAnjYdJj6BET1wCAQ1cN6rAvQKKVsEjhjwKAL0CilvErg9ICVUsrLaAArpZRNNICVUsomGsBKKWUTDWCllLKJBrBSStlEA1gppWyiAayUUjbRAFZKKZuIMcbuGppMRPYBO1wPo4DcKk9XfVzzuRhgfwuWUvP9m3t+fc/X9pw7x+pqj5Zui7rqac752h7uP6/t0fBzDR2rr22a2h69jDFdjjhqjPGLL+D5uh7X8twKT352c8+v7/nannPnWF3t0dJtoe2h7eHr7dFA27Roe/jTEMTSeh7XfM7Tn93c8+t7vrbn3Dmm7VH3Y20PbY/6/vweaw+fHoJoKhFZYYxJtrsOb6BtUZ22R3XaHtW1dHv4Uw+4MZ63uwAvom1RnbZHddoe1bVoewRkD1gppbxBoPaAlVLKdhrASillEw1gpZSyiQawUkrZJOADWETOEpEXROQtEfmz3fXYTUQGisizIrJYRK60ux5vICLhIrJCRE63uxa7ichEEfnO9Tsy0e567CYiQSJyn4g8KSKXNPb1fhnAIvKSiOwVkbQax08RkXQR2SwitwIYY5YYY2YBfwfOt6NeT2tke2wwxvwdmA6Mt6NeT2tMe7jcAixq3SpbTyPbwwAFQCiQ0dq1toZGtseZQAJQRlPao6VvM/SGL+B4YBSQVuVYMLAF6A20BVKAQVWefwQYZXft3tAewBnAJ8BMu2u3uz2AScAFwKXA6XbX7gXtEeR6PhZ4w+7avaA9bgX+5jpncWM/yy97wMaYb4EDNQ6PBTYbY7YaY0qBhcCZYnkQ+MQYs6q1a20NjWkP1/kfGGOmABe2bqWto5HtMRE4GpgJzBIRv/s705j2MMY4Xc8fBNq1YpmtppG/HxlYbQHgaOxntWlOoT4mHthZ5XEGMA64GjgZiBKRPsaYZ+0ozga1todrXO8crL9cH9tQl11qbQ9jzBwAEbkU2F8lgPxdXb8f5wCTgWjgKTsKs0ld+fE48KSITAC+beybBlIA18oY8wTwhN11eAtjzHJguc1leB1jzMt21+ANjDHvAu/aXYe3MMYUAlc09fV+98+pemQCPao8TnAdC1TaHtVpe1Sn7VGdR9ojkAL4N6CviCSJSFusCysf2FyTnbQ9qtP2qE7bozqPtIdfBrCILAB+AvqLSIaIXGGMKQfmAMuADcAiY8w6O+tsLdoe1Wl7VKftUV1rtoeuhqaUUjbxyx6wUkr5Ag1gpZSyiQawUkrZRANYKaVsogGslFI20QBWSimbaACrgCci20UkpoXfM1FEZlZ5fKmIBNLaCcoNGsBKeUYi1gpqStVJA1h5NdduFB+JSIqIpInI+a7jo0XkGxFZKSLLRKR7leMprq/5NRfVduPzLhKRX0VkjYg8JyLBruMFrp0PUkTkZxGJdR0/yvV4rYj8S0QKXG/1ADDB9T7Xu47FicinIvK7iDzUIg2kfJoGsPJ2pwBZxpjhxpghwKciEgI8CUwzxowGXgLuc53/P+BqY8zwxn6QiAzE2hVlvDFmBNb6rhVrIocDP7ve91tgluv448DjxpihVN8R4VbgO2PMCGPMo65jI1zvPxQ4X0SqLu6iApAGsPJ2a4FJIvKgiEwwxuQC/YEhwOcisgaYBySISDQQ7VpQG+C1Rn7WScBo4DfX+56EtQMCQCnwoevnlVhDDADHAG+7fn6zgff/0hiTa4wpBtYDvRpZn/IzAb8esPJuxphNIjIKOBX4l4h8CbwHrDPGHFP1XFcAN4cArxhjbqvluTJTuXCKg6b93Smp8nNT30P5Ee0BK68mInFAoTHmdWA+1l5d6UAXETnGdU6IiAw2xuQAOSJynOvljd1S6Utgmoh0db1vJxFpqJf6M3Cu6+cLqhzPByIa+fkqwGgAK283FPjVNSRwF/Av155c04AHRSQFWAMc6zr/MuBp1/lS8SYiEici9W6xZIxZjzWc8ZmIpAKfA90bqO864AbX+X2AXNfxVMDhumh3fZ2vVgFNl6NUfktEEoEPXRfvPPUZ7YEiY4wRkQuAGcaYMz31ecq/6BiUUs0zGnhKRATIAS63uR7lQ7QHrJRSNtExYKWUsokGsFJK2UQDWCmlbKIBrJRSNtEAVkopm/x/QOJTmKwJfGwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(5, 5))\n",
+    "plt.loglog(Ts, serial_filtering_durations, '-o', label='serial')\n",
+    "plt.loglog(Ts, parallel_filtering_durations, '-o', label='parallel')\n",
+    "plt.xticks(Ts)\n",
+    "plt.xlabel(\"seq. length\")\n",
+    "plt.ylabel(\"time per forward pass (s)\")\n",
+    "plt.grid(True)\n",
+    "plt.legend()\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0mSknJxzLCbt",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "0mSknJxzLCbt",
+    "outputId": "0f4db370-d0b0-4d2f-bab3-bbe6d3128316"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num timesteps=100, \t time serial = 0.7041940212249755\n",
+      "Num timesteps=100, \t time parallel = 0.36930127143859864\n",
+      "Num timesteps=1000, \t time serial = 0.9897834300994873\n",
+      "Num timesteps=1000, \t time parallel = 0.530796480178833\n",
+      "Num timesteps=10000, \t time serial = 3.2751163959503176\n",
+      "Num timesteps=10000, \t time parallel = 0.7730414390563964\n",
+      "Num timesteps=100000, \t time serial = 26.506278562545777\n",
+      "Num timesteps=100000, \t time parallel = 0.9454202651977539\n"
+     ]
+    }
+   ],
+   "source": [
+    "key = jr.PRNGKey(0)\n",
+    "Ts = [100, 1_000, 10_000, 100_000]\n",
+    "serial_smoothing_durations = []\n",
+    "parallel_smoothing_durations = []\n",
+    "num_repeats = 5\n",
+    "compiled = False\n",
+    "\n",
+    "for T in Ts:\n",
+    "    inputs = jnp.zeros((T,input_dim))\n",
+    "    \n",
+    "    key, subkey = jr.split(key)\n",
+    "    z,emissions = lgssm_sample(subkey,lgssm_params,T, inputs)\n",
+    "\n",
+    "    if not compiled:\n",
+    "        ssm_posterior = block_until_ready(lgssm_smoother(lgssm_params, emissions, inputs))\n",
+    "        pfilt_means, pfilt_covs = block_until_ready(parallel_kalman_smoother(lgssm_params, emissions))\n",
+    "    \n",
+    "    start = time.time()\n",
+    "    for _ in range(num_repeats):\n",
+    "        ssm_posterior = block_until_ready(lgssm_smoother(lgssm_params, emissions, inputs))\n",
+    "    end = time.time()\n",
+    "    mean_time = (end-start)/num_repeats\n",
+    "    serial_smoothing_durations.append(mean_time)\n",
+    "    print(f\"Num timesteps={T}, \\t time serial = {mean_time}\")\n",
+    "    \n",
+    "    start = time.time()\n",
+    "    for _ in range(num_repeats):\n",
+    "        pfilt_means, pfilt_covs = block_until_ready(parallel_kalman_smoother(lgssm_params, emissions))\n",
+    "    end = time.time()\n",
+    "    mean_time = (end-start)/num_repeats\n",
+    "    parallel_smoothing_durations.append(mean_time)\n",
+    "    print(f\"Num timesteps={T}, \\t time parallel = {mean_time}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eCyil2PbNdEG",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 369
+    },
+    "id": "eCyil2PbNdEG",
+    "outputId": "ec99476b-7bc4-48f3-86fa-7112417596de"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAFgCAYAAACFYaNMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3yV5d3H8c+PEEhYgYS9w95DlooDrfNRHKi4nzoKjqpVK622Dh5rW+vosLVaLYqzVdSiWJVaFSdb9lJIGAFkhYQEErKu54/7BAKS5ITknPuM7/v1Oq+Q+6wf9yt8c/E7131d5pxDRETCr57fBYiIxCsFsIiITxTAIiI+UQCLiPhEASwi4pP6fhdQGy1btnRdu3at8fP27t1L48aN674gOYTOc/joXIfH0Z7nhQsX7nTOtTr8eFQHcNeuXVmwYEGNnzdr1izGjBlT9wXJIXSew0fnOjyO9jyb2YYjHVcLQkTEJwpgERGfKIBFRHwS1T3gIykuLiYrK4vCwsJKH5OSksKqVavCWFXkSEpKomPHjiQmJvpdikjci8oANrOxwNgePXp8776srCyaNm1K165dMbMjPj8vL4+mTZuGuMrI45xj165dZGVlkZ6e7nc5InEvKlsQzrkZzrmJKSkp37uvsLCQtLS0SsM3npkZaWlpVf7vQETCJyoDuDoK38rp3IhEjpgMYBGRaKAAjjBPP/00L774YpWPmTx5Mo899liYKhKRUInKD+Hq0vRFm3l05hq25BTQvnkyk87szQVDO/hSS0lJCTfeeKMv7y0ilSvPic05BXSY83Gd5URcB/D0RZu5561lFBSXArA5p4B73loGUKuTu3fvXsaPH09WVhalpaXcd9999OjRgzvvvJP8/HxatmzJ1KlTadeuHWPGjGHIkCF88cUXXH755eTl5dGkSRPuuusunn32WZ555hmKioro0aMHL730Eo0aNaqTv7uIBCdUOQExHsD/N2MFK7fs+d7x0tJSEhISWLQxh6LSskPuKygu5WdvLOUf8zYe8TX7tW/GA2P7V/m+H3zwAe3bt+ff//43ALm5uZx99tm8/fbbtGrVitdee41f/vKXPPfccwAUFRUdWNNi8uTJB15n3LhxTJgwAYB7772XKVOmcOuttwb3lxeROvHozDUHwrdcQXEpj85cowCujcPDt7rjwRo4cCA//elP+fnPf865555LixYtWL58Oaeffjrg/QJo167dgcdfeumlR3yd5cuXc++995KTk0N+fj5nnnlmreoSkZrbklNQo+M1EdMBXNlItfxCjNEPf8zmI5zEDs2Tee2G4476fXv16sXXX3/Ne++9x7333supp55K//79mT179hEfX9nydtdccw3Tp09n8ODBTJ06lVmzZh11TSJydNo1T2JLzvfnzrdvnlzr147rWRCTzuxNcmLCIceSExOYdGbvWr3uli1baNSoEVdddRWTJk1i7ty57Nix40AAFxcXs2LFimpfJy8vj3bt2lFcXMwrr7xSq5pE5Ogc1y3te8fqIicgxkfA1Snv39T1LIhly5YxadIk6tWrR2JiIk899RT169fntttuIzc3l5KSEm6//Xb696+6l/yrX/2KUaNG0apVK0aNGkVeXl6t6hKRmtm4ax/vLfuO3m2bkl9YzOacQjrU4Wwpc87VQZn+GD58uDt8QfZVq1bRt2/fKp8Xr2tBlAvmHNUFLRIePjrXda+szHHZs3NYtWUPM+84ifbNk2uzIPtC59zww4/HdQtCRKQyL85ez7zMbO47t1+d9HuPRAEsInKY9Tv38vAHqxnTuxWXDO8YsvdRAIuIVFBW5pj0xhISE+rx8LhBIV3ASgEsIlLB81+tZ/763Twwtj9tU5JC+l4KYBGRgIwd+Tw6czWn9mnNRceEfk0YBbCICFBa5pj0xlIaJNTjt+MGhmXtbAVwFJk6dSq33HILENySlFq2UiR4z3+ZycINu5l8Xn/aNAtt66GcAnjp6/CHATC5ufd16eu+llNSUuLr+4vEo3U78nl05hpO69uGC8O4HG18B/DS12HGbZC7CXDe1xm31TqE169fT58+fbjyyivp27cvF198Mfv27ePBBx9kxIgRDBgwgIkTJ1J+EcyYMWO4/fbbGT58OH/605+YMWMGo0aNYujQoZx22mls27atyvdbt24dZ511FsOGDePEE09k9erVtapfJJ6UljnumraEpMQEfnPhgLBu2xXblyK/fzd8t+x7h5NLSyChPmTNh9L9h95ZXABv3wILXzjya7YdCGc/XO1br1mzhilTpjB69Giuu+46/vrXv3LLLbdw//33A3D11Vfz7rvvMnbsWODQJSl3797NnDlzMDP+/ve/88gjj/D4449X+l4TJ07k6aefpmfPnsydO5ebb76Zjz/+uNoaRQT+/nkGizbm8KfLhtA6TK2HcrEdwNU5PHyrO14DnTp1YvTo0QBcddVVPPHEE6Snp/PII4+wb98+srOz6d+//4EArrgkZVZWFpdeeilbt26lqKioyi3k8/Pz+eqrr7jkkksOHNu/v/b1i8SDtdvzePzDbzijXxvOG9w+7O8f2wFcyUi1oHwtiD8MCLQfDpPSCa79d63e+vD/xpgZN998MwsWLKBTp05Mnjz5kO3hKy5Jeeutt3LnnXdy3nnnMWvWrEMWaT9cWVkZzZs3Z/HixbWqVyTelJSW8dNpS2ncIIFfXxieWQ+Hi+8e8A/uh8TDrvFOTPaO19LGjRsPLD/56quvcsIJJwDQsmVL8vPzeeONNyp9bm5uLh06eB8EvPBCJa2QgGbNmpGens60adMAcM6xZMmSWtcvEuue/TyTJZty+L/zB9CqaUNfaojKADazsWb2TG5ubu1eaNB4GPuEN+LFvK9jn/CO11Lv3r158skn6du3L7t37+amm25iwoQJDBgwgDPPPJMRI0ZU+tzJkydzySWXMGzYMFq2bFnte73yyitMmTKFwYMH079/f95+++1a1y8Sy77ZlscfPvyGswe0ZeygdtU/IVScc1F7GzZsmDvcypUrv3fscHv27Kn2MbWRmZnp+vfvH9L3qI1gzlFd+OSTT8LyPqJzXRPFJaVu7J8/d0Mf/I/bkVdYo+ce7XkGFrgjZFhs94BFRA7zt88yWJqVy5NXHEPLJv60HspFZQsi0nXt2pXly5f7XYaIHGb1d3v443+/4ZyB7TjHz9ZDQEwGsIviXT5CTedG4lVxaRl3TVtCs6REHjy/6u3AwiXmAjgpKYldu3YpaI7AOceuXbtISgrvZHORSPD0rHUs37yHhy4YQJrPrYdyMdcD7tixI1lZWezYsaPSxxQWFsZtCCUlJdGxY+hW+BeJRKu27uGJj79l7OD2nD3Q/9ZDuZgL4MTExCqvHANvA8OhQ4eGqSIR8VNxaRk/fX0JKckNePC8yGg9lIu5ABYRqejJT9aycuse/nb1MFo0buB3OYeIuR6wiEi5FVty+cvHa7lgSHvO7N/W73K+RwEsIjGpqMRrPbRo3IDJEdZ6KKcWhIjEpL98spbV3+Xx7P8Op3mjyGo9lNMIWERizvLNuTz5yVrGDe3A6f3a+F1OpRTAIhJT9peUcte0JaQ1bsADYyOz9VBOLQgRiSl//shrPTx3zXBSGiX6XU6VNAIWkZixNCuHpz5dx8XDOnJqn8htPZRTAItITChvPbRq0pD7zu3ndzlBUQtCRGLCn/77Ld9sy+f5a0eQkhzZrYdyGgGLSNRbvCmHpz9dx/jhHTmld2u/ywmaAlhEolphcSk/fX0xbZolcW+UtB7KqQUhIlHtD//9hnU79vLCdSNplhQdrYdyGgGLSNT6euNunv0sg8tHduLkXq38LqfGFMAiEpUKi71ZD+1SkvnF//T1u5yjohaEiESlx/+zhowde3n5+lE0jbLWQzmNgEUk6izckM3fv8jkilGdOaFnS7/LOWoKYBGJKgVFpdw1bSnto7j1UE4tCBGJKo/9Zw2ZO/fy6o9G0aRhdEeYRsAiEjXmZWbz3JeZXH1sF47vEb2th3IKYBGJCvuKSvjZG0vo2CKZu8/u43c5dSK6x+8iEjce+WAN63ft4x8TjqVxlLceymkELCIRb07GLqZ+tZ4fHteF47qn+V1OnVEAi0hE81oPS+mc2oifx0jroVxsjONFJGb97v3VbMzex2sTj6VRg9iKLI2ARSRifbVuJy/M3sC1o7syqlvstB7KKYBFJCLt3e+1HrqmNeJnZ8ZW66FcbI3nRSRm/Pb9VWzOKeD1G44juUGC3+WEhEbAIhJxvly7k5fnbOS60emM6JrqdzkhowAWkYiSH2g9dGvZmLvO6O13OSGlFoSIRJTfvLeKLbkFvHFj7LYeymkELCIR4/Nvd/Dq3I1MOLEbw7rEbuuhnAJYRCJCXmExP39jKd1bNebO03v5XU5YqAUhIhHh1/9exXd7CnnzpuNJSozt1kO5iBkBm1k3M5tiZm/4XYuIhNen3+zgn/M3MfGk7gzt3MLvcsImpAFsZs+Z2XYzW37Y8bPMbI2ZrTWzuwGccxnOuetDWY+IRJ49hcXc/eZSerZuwu2n9fS7nLAK9Qh4KnBWxQNmlgA8CZwN9AMuN7N+Ia5DRCLUQ++uZHvefh67ZHDctB7KhbQH7Jz7zMy6HnZ4JLDWOZcBYGb/BM4HVgbzmmY2EZgI0KZNG2bNmlXjuvLz84/qeVIzOs/hE63nesmOEl5fuJ9zuyWye91iZq3zu6Kq1fV59uNDuA7ApgrfZwGjzCwN+DUw1Mzucc799khPds49AzwDMHz4cDdmzJgaFzBr1iyO5nlSMzrP4RON5zp3XzE//+On9GrThMevO4GG9SN/9FvX5zliZkE453YBN/pdh4iEx4PvrmRnfhF//98RURG+oeDHLIjNQKcK33cMHBOROPHRqm28+XUWN4/pzsCOKX6X4xs/Ang+0NPM0s2sAXAZ8I4PdYiID3L3FXPPW8vo07Ypt54aX7MeDhfqaWj/AGYDvc0sy8yud86VALcAM4FVwOvOuRWhrENEIsf/zVhB9t4iHrtkMA3qR8ylCL4I9SyIyys5/h7wXijfW0Qiz4crt/HWos3c9oOeDOgQv62HclH568fMxprZM7m5uX6XIiJB2r23iF/8axl92zXjllN6+F1ORIjKAHbOzXDOTUxJ0W9QkWgxecYKdu8t4rFLBsV966GczoKIhNwHy7/j7cVbuPXUnvRvr4FTOQWwiIRU9t4i7p2+jP7tm3HzKd39LieiRMyFGCISmx54ZwW5BcW8dP0oEhM05qtIZ0NEQub9ZVuZsWQLt53ak77tmvldTsRRAItISOzK38+905czsEMKN45R6+FIFMAiEhL3v72CvMISHrtksFoPlajyrJjZcWb2pJktNbMdZrbRzN4zsx+bmW8fZWoesEhke3fpFv69bCs/Oa0nvds29buciFVpAJvZ+8CP8C4ZPgtoh7eA+r1AEvC2mZ0XjiIPp3nAIpFrR95+7pu+nMEdU7jhpG5+lxPRqpoFcbVzbudhx/KBrwO3x82sZcgqE5Go45zjvunL2bu/lMcuGUx9tR6qVOnZKQ9fM2tsZvUCf+5lZueZWWLFx4iIAMxYupUPVnzHHaf3omcbtR6qE8yvp8+AJDPrAPwHuBpvrzcRkQO25xVy/9vLGdKpORNOTPe7nKgQTACbc24fMA74q3PuEqB/aMsSkWjinOOX/1rOviK1HmoiqAA2s+OAK4F/B47F5/4hInJEby/ewocrt3HXGb3o0bqJ3+VEjWAC+CfAPcC/nHMrzKwb8EloyxKRaLF9TyEPvLOCYzo35/oTNOuhJqpdC8I59xleH7j8+wzgtlAWVR0zGwuM7dFDa4qK+Mk5xy/+tYzC4lIevWQwCfXM75KiSlXzgJ81s4GV3NfYzK4zsytDV1rlNA9YJDL8a9Fm/rtqO5PO7E33Vmo91FRVI+AngfsCIbwc2IF3AUZPoBnwHPBKyCsUkYi0bU8hk99ZwfAuLbh2tGY9HI1KA9g5txgYb2ZNgOF4V8IVAKucc2vCVJ+IRCDnHPe8tYyi0jK1HmohmB5wPjAr9KWISLR4Y2EWH6/ezv3n9iO9ZWO/y4lamqwnIjWyNbeAB99dyciuqVxzfFe/y4lqCmARCZpzjrvfXEZJqeORiwdRT62HWqlRAJtZPTPTsvYicWragiw+/WYHd5/dh65qPdRatQFsZq+aWTMza4w3G2KlmU0KfWkiEkm25BTwq3dXcmy3VK4+tovf5cSEYEbA/Zxze4ALgPeBdLwFeUQkTjjn+PmbSyl1jkcuGqzWQx0JJoATA8tPXgC845wrBlxoy6qadsQQCa9/zt/E59/u5J6z+9A5rZHf5cSMYAL4b8B6oDHwmZl1AfaEsqjq6Eo4kfDJ2r2PX/97Fcd3T+PKUWo91KVg5gE/ATxR4dAGMzsldCWJSKQon/XgnON3F2nWQ10L5kO4nwQ+hDMzm2JmXwOnhqE2EfHZq/M28sXanfzinL50SlXroa4F04K4LvAh3BlAC7wP4B4OaVUi4rtN2fv4zb9XcUKPllwxsrPf5cSkoBZkD3z9H+Al59yKCsdEJAaVlXmzHsyMhy8aiJn+yYdCMAG80Mz+gxfAM82sKVAW2rJExE+vzN3AV+t28ctz+tKxhVoPoVLth3DA9cAQIMM5t8/M0oBrQ1uWiPhl4659/Pb91ZzYsyWXjejkdzkxLZhZEGVmlgn0MrOkMNQkIj4pK3NMemMJCWb87qJBaj2EWLUBbGY/wtsXriOwGDgWmI1mQojEnJfmbGBuZjaPXDSI9s2T/S4n5gW7KecIYINz7hRgKJAT0qpEJOw27NrLw++vZkzvVlwyvKPf5cSFYAK40DlXCGBmDZ1zq4HeoS1LRMKprMwxadpS6icYvx2nWQ/hEsyHcFlm1hyYDnxoZruBDaEtq2raFVmkbk39aj3z1mfz6MWDaJei1kO4VDsCds5d6JzLcc5NBu4DpuAtzOMbrQUhUncyd+7lkZmrObVPay4eptZDOAUzAsbMjgFOwFsF7UvnXFFIqxKRsCgtc0yatoQGCfXUevBBMGtB3A+8AKQBLYHnzezeUBcmIqH3/JeZLNiwm8nn9adNM80yDbdgRsBXAoMrfBD3MN50tIdCWZiIhNa6Hfk8OnMNp/VtzYVDO/hdTlwKZhbEFqDir8aGwObQlCMi4VDeekhKTOA3F6r14JdgRsC5wAoz+xCvB3w6MM/MngBwzt0WwvpEJASmfJHB1xtz+OOlQ2it1oNvggngfwVu5WaFphQRCYe12/N57D/fcEa/Npw/pL3f5cS1YNaCeCEchYhI6JWWOe6atoRGDRJ46MIBaj34LKhpaCISG579PIPFm3J44vKhtG6q1oPfgvkQTkRiwLfb8vj9f77hrP5tGTuond/lCApgkbhQUlrGT6ctoUlSfbUeIkilLQgzm4E36+GInHPnhaQiEalzf/ssg6VZufzliqG0bNLQ73IkoKoe8GOBr+OAtsDLge8vB7aFsigRqTtrvsvjj//9hnMGtuPcQZr1EEkqDWDn3KcAZva4c254hbtmmNmCkFdWBa2GJhKc4tIy7pq2hGZJiTx4fn+/y5HDBNMDbmxm3cq/MbN0oHHoSqqeVkMTCc7Ts9axbHMuD10wgDS1HiJOMNPQbgdmmVkG3nb0XYCJIa1KRGpt1dY9PPHxt5w7qB1nD9Ssh0hUZQCbWT0gBegJ9AkcXu2c2x/qwkTk6JW3HlKSE3nw/AF+lyOVqLIF4ZwrA37mnNvvnFsSuCl8RSLcXz9Zx4ote3jogoGkNm7gdzlSiWB6wP81s7vMrJOZpZbfQl6ZiByVFVty+fPH33L+kPacNaCt3+VIFYLpAV8a+PrjCscc0O0IjxURHxWVlHHXtKW0aNyAyWM16yHSBbMYT3o4ChGR2vvLJ2tZtXUPz/7vcFqo9RDxgt0TbgDQjwoLszvnXgxVUSJSc8s35/LXT9YybmgHTu/Xxu9yJAjVBrCZPQCMwQvg94CzgS8ABbBIhCgJLDOZ2rgBD6j1EDWCGQFfDAwGFjnnrjWzNhy8LFlEfDR90WYenbmGzTkFAPzoxHRSGiX6XJUEK5hZEAWB6WglZtYM2A50Cm1ZIlKd6Ys2c89byw6EL8ArczYyfZG2bIwWwQTwAjNrDjwLLAS+BmaHtCoRqdajM9dQUFx6yLGC4lIenbnGp4qkpoKZBXFz4I9Pm9kHQDPn3NLQliUi1dlSYeQbzHGJPMF8CPcS8BnwuXNudehLEpHqrNiSixm4I6zY3b55cvgLkqMSTAviOaAd8GczyzCzN83sJyGuS0Qq8fHqbVzy9GyaJtWnYf1D/wknJyYw6czePlUmNVVtADvnPgF+DdyH1wceDtwU4rpE5Aie/zKTH72wgO6tmvDhHSfzu4sG0SEw4u3QPJnfjhvIBUM7+FylBCuYFsRHeOv/zgY+B0Y457aHujAROaiktIxfvbuSF2Zv4Ix+bfjjZUNo1KA+FwztwAVDOzBr1izGjBnjd5lSQ8HMA14KDAMGALlAjpnNds6p0y8SBvn7S7j11a/5ZM0OJpyYzt1n9yWhnjbVjAXBzIK4A8DMmgLXAM/j7RHn2/L62pJI4sWWnAKumzqfb7fn8+sLB3DlqC5+lyR1qNoesJndamavAYuA8/E+lDs71IVVRVsSSTxYlpXLBU9+yebdBTx/zQiFbwwKpgXRAPg9sNA5VxLiekQEmLniO27/52JSGzfgpZtG0bttU79LkhCocgRsZgnABOfcXIWvSOg553j2swxufHkhvds2ZfqPRyt8Y1iVI2DnXKmZrTGzzs65jeEqSiQeFZeW8cA7K3h17kbOGdiOx8cPJikxwe+yJISCaUG0AFaY2Txgb/lB59x5IatKJM7sKSzmx698zeff7uTmMd2564ze1NNMh5gXTADfF/IqROLYpux9XP/CfDJ27OWRiwYxfoQWG4wXwUxD+zSwBvCIwKF5uhBDpG4s2ribCS8uoKikjBevH8nx3Vv6XZKEUTDT0MYD84BLgPHAXDO7ONSFicS695Zt5bJn5tCoQX3eunm0wjcOBdOC+CUVLj82s1bAf4E3QlmYSKxyzvHUp+t45IM1DOvSgmeuHkZaE9+uaxIfBRPA9Q5rOewiuFXUROQwRSVl3Dt9Ga8vyOK8we155OJBmukQx4IJ4A/MbCbwj8D3l+JtzikiNZC7r5gbX17I7Ixd3PaDntxxWk/MNNMhnlUawGbW0Dm33zk3yczGAScE7nrGOfev8JQnEhs27NrLtVPnsyl7H78fP5hxx3T0uySJAFWNgGcDx5jZS865q4G3wlSTSExZsD6biS8tpMw5Xr5+FKO6pfldkkSIqgK4gZldARwfGAEfwjmnQBapxtuLNzNp2lI6tEjmuWtGkN6ysd8lSQSpKoBvBK4EmgNjD7vPoRGxSKWcc/z547X8/sNvGJmeyt+uGkaLxg38LksiTKUB7Jz7AvjCzBY456aEsSaRqLa/pJR73lzGW4s2M+6YDvx23EAa1tdMB/m+YK6EU/iKBGn33iJueGkh89Znc9cZvfjxKT0000EqFcw0NBEJQsaOfK6bOp8tuYU8cflQzhvc3u+SJMJVGcDm/eru6JzbFKZ6RKLSnIxd3PjyQuqZ8Y8JoxjWJdXvkiQKVHlFm3POoYsuRKr05sIsrp4yl7TGDZh+82iFrwQtmBbE12Y2wjk3P+TViEQR5xy///Ab/vzxWkb3SOOvVw4jJTnR77IkigQTwKOAK81sA96C7IY3OB4U0spEIlhhcSmT3ljKjCVbuHR4Jx66cACJCVoiRWommAA+M+RViESRXfn7mfDiAr7emMPdZ/fhhpO6aaaDHJVgpqFtMLMTgJ7OuecDy1E2CX1pIpFn7fY8rp06n+179vPUlcdw9sB2fpckUazaADazB4DhQG/geSAReBkYHdrSRCLLl2t3cuPLC2lYP4HXbjiOIZ2a+12SRLlgmlYXAucR2JDTObcF8HWfbDMba2bP5Obm+lmGxJHX5m/kh8/No31KMtN/fLzCV+pEMAFcFJiO5gDMzPfVRJxzM5xzE1NSUvwuRWJcWZnj4fdX8/M3l3F8j5ZMu+k4OrZo5HdZEiOC+RDudTP7G9DczCYA1wHPhrYsEf8VFJVy5+uLeX/5d1x1bGcmj+1Pfc10kDoUzIdwj5nZ6cAeoBdwv3Puw5BXJuKj7XmFTHhxIUuzcrj3nL5cf0K6ZjpInQt2LYhlQDJeG2JZ6MoR8d+a7/K4bup8svcW8berhnFG/7Z+lyQxKpht6X+Ety39OOBiYI6ZXRfqwkT88Ok3O7joqa8oKStj2o3HKXwlpIIZAU8ChjrndgGYWRrwFfBcKAsTCbeX52zggXdW0KtNU567ZjjtUpL9LkliXDABvAvIq/B9XuCYSEwoLXP85r1VTPkik1P7tObPlw+lcUOt1CqhF8xP2Vpgrpm9jdcDPh9YamZ3Ajjnfh/C+kRCal9RCbf9YzH/XbWNa47vyn3n9iOhnj5sk/AIJoDXBW7l3g589fViDJHa2rankOtfmM/KLXv4v/P688Pju/pdksSZYKah/V84ChEJpxVbcrl+6gLyCouZ8sMRnNKntd8lSRxSo0vizsert3HLq4tISU5k2o3H0699M79LkjilAJa4MvXLTB58dyX926cw5YfDad0sye+SJI4pgCUulJSW8at3V/LC7A2c0a8Nf7xsCI0a6Mdf/BXMhRi9zOwjM1se+H6Qmd0b+tJE6kb+/hImvLiAF2ZvYMKJ6Tx11TCFr0SEYFYWeRa4BygGcM4tBS4LZVEidWVLTgGXPD2bz77dya8vHMAvz9E0M4kcwQwDGjnn5h22EElJiOoRqTPLsnK5/oX5FBSV8vw1IzipVyu/SxI5RDABvNPMunNwPeCLga0hrUqklmau+I7b/7mY1MYNePnmUfRqo2nrEnmCCeAfA88AfcxsM5AJXBXSqkSOknOOv3+eyW/eX8Xgjs159n+H06ppQ7/LEjmiYC7EyABOC+yEUc85l1fdc0T8UFxaxgPvrODVuRs5Z2A7Hh8/mKTEBL/LEqlUMJtyNgf+F+gK1C/vBTvnbgtpZSI1sKewmB+/8jWff7uTm8d0564zelNPH7ZJhOc9jksAABdESURBVAumBfEeMAdvIfay0JYjUnObsvdx/Qvzydixl0cuGsT4EZ38LkkkKMEEcJJz7s6QVyJyFBZt3M2EFxdQVFLGi9eP5PjuLf0uSSRowQTwS4HNON8F9pcfdM5lh6wqkSC8t2wrd7y2mDbNkvjnxBH0aN3E75JEaiSYAC4CHgV+SWAqWuBrt1AVJVIV5xxPfbqORz5Yw7AuLXjm6mGkNdFMB4k+wQTwT4EezrmdoS5GpDpFJWXcN305ry3YxHmD2/PIxYM000GiVrA7YuwLdSEi1cndV8xNryzkq3W7uO0HPbnjtJ7aKl6iWjABvBdYbGafcGgPWNPQJGw27NrLtVPnsyl7H78fP5hxx3T0uySRWgsmgKcHbiK+WLA+m4kvLaTMOV6+fhSjuqX5XZJInQjmSrgXwlGIyJG8vXgzk95YSofmyTx3zQjSWzb2uySROlNpAJvZ68658Wa2jIOzHw5wzg0KaWUS15xz/Pnjtfz+w28YlZ7K364eRvNGDfwuS6ROVTUC/kng67nhKESk3P6SUu55cxlvLdrMuGM68PC4QTSoH8zS1SLRpdKfaudc+ZKTNzvnNlS8ATeHpzyJN7v3FnH1lHm8tWgzd53Ri8cvGazwlZgVzE/26Uc4dnZdFyKSsSOfC//6JYs35fDE5UO55VRNM5PYVlUP+Ca8kW43M1ta4a6mwJehLkziy9yMXdzw8kLqmfGPCaMY1iXV75JEQq6qHvCrwPvAb4G7KxzP0zoQUpfeXJjF3W8tpXNqI56/ZiSd0xr5XZJIWFQawM65XCAXuDx85Ug8cc7xhw+/4YmP1zK6Rxp/vXIYKcmJfpclEjbam1t8UVhcyqQ3ljJjyRYuHd6Jhy4cQGKCPmyT+KIAlrDblb+fiS8tZOGG3dx9dh9uOKmbPmyTuKQAlrBauz2Pa6fOZ/ue/Tx15TGcPbCd3yWJ+EYBLGHz5dqd3PjyQhrWT+C1G45jSKfmfpck4isFsITFa/M38st/Lad7qyZMuWY4HVtopoNIxARwYNv7v+LtwDHLOfeKzyVJHSgrczwycw1Pf7qOk3q14i9XDKVZkmY6iECIA9jMnsNbS2K7c25AheNnAX8CEoC/O+ceBsYBbzjnZpjZa4ACOEpNX7SZR2euYXNOAUkffUBhcRlXHduZyWP7U18zHUQOCPW/hqnAWRUPmFkC8CTe5cz9gMvNrB/QEdgUeFhpiOuSEJm+aDP3vLWMzTkFABQWl5GYYAzr3ELhK3KYkI6AnXOfmVnXww6PBNY65zIAzOyfwPlAFl4IL6aKXwxmNhGYCNCmTRtmzZpV47ry8/OP6nlyZM45dhQ41mSX8vKqIvYf9uuzuNTx0DtLabFnrT8FxgH9TIdW622f0i3jJU7ev4PC2a3I6HY129ucXOvX9aMH3IGDI13wgncU8ATwFzM7B5hR2ZOdc88AzwAMHz7cjRkzpsYFzJo1i6N5nnicc6zbkc/czGzmZWYzNyOb7/YUVvmc7EKncx5C+pkOoaWvw5dPQbH3v7qk/Tvot/Yp+vXtC4PG1+qlI+ZDOOfcXuBav+uQ7ystc6z+bs+BsJ2/Pptde4sAaN20IaO6pTEyPZVR6alc8/w8tuR8P4zbN08Od9kideOjBw+E7wHFBd7xKAzgzUCnCt93DByTCFFcWsbyzbkHRrjz12eTV1gCQMcWyYzp3ZpR6amMTE+lS1qjQ65i+9mZfbjnrWUUFB/sQyQnJjDpzN5h/3uI1Mj+fMheB9kZsKvC19xNR358blat39KPAJ4P9DSzdLzgvQy4woc6JKCwuJQlm3IOBO7CDbsPBGj3Vo05d1B7RqWnMiI9lQ7VjGQvGNoB4MAsiA7Nk5l0Zu8Dx0V8VbS3QsCWh2yG9+f8bYc+tklbSOsOiY2heO/3Xyul9jtzh3oa2j+AMUBLM8sCHnDOTTGzW4CZeNPQnnPOrQhlHXKovftLWLhhN/MCgbt4Uw5FpWWYQZ+2zbh0RCdGpqcyomsqrZo2rPHrXzC0AxcM7aC+pPijaJ8XrNmBYC0fzWZnQN7WQx/bpA2kdocep0NaN+/Pad2hRTo0bOI9ZunrMOO2Q9sQicnwg/trXWqoZ0EccSlL59x7wHuhfG85KHdfMfPXZzNvfTZzM7NZvjmX0jJHQj1jQIcUrhndlZFdvcBNaaSLJCQKFBdAdub3A3bXOsjbcuhjG7fygrX7qZDazbuldfe+Nmxa/XuV93k/ehCXm4WldPTCt5b9X4igD+FqwszGAmN79OjhdykRaUfefi9wM73AXf3dHpyDBgn1GNKpOTed3J2R6akM69KCxg2j8kdA4kFxIexeXyFky79mwp7D+q+NWnqh2u3kwCg2MJpN7QZJzWpfy6DxMGg8n9bx/+qi8l+fc24GMGP48OET/K4lEmzJKTgQtnMzd5Gxw+tXJScmMKxLC+44rRej0lMZ3Kk5SYkJPlcrUkHJfi9kD+nJBr7mZgHu4GOTU72Q7XrCwRFs+S05Ohd2isoAjmfOOTbs2ndI4Gbt9npTTZPqM6JrKpcO93q4AzqkaJFz8V9JEeRsOGwUWyFkXdnBxya38EaunY8LhGz5aLabd1+MUQBHuLIyx9rARQ9zM3YxLzOb7Xn7AUhr3ICR6alcf0I6I9NT6dO2GQn1tLC5+KC0GHZvOGwUu+7gNK6KIZuU4gVrp1Ew+IpDe7KN4mszVgVwhCktc6zauoc5gbCdvz6b3fuKAWjbLInjuh+86KF7qybaSULCp7QYcjYeYRrXOu+4q3ANesMUb+TacTgMurTCaLa7N5LVzy2gAPZdUUkZyzZXmIO7fjd5+72LHrqkNeK0vm0CgZtGp9RkBa6EVmkJ5G4MzI3NOLRlkLMRykoOPrZBUy9k2w+FgRcH+rGBkG2UppANggI4zAqKSlm06eAc3K837qaw2PvvWc/WTThvSHtGBq4ya5eiy3elGktfh48e5OTcLFgU5PSoslKvLbDrsA+9std5bYSy4oOPbdDEC9a2g6D/hQcDNrU7NG6pkK2lqAzgaJqGlldYfMhFD0uycigudZhBv3bNuHxkZ+8qs66ppDWp+UUPEscqXCBg4IXqjNu8+wZc5H3AdfjVXrvWebMOKoZsYmMvZNv0h77nVejJdocmrRWyIRSVARzJ09B27y06MAd33nrvoocyB/XrGQM7pnDdCekcm57GMV1akJKsix6kFipbJGb6TfD2j6G06ODxxEZesLbuA33OObQn26SNQtYnURnAkWT7nkLmrT+4LOOabXkANKhfj6GdmnPLKT0Y1S2NoZ2b06iBTrfUUlkpbF0CGZ9UvkhMWQmM/smhPdmm7RSyEUiJUENZu/cdCNt567PJ3Old9NCogXfRQ3kPd1DHFBrW10UPUgd2r4d1n0DGLMj8FAp2e8frJR7aSiiX0glOfzCcFcpRUgBXwTlH5s69B2YozMvMPrDVTrOk+oxMT+WKkZ0ZmZ5K//bNtOWO1I2C3ZD52cHQ3Z3pHW/aHnr/D3Qb490yZoVskRgJDwVwBWVljjXb8g6E7dzMbHbmexc9tGzSgFHpaUw8qRsj01Pp3aYp9XTRg9SFkv2waZ7XVlj3CWxd7F240KAJdD0Rjr3JC9yWvQ5tI4RwkRgJj7gK4Iq79XaY8zE/Pb0n3Vs3PRC289dnk1vg/ZeufUoSJ/ZseWBKWLeWjTUHV+qGc7B9ZWCE+wls+AqK94EleBcunPQz6H4KdBgGCdV8UBuiRWIkPOImgKcv2szdby09MOd2c04Bd05beuD+9JaNOat/2wOB2ym1kV+lSizas8VrGZS3FfZu946n9YShV0G3U6DraO8yXYkbcRPAj85ccyB8K2rRKJGZt59E62ZJPlQlMWt/Hqz/8mBbYeca73ijll47ofsp3tc62FVBoldUBvDRXIixJafgiMdz9hUrfKX2Sktgy9cH2wpZ873pYPWTocvx3ii3+ynQuj/U04e14onKAD6aCzHaN08+MIPh8OMiNeYc7Fp7sK2w/nPYvwcwaD8Ejr/Vayt0GgWJ+gUvRxaVAXw0Jp3ZW7v1Su3s3ekFbsYnsG7WwV0ZmneBAeO8lkL6yXG3pKIcvbgJYO3WKzVWXODNUMgIfHD23TLveFKKF7Qn/dQL3dRuPhYp0SxuAhi0W69Uo6wMvltycKbCxjlQut+74qzzsXDqfV5bof0QqKerHKX24iqARb5n94aDI9yMT6Eg2zveuj+MnOCNcLscDw0a+1ikxCoFsMSXghzvMt/y0M3O8I43bQe9zvJmKqSfDE3b+FqmxAcFsMS2kiLImnewrbDl6wqX+Z4AI2/wQvfwy3xFwkABLLHFOdi+6uAFEBu+PHiZb4dhcNIkr4/bcXj1l/mKhJgCWKLfnq0Hp4dlzIL8bd7xtJ4w5EpvhNv1BF3mKxEnKgM4mrYkkhDYn+dNDyu/6mzHau94+WW+5bfmnfyqUCQoURnAkbwlkYRAaQlsWXSwrZA1L3CZb5I3Q2HIFV5boc0AXeYrUSUqA1hinHPe5pHlLYXMz2F/LmDQbnDgMt8x0OlYXeYrUU0BLJHhwGW+gVv5fmfNO0P/CwJ93JOgcZqPRYrULQWw+KO4ADbOPriYzXeBtZmTUiD9JDjhjoOX+Wp6mMQoBbDUvaWvw0cPcnJuFiwKbJMz4GIvZMvbChtmH7zMt9MoOPVe6HaqLvOVuKIAlrq19PUDG0UaeK2Ef90IM26HYm8HaVr3gxE/8toKnY+Dhk38rFjENwpgqTv5O+CDuw/dpRfAlQIOLnwGup0MTdv6Up5IpFEAy9ErzPW23cn8zLttX1H5Y4sLYPCl4atNJAoogCV4Rftg01zI/NQL3C2LvHUV6id5yzUOfADmPgX527//XO19JvI9CmCpXGkxbF4YWD3sU+8CiNIiqFcfOgyHE+/yWgodR0D9ht5zUjoe6AEfkJjsfRAnIodQAMtBZaXerg+Zn3mj3A2zAx+cGbQbBKNugPQx3mi3sg/OBo33vn70IC43C0sJzIIoPy4iB0RlAGstiDriHOz85mDgZn4OhTnefS17e5f4pp/kLWRTk33OBo2HQeP5VDuPiFQpKgNYa0HUwu4NBz80y/wM8r/zjqd0hr7neouRp5+kmQoiYRCVASw1kLfN2zK9/IOz3eu9441be0FbfktN97VMkXikAI41BbsPnRq2Y5V3PCkFup4Ix97sBW6rPrrEV8RnCuBoV7TXW1OhPHC3LvGmhiU28q4yG3yZF7jtBusSX5EIowCONiVFsHmBNy0s8zPImg9lxd6aCh1HwMk/9wK3w3Co38DvakWkCgrgSFdW6o1qy3u4G+d4e5xh3sI1x93sfXDW+VhtnS4SZRTAkcY5b4ud8hHu+i8Ci5EDrfrC0Ku9ix+6HA/JLfytVURqRQHsN+e8mQkH5uJ+Bnt3ePe16Ar9z/dGuF1PhKZt/KxUROqYAtgPe7YenBqW8RnkbvSON2nr7W1WPjWsRRd/6xSRkFIAh8O+bK+VUD7K3fmNdzypOaSfCKNv8wK3ZS9NDROJIwrgUNifH5ga9qnXy/1uGeAgsbHXux16tRe4bQdqaphIHFMA14XiQm86WPlc3M0LvG3TExp42+2c8gsvcNsfo6lhInKAAvholJbA1sWHTg0rKQSr54Xs8YGWQqdR0KCR39WKSISKygAO+2poZWWwfeXBEe6GL2H/Hu++1v1h+HVe4HY53rvkV0QkCFEZwCFfDc05yM44OMLN/Bz27fTuS+0GA8YdnBrWpFVIShCR2BeVAXzUjrRdevlC4bmbD12mcU+Wd7xpO+hxmnfxQ9cToXkn/+oXkZgSPwF8pO3S3/4xLHoZ9myGXWu9xyWnelPD0u/wdn9I666pYSISEvETwB89+P3t0kuLvNFuzzNg2LVeH7fNAKhXz58aRSSuxE8A52ZVft+Vr4evDhGRgPgZ6lW2Lbq2SxcRn8RPAP/gfm979Iq0XbqI+Ch+AnjQeBj7BKR0wmGQ0sn7Xtuli4hP4qcHDNouXUQiSvyMgEVEIowCWETEJwpgERGfKIBFRHyiABYR8YkCWETEJwpgERGfKIBFRHyiABYR8UlUXglXviURsMfMvj3s7hQgt4rvAVoCO0NXYZX1hPL5wTy2qsdUdt+RjgdzLFbPczCPP5rzXNl9+pk++sdEys90lyMedc7F1A14pqrvA8cW+FVPKJ8fzGOrekxl91VyDqs9FqvnOZjHH815rsF51c90Lc91pPxMx2ILYkY134dbbd+/Js8P5rFVPaay+450PNhj4RLO8xzM44/mPFd2n36mj/4xEf0zbYFUjytmtsA5N9zvOmKdznP46FyHR12f51gcAQfjGb8LiBM6z+Gjcx0edXqe43IELCISCeJ1BCwi4jsFsIiITxTAIiI+UQCLiPgk7gPYzC4ws2fN7DUzO8PvemKZmfU1s6fN7A0zu8nvemKZmTU2swVmdq7ftcQyMxtjZp8Hfq7H1PT5MRnAZvacmW03s+WHHT/LzNaY2VozuxvAOTfdOTcBuBG41I96o1kNz/Uq59yNwHhgtB/1RquanOeAnwOvh7fK2FDDc+2AfCAJyKrxm4Xr8sVw3oCTgGOA5RWOJQDrgG5AA2AJ0K/C/Y8Dx/hde7TdanqugfOA94Er/K49mm41Oc/A6cBlwDXAuX7XHm23Gp7reoH72wCv1PS9YnIE7Jz7DMg+7PBIYK1zLsM5VwT8EzjfPL8D3nfOfR3uWqNdTc514PHvOOfOBq4Mb6XRrYbneQxwLHAFMMHMYvLfeajU5Fw758oC9+8GGtb0vaJyNbSj1AHYVOH7LGAUcCtwGpBiZj2cc0/7UVyMOeK5DvTIxuH9oL7nQ12x5ojn2Tl3C4CZXQPsrBAScvQq+5keB5wJNAf+UtMXjacAPiLn3BPAE37XEQ+cc7OAWT6XETecc1P9riHWOefeAt462ufH039NNgOdKnzfMXBM6p7OdXjoPIdPSM51PAXwfKCnmaWbWQO8Dyne8bmmWKVzHR46z+ETknMdkwFsZv8AZgO9zSzLzK53zpUAtwAzgVXA6865FX7WGQt0rsND5zl8wnmutRqaiIhPYnIELCISDRTAIiI+UQCLiPhEASwi4hMFsIiITxTAIiI+UQBL3DOz9WbWso5fs6uZXVHh+2vMrMZrBUhsUwCLhEZXvNXIRCqlAJaIFtjZ4d9mtsTMlpvZpYHjw8zsUzNbaGYzzaxdheNLArdHD19UO4j3u8rM5pnZYjP7m5klBI7nm9mvA687x8zaBI53D3y/zMweMrP8wEs9DJwYeJ07Asfam9kHZvatmT1SJydIopoCWCLdWcAW59xg59wA4AMzSwT+DFzsnBsGPAf8OvD454FbnXODa/pGZtYXb1eU0c65IUApB9ctbgzMCbzuZ8CEwPE/AX9yzg3k0B0R7gY+d84Ncc79IXBsSOD1BwKXmlnFxV0kDimAJdItA043s9+Z2YnOuVygNzAA+NDMFgP3Ah3NrDnQPLCgNsBLNXyvHwDDgPmB1/0B3g4IAEXAu4E/L8RrMQAcB0wL/PnVal7/I+dcrnOuEFgJdKlhfRJj4n49YIlszrlvzOwY4H+Ah8zsI+BfwArn3HEVHxsI4Now4AXn3D1HuK/YHVw4pZSj+7ezv8Kfj/Y1JIZoBCwRzczaA/uccy8Dj+Lt1bUGaGVmxwUek2hm/Z1zOUCOmZ0QeHpNtz36CLjYzFoHXjfVzKobpc4BLgr8+bIKx/OApjV8f4kzCmCJdAOBeYGWwAPAQ4E9uS4GfmdmS4DFwPGBx18LPBl4vJW/iJm1N7Mqt0Fyzq3Ea2f8x8yWAh8C7aqp73bgzsDjewC5geNLgdLAh3Z3VPpsiWtajlJilpl1Bd4NfHgXqvdoBBQ455yZXQZc7pw7P1TvJ7FFPSiR2hkG/MXMDMgBrvO5HokiGgGLiPhEPWAREZ8ogEVEfKIAFhHxiQJYRMQnCmAREZ/8P3j4sQYHIdaGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(5, 5))\n",
+    "plt.loglog(Ts, serial_smoothing_durations, '-o', label='serial')\n",
+    "plt.loglog(Ts, parallel_smoothing_durations, '-o', label='parallel')\n",
+    "plt.xticks(Ts)\n",
+    "plt.xlabel(\"seq. length\")\n",
+    "plt.ylabel(\"time per forward pass (s)\")\n",
+    "plt.grid(True)\n",
+    "plt.legend()\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "IpBHMUtyS2-G",
+   "metadata": {
+    "id": "IpBHMUtyS2-G"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ssm_jax/linear_gaussian_ssm/parallel_inference.py
+++ b/ssm_jax/linear_gaussian_ssm/parallel_inference.py
@@ -1,0 +1,157 @@
+# Parallel filtering and smoothing for a lgssm.
+# This implementation is adapted from the work of Adrien Correnflos in,
+#  https://github.com/EEA-sensors/sequential-parallelization-examples/
+from jax import numpy as jnp
+from jax import scipy as jsc
+from jax import vmap, lax
+
+from ssm_jax.containers import GSSMPosterior
+
+def make_associative_filtering_elements(params, emissions):
+    """Preprocess observations to construct input for filtering assocative scan."""
+
+    def _first_filtering_element(params, y):
+        F = params.dynamics_matrix
+        H = params.emission_matrix
+        Q = params.dynamics_covariance
+        R = params.emission_covariance
+        
+        S = H @ Q @ H.T + R
+        CF, low = jsc.linalg.cho_factor(S)
+
+        m1 = F @ params.initial_mean
+        P1 = F @ params.initial_covariance @ F.T + Q
+        S1 = H @ P1 @ H.T + R
+        K1 = jsc.linalg.solve(S1, H @ P1, assume_a='pos').T  
+
+        A = jnp.zeros_like(F)
+        b = m1 + K1 @ (y - H @ m1)
+        C = P1 - K1 @ S1 @ K1.T
+
+        eta = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), y)
+        J = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), H @ F)
+        return A, b, C, J, eta
+
+
+    def _generic_filtering_element(params, y):
+        F = params.dynamics_matrix
+        H = params.emission_matrix
+        Q = params.dynamics_covariance
+        R = params.emission_covariance
+        
+        S = H @ Q @ H.T + R
+        CF, low = jsc.linalg.cho_factor(S)  
+        K = jsc.linalg.cho_solve((CF, low), H @ Q).T  
+        A = F - K @ H @ F
+        b = K @ y
+        C = Q - K @ H @ Q
+
+        eta = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), y)
+        J = F.T @ H.T @ jsc.linalg.cho_solve((CF, low), H @ F)
+        return A, b, C, J, eta
+
+    first_elems = _first_filtering_element(params, emissions[0])
+    generic_elems = vmap(_generic_filtering_element, (None, 0))(params, emissions[1:])
+    combined_elems = tuple(jnp.concatenate((first_elm[None,...], gen_elm))
+                           for first_elm, gen_elm in zip(first_elems, generic_elems))
+    return combined_elems
+
+def lgssm_filter(params, emissions):
+    """A parallel version of the lgssm filtering algorithm.
+
+    See S. Särkkä and Á. F. García-Fernández (2021) - https://arxiv.org/abs/1905.13002.
+    
+    Note: This function does not yet handle `inputs` to the system.
+    """
+    #TODO: Add marginal loglikelihood calculation.
+    #TODO: Add input handling.
+    initial_elements = make_associative_filtering_elements(params, emissions)
+
+    @vmap
+    def filtering_operator(elem1, elem2):
+        A1, b1, C1, J1, eta1 = elem1
+        A2, b2, C2, J2, eta2 = elem2
+        dim = A1.shape[0]
+        I = jnp.eye(dim)  
+
+        I_C1J2 = I + C1 @ J2
+        temp = jsc.linalg.solve(I_C1J2.T, A2.T).T
+        A = temp @ A1
+        b = temp @ (b1 + C1 @ eta2) + b2
+        C = temp @ C1 @ A2.T + C2
+
+        I_J2C1 = I + J2 @ C1
+        temp = jsc.linalg.solve(I_J2C1.T, A1).T
+
+        eta = temp @ (eta2 - J2 @ b1) + eta1
+        J = temp @ J2 @ A1 + J1
+
+        return A, b, C, J, eta
+
+    _, filtered_means, filtered_covs, *_ = lax.associative_scan(
+                                                filtering_operator, initial_elements
+                                                )
+    return GSSMPosterior(filtered_means=filtered_means, filtered_covariances=filtered_covs)
+
+
+
+def make_associative_smoothing_elements(params, filtered_means, filtered_covariances):
+    """Preprocess filtering output to construct input for smoothing assocative scan."""
+
+    def _last_smoothing_element(m, P):
+        return jnp.zeros_like(P), m, P
+
+    def _generic_smoothing_element(params, m, P):
+        F = params.dynamics_matrix
+        H = params.emission_matrix
+        Q = params.dynamics_covariance
+        R = params.emission_covariance
+
+        Pp = F @ P @ F.T + Q
+
+        E  = jsc.linalg.solve(Pp, F @ P, assume_a='pos').T
+        g  = m - E @ F @ m
+        L  = P - E @ Pp @ E.T
+        return E, g, L
+
+    last_elems = _last_smoothing_element(filtered_means[-1], filtered_covariances[-1])
+    generic_elems = vmap(_generic_smoothing_element, (None, 0, 0))(
+        params, filtered_means[:-1], filtered_covariances[:-1]
+        )
+    combined_elems = tuple(jnp.append(gen_elm, last_elm[None,:], axis=0)
+                           for gen_elm, last_elm in zip(generic_elems, last_elems))
+    return combined_elems
+
+
+def lgssm_smoother(params, emissions):
+    """A parallel version of the lgssm smoothing algorithm.
+
+    See S. Särkkä and Á. F. García-Fernández (2021) - https://arxiv.org/abs/1905.13002.
+
+    Note: This function does not yet handle `inputs` to the system.
+    """
+    filtered_posterior = lgssm_filter(params, emissions)
+    filtered_means = filtered_posterior.filtered_means
+    filtered_covs = filtered_posterior.filtered_covariances
+    initial_elements = make_associative_smoothing_elements(params, filtered_means, filtered_covs)
+
+    @vmap
+    def smoothing_operator(elem1, elem2):
+        E1, g1, L1 = elem1
+        E2, g2, L2 = elem2
+
+        E = E2 @ E1
+        g = E2 @ g1 + g2
+        L = E2 @ L1 @ E2.T + L2
+
+        return E, g, L
+
+    _, smoothed_means, smoothed_covs, *_ = lax.associative_scan(
+                                                smoothing_operator, initial_elements, reverse=True
+                                                )
+    return GSSMPosterior(
+        filtered_means=filtered_means,
+        filtered_covariances=filtered_covs,
+        smoothed_means=smoothed_means,
+        smoothed_covariances=smoothed_covs
+    )

--- a/ssm_jax/linear_gaussian_ssm/parallel_inference_test.py
+++ b/ssm_jax/linear_gaussian_ssm/parallel_inference_test.py
@@ -1,0 +1,68 @@
+from jax import numpy as jnp
+from jax import random as jr
+
+from ssm_jax.linear_gaussian_ssm.inference import lgssm_sample, LGSSMParams
+from ssm_jax.linear_gaussian_ssm.inference import lgssm_smoother as serial_lgssm_smoother
+from ssm_jax.linear_gaussian_ssm.parallel_inference import lgssm_smoother as parallel_lgssm_smoother
+
+
+def test_parallel_kalman_smoother(num_timesteps=5, seed=0):
+    """ Compare parallel and serial lgssm smoothing implementations."""
+    dt = 0.1
+    F = jnp.eye(4) + dt * jnp.eye(4, k=2)
+    Q = 1. * jnp.kron(jnp.array([[dt**3/3, dt**2/2],
+                          [dt**2/2, dt]]), 
+                     jnp.eye(2))
+    H = jnp.eye(2, 4)
+    R = 0.5 ** 2 * jnp.eye(2)
+    μ0 = jnp.array([0.,0.,1.,-1.])
+    Σ0 = jnp.eye(4)
+
+    latent_dim = 4
+    observation_dim = 2
+    input_dim = 1
+
+    lgssm_params = LGSSMParams(
+        initial_mean = μ0,
+        initial_covariance = Σ0,
+        dynamics_matrix = F,
+        dynamics_input_weights = jnp.zeros((latent_dim,input_dim)),
+        dynamics_bias = jnp.zeros(latent_dim),
+        dynamics_covariance = Q,
+        emission_matrix = H,
+        emission_input_weights = jnp.zeros((observation_dim, input_dim)),
+        emission_bias = jnp.zeros(observation_dim),
+        emission_covariance = R
+    )
+
+    num_timesteps = 50
+    inputs = jnp.zeros((num_timesteps,input_dim))
+
+    key = jr.PRNGKey(seed)
+    key, subkey = jr.split(key)
+    _, emissions = lgssm_sample(subkey,lgssm_params,num_timesteps, inputs)
+
+    serial_posterior = serial_lgssm_smoother(lgssm_params, emissions, inputs)
+    parallel_posterior = parallel_lgssm_smoother(lgssm_params, emissions)
+
+    # There are some very slight discrepencies between filtered means at early timepoints, 
+    #  for the time being use the average absolute difference for testing purposes.
+    av_abs_filtered_mean_diff = jnp.abs(
+            serial_posterior.filtered_means - parallel_posterior.filtered_means
+            ).mean()
+    av_abs_filtered_cov_diff = jnp.abs(
+            serial_posterior.filtered_covariances - parallel_posterior.filtered_covariances
+            ).mean()
+    av_abs_smoothed_mean_diff = jnp.abs(
+            serial_posterior.smoothed_means - parallel_posterior.smoothed_means
+            ).mean()
+    av_abs_smoothed_cov_diff = jnp.abs(
+            serial_posterior.smoothed_covariances - parallel_posterior.smoothed_covariances
+            ).mean()
+
+    thresh = 1e-2
+
+    assert av_abs_filtered_mean_diff < thresh
+    assert av_abs_filtered_cov_diff < thresh
+    assert av_abs_smoothed_mean_diff < thresh
+    assert av_abs_smoothed_cov_diff < thresh


### PR DESCRIPTION
This PR adds parallel filtering and smoothing for lgssms, along with a test, and a demo which explores the computational scaling of the parallel and serial algorithms.

### Parallel algorithm
The implementation is adapted from this [example notebook](https://github.com/EEA-sensors/sequential-parallelization-examples/blob/main/python/temporal-parallelization-bayes-smoothers/parallel_kalman_jax.ipynb) from [Adrien Correnflos](https://github.com/AdrienCorenflos), with some small updates and some changes so that it works with ssm-jax parameter and posterior containers.

### Testing
It is tested against the serial version of the algorithm in `linear_gaussian_ssm/parallel_inference_test.py`.

### Future improvements:
The parallel algorithms do not yet implement the following
- marginal likelihood calculation.
- input handling.

